### PR TITLE
circleci runs grunt as step; removed from jest-ci npm script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,9 @@ jobs:
           paths:
             - node_modules
       - run:
+          name: Build the project with grunt
+          command: npm run grunt
+      - run:
           name: Run jest tests
           command: npm run jest-ci --silent
           environment:

--- a/package.json
+++ b/package.json
@@ -51,9 +51,10 @@
     "doc": "docs"
   },
   "scripts": {
+    "grunt": "grunt",
     "test": "node_modules/.bin/jest --colors",
     "jest-cov": "node_modules/.bin/jest --coverage --colors",
-    "jest-ci": "grunt && node_modules/.bin/jest --ci --runInBand --coverage --reporters=default --reporters=jest-junit --colors"
+    "jest-ci": "node_modules/.bin/jest --ci --runInBand --coverage --reporters=default --reporters=jest-junit --colors"
   },
   "license": "ISC",
   "dependencies": {


### PR DESCRIPTION
In keeping with sinopia_profile_editor.