### PR TITLE
CI build includes eslint, which will fail on errors or additional warnings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,8 +28,11 @@ jobs:
           paths:
             - node_modules
       - run:
+          name: Run eslint
+          command: npm run eslint --silent
+      - run:
           name: Build the project with grunt
-          command: npm run grunt
+          command: npm run grunt --silent
       - run:
           name: Run jest tests
           command: npm run jest-ci --silent

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,6 @@
+build_support/*
+builds/*
+coverage/*
+docs/*
+node_modules/*
+static/*

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,29 +1,18 @@
-const ERROR = 2;
-const WARN = 1;
-
 module.exports = {
-    extends: [ "eslint:recommended", "plugin:node/recommended", "plugin:security/recommended"],
+    extends: [ "eslint:recommended", "plugin:node/recommended", "plugin:security/recommended", "plugin:jest/recommended"],
     overrides: [
       {
         files: "**/*.js",
         env: {
           jest: true
         },
-        plugins: [
-          "jest", "security"
-        ],
+        plugins: ["jest", "security"],
         rules: {
-          "jest/no-disabled-tests": "warn",
-          "jest/no-focused-tests": "error",
-          "jest/no-identical-title": "error",
-          "jest/prefer-to-have-length": "warn",
-          "jest/valid-expect": "error",
-          "node/exports-style": ["error", "module.exports"],
-          "node/prefer-global/buffer": ["error", "always"],
-          "node/prefer-global/console": ["error", "always"],
-          "node/prefer-global/process": ["error", "always"],
-          "node/prefer-global/url-search-params": ["error", "always"],
-          "node/prefer-global/url": ["error", "always"],
+          "no-console": "warn",
+          "no-redeclare": "warn", // FIXME: want this to be error, but don't want to address in 5000 line bfe.js
+          "no-undef": "warn",
+          "no-unused-vars": "warn",
+          "no-useless-escape": "warn"
         }
       }
   ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,6 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
       "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
-      "dev": true,
       "requires": {
         "mime-types": "~2.1.18",
         "negotiator": "0.6.1"
@@ -477,8 +476,7 @@
     "array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
-      "dev": true
+      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
     "array-union": {
       "version": "1.0.2",
@@ -913,7 +911,6 @@
       "version": "1.18.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
       "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
-      "dev": true,
       "requires": {
         "bytes": "3.0.0",
         "content-type": "~1.0.4",
@@ -930,8 +927,7 @@
         "iconv-lite": {
           "version": "0.4.19",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-          "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
-          "dev": true
+          "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
         }
       }
     },
@@ -1002,8 +998,7 @@
     "bytes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
-      "dev": true
+      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
     },
     "cache-base": {
       "version": "1.0.1",
@@ -1270,14 +1265,12 @@
     "content-disposition": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
-      "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
-      "dev": true
+      "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
     },
     "content-type": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
-      "dev": true
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
     },
     "convert-source-map": {
       "version": "1.6.0",
@@ -1291,14 +1284,12 @@
     "cookie": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
-      "dev": true
+      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
     },
     "cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
-      "dev": true
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
     "copy-descriptor": {
       "version": "0.1.1",
@@ -1410,7 +1401,6 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
@@ -1527,14 +1517,12 @@
     "depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
-      "dev": true
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
     },
     "destroy": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
-      "dev": true
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
     "detect-indent": {
       "version": "4.0.0",
@@ -1595,14 +1583,12 @@
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
-      "dev": true
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
-      "dev": true
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
     "error-ex": {
       "version": "1.3.2",
@@ -1654,8 +1640,7 @@
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
-      "dev": true
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -1917,8 +1902,7 @@
     "etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
-      "dev": true
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
     "event-stream": {
       "version": "3.3.6",
@@ -2034,7 +2018,6 @@
       "version": "4.16.3",
       "resolved": "http://registry.npmjs.org/express/-/express-4.16.3.tgz",
       "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
-      "dev": true,
       "requires": {
         "accepts": "~1.3.5",
         "array-flatten": "1.1.1",
@@ -2071,8 +2054,7 @@
         "safe-buffer": {
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-          "dev": true
+          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
         }
       }
     },
@@ -2228,9 +2210,8 @@
     },
     "finalhandler": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
       "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
-      "dev": true,
       "requires": {
         "debug": "2.6.9",
         "encodeurl": "~1.0.2",
@@ -2366,8 +2347,7 @@
     "forwarded": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
-      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
-      "dev": true
+      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
     },
     "fragment-cache": {
       "version": "0.2.1",
@@ -2381,8 +2361,7 @@
     "fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
-      "dev": true
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
     "from": {
       "version": "0.1.7",
@@ -3594,7 +3573,6 @@
       "version": "1.6.3",
       "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
-      "dev": true,
       "requires": {
         "depd": "~1.1.2",
         "inherits": "2.0.3",
@@ -3763,8 +3741,7 @@
     "ipaddr.js": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
-      "integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4=",
-      "dev": true
+      "integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4="
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
@@ -5007,8 +4984,7 @@
     "media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
-      "dev": true
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
     "mem": {
       "version": "1.1.0",
@@ -5045,8 +5021,7 @@
     "merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
-      "dev": true
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
     },
     "merge-stream": {
       "version": "1.0.1",
@@ -5060,8 +5035,7 @@
     "methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
-      "dev": true
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
     },
     "micromatch": {
       "version": "2.3.11",
@@ -5087,20 +5061,17 @@
     "mime": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
-      "dev": true
+      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
     },
     "mime-db": {
       "version": "1.36.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.36.0.tgz",
-      "integrity": "sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw==",
-      "dev": true
+      "integrity": "sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw=="
     },
     "mime-types": {
       "version": "2.1.20",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
       "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
-      "dev": true,
       "requires": {
         "mime-db": "~1.36.0"
       }
@@ -5163,8 +5134,7 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "mute-stream": {
       "version": "0.0.7",
@@ -5227,8 +5197,7 @@
     "negotiator": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
-      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
-      "dev": true
+      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
     },
     "nice-try": {
       "version": "1.0.5",
@@ -5399,7 +5368,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
       "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
-      "dev": true,
       "requires": {
         "ee-first": "1.1.1"
       }
@@ -5553,8 +5521,7 @@
     "parseurl": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
-      "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=",
-      "dev": true
+      "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
     },
     "pascalcase": {
       "version": "0.1.1",
@@ -5596,8 +5563,7 @@
     "path-to-regexp": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
-      "dev": true
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
     "path-type": {
       "version": "1.1.0",
@@ -5765,7 +5731,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz",
       "integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
-      "dev": true,
       "requires": {
         "forwarded": "~0.1.2",
         "ipaddr.js": "1.8.0"
@@ -5846,8 +5811,7 @@
     "qs": {
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
-      "dev": true
+      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
     },
     "randomatic": {
       "version": "3.1.0",
@@ -5877,14 +5841,12 @@
     "range-parser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
-      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
-      "dev": true
+      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
     },
     "raw-body": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
       "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
-      "dev": true,
       "requires": {
         "bytes": "3.0.0",
         "http-errors": "1.6.2",
@@ -5895,14 +5857,12 @@
         "depd": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
-          "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
-          "dev": true
+          "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
         },
         "http-errors": {
           "version": "1.6.2",
           "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
           "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
-          "dev": true,
           "requires": {
             "depd": "1.1.1",
             "inherits": "2.0.3",
@@ -5913,14 +5873,12 @@
         "iconv-lite": {
           "version": "0.4.19",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-          "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
-          "dev": true
+          "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
         },
         "setprototypeof": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
-          "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
-          "dev": true
+          "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
         }
       }
     },
@@ -6531,7 +6489,6 @@
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
       "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
-      "dev": true,
       "requires": {
         "debug": "2.6.9",
         "depd": "~1.1.2",
@@ -6552,7 +6509,6 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
       "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
-      "dev": true,
       "requires": {
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
@@ -6592,8 +6548,7 @@
     "setprototypeof": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
-      "dev": true
+      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -6908,8 +6863,7 @@
     "statuses": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-      "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
-      "dev": true
+      "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
     },
     "stealthy-require": {
       "version": "1.1.1",
@@ -7232,7 +7186,6 @@
       "version": "1.6.16",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
       "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
-      "dev": true,
       "requires": {
         "media-typer": "0.3.0",
         "mime-types": "~2.1.18"
@@ -7309,8 +7262,7 @@
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
-      "dev": true
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
     },
     "unset-value": {
       "version": "1.0.0",
@@ -7403,8 +7355,7 @@
     "utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
-      "dev": true
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
       "version": "3.3.2",
@@ -7424,8 +7375,7 @@
     "vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
-      "dev": true
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
     },
     "verror": {
       "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "scripts": {
     "grunt": "grunt",
-    "eslint": "node_modules/.bin/eslint --color -c .eslintrc.js .",
+    "eslint": "node_modules/.bin/eslint --max-warnings 1319 --color -c .eslintrc.js .",
     "test": "node_modules/.bin/jest --colors",
     "jest-cov": "node_modules/.bin/jest --coverage --colors",
     "jest-ci": "node_modules/.bin/jest --ci --runInBand --coverage --reporters=default --reporters=jest-junit --colors"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "eslint-plugin-jest": "^21.22.1",
     "eslint-plugin-node": "^7.0.1",
     "eslint-plugin-security": "^1.4.0",
-    "express": "^4.16.3",
     "grunt-contrib-clean": "^2.0.0",
     "grunt-contrib-concat": "^1.0.1",
     "grunt-contrib-cssmin": "^3.0.0",
@@ -59,6 +58,7 @@
   },
   "license": "ISC",
   "dependencies": {
+    "express": "^4.16.3",
     "grunt": "^1.x.x"
   },
   "jest": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   },
   "scripts": {
     "grunt": "grunt",
+    "eslint": "node_modules/.bin/eslint --color -c .eslintrc.js .",
     "test": "node_modules/.bin/jest --colors",
     "jest-cov": "node_modules/.bin/jest --coverage --colors",
     "jest-ci": "node_modules/.bin/jest --ci --runInBand --coverage --reporters=default --reporters=jest-junit --colors"

--- a/src/bfelookups.js
+++ b/src/bfelookups.js
@@ -132,7 +132,6 @@ bfe.define('src/lookups/lcnames', ['require', 'exports', 'module', 'src/lookups/
       var triple = {};
       triple.s = subjecturi;
       triple.p = property.propertyURI;
-      selected.uri = selected.uri;
       triple.o = selected.uri;
       triple.otype = 'uri';
       triples.push(triple);

--- a/src/bfelookups.js
+++ b/src/bfelookups.js
@@ -1,16 +1,16 @@
 bfe.define('src/lookups/lcnames', ['require', 'exports', 'module', 'src/lookups/lcshared'], function (require, exports, module) {
     var lcshared = require('src/lookups/lcshared');
-  
+
     var cache = [];
-  
+
     // This var is required because it is used as an identifier.
     exports.scheme = 'http://id.loc.gov/authorities/names';
-  
+
     exports.source = function (query, process, formobject) {
       // console.log(JSON.stringify(formobject.store));
-  
+
       var triples = formobject.store;
-  
+
       var type = '';
       var hits = _.where(triples, {
         'p': 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type'
@@ -19,7 +19,7 @@ bfe.define('src/lookups/lcnames', ['require', 'exports', 'module', 'src/lookups/
         type = hits[0].o;
       }
       // console.log("type is " + type);
-  
+
       var scheme = 'http://id.loc.gov/authorities/names';
       hits = _.where(triples, {
         'p': 'http://id.loc.gov/ontologies/bibframe/authoritySource'
@@ -29,7 +29,7 @@ bfe.define('src/lookups/lcnames', ['require', 'exports', 'module', 'src/lookups/
         scheme = hits[0].o;
       }
       // console.log("scheme is " + scheme);
-  
+
       var rdftype = '';
       if (type == 'http://www.loc.gov/mads/rdf/v1#PersonalName') {
         rdftype = 'rdftype:PersonalName';
@@ -51,7 +51,7 @@ bfe.define('src/lookups/lcnames', ['require', 'exports', 'module', 'src/lookups/
       } else if (type == 'http://id.loc.gov/ontologies/bibframe/role') {
         rdftype = 'rdftype:Role';
       }
-  
+
       var q = '';
       if (scheme !== '' && rdftype !== '') {
         q = 'cs:' + scheme + ' AND ' + rdftype;
@@ -67,7 +67,7 @@ bfe.define('src/lookups/lcnames', ['require', 'exports', 'module', 'src/lookups/
       }
       // console.log('q is ' + q);
       q = encodeURI(q);
-  
+
       if (cache[q]) {
         process(cache[q]);
         return;
@@ -76,15 +76,15 @@ bfe.define('src/lookups/lcnames', ['require', 'exports', 'module', 'src/lookups/
         clearTimeout(this.searching);
         process([]);
       }
-  
+
       this.searching = setTimeout(function () {
         if (query.length > 2 && query.substr(0, 1) != '?' && !query.match(/^[Nn][A-z]{0,1}\d/)) {
           suggestquery = query.normalize();
           console.log(query);
           if (rdftype !== '') { suggestquery += '&rdftype=' + rdftype.replace('rdftype:', ''); }
-  
+
           u = exports.scheme + '/suggest/?q=' + suggestquery + '&count=50';
-  
+
           $.ajax({
             url: u,
             dataType: 'jsonp',
@@ -110,9 +110,9 @@ bfe.define('src/lookups/lcnames', ['require', 'exports', 'module', 'src/lookups/
         }
       }, 300); // 300 ms
     };
-  
+
     /*
-  
+
           subjecturi hasAuthority selected.uri
           subjecturi  bf:label selected.value
       */
@@ -120,15 +120,15 @@ bfe.define('src/lookups/lcnames', ['require', 'exports', 'module', 'src/lookups/
   });
   bfe.define('src/lookups/lcshared', ['require', 'exports', 'module'], function (require, exports, module) {
     // require('https://twitter.github.io/typeahead.js/releases/latest/typeahead.bundle.js');
-  
+
     /*
           subjecturi propertyuri selected.uri
           selected.uri  bf:label selected.value
       */
-  
+
     exports.getResource = function (subjecturi, property, selected, process) {
       var triples = [];
-  
+
       var triple = {};
       triple.s = subjecturi;
       triple.p = property.propertyURI;
@@ -136,7 +136,7 @@ bfe.define('src/lookups/lcnames', ['require', 'exports', 'module', 'src/lookups/
       triple.o = selected.uri;
       triple.otype = 'uri';
       triples.push(triple);
-  
+
       triple = {};
       triple.s = selected.uri;
       triple.p = 'http://www.w3.org/2000/01/rdf-schema#label';
@@ -144,20 +144,20 @@ bfe.define('src/lookups/lcnames', ['require', 'exports', 'module', 'src/lookups/
       triple.otype = 'literal';
       triple.olang = 'en';
       triples.push(triple);
-  
+
       return process(triples, property);
     };
-  
+
     exports.getResourceWithAAP = function (subjecturi, property, selected, process) {
       var triples = [];
-  
+
       var triple = {};
       triple.s = subjecturi;
       triple.p = property.propertyURI;
       triple.o = selected.uri;
       triple.otype = 'uri';
       triples.push(triple);
-  
+
       triple = {};
       triple.s = subjecturi;
       triple.p = 'http://www.w3.org/2000/01/rdf-schema#label';
@@ -165,13 +165,13 @@ bfe.define('src/lookups/lcnames', ['require', 'exports', 'module', 'src/lookups/
       triple.otype = 'literal';
       triple.olang = 'en';
       triples.push(triple);
-  
+
       process(triples, property);
     };
-  
+
     exports.getResourceLabelLookup = function (subjecturi, propertyuri, selected, process) {
       var triples = [];
-  
+
       var triple = {};
       triple.s = subjecturi;
       triple.p = propertyuri;
@@ -197,7 +197,7 @@ bfe.define('src/lookups/lcnames', ['require', 'exports', 'module', 'src/lookups/
         }
       });
     };
-  
+
     exports.processJSONLDSuggestions = function (suggestions, query, scheme) {
       var typeahead_source = [];
       if (suggestions['@graph'] !== undefined) {
@@ -226,7 +226,7 @@ bfe.define('src/lookups/lcnames', ['require', 'exports', 'module', 'src/lookups/
       }
       return typeahead_source;
     };
-  
+
     exports.processSuggestions = function (suggestions, query) {
       var typeahead_source = [];
       if (suggestions[1] !== undefined) {
@@ -235,13 +235,14 @@ bfe.define('src/lookups/lcnames', ['require', 'exports', 'module', 'src/lookups/
           var u = suggestions[3][s];
           var id = u.replace(/.+\/(.+)/, '$1');
           var d = l + ' (' + id + ')';
+          var li;
           if (suggestions.length === 5) {
             var i = suggestions[4][s];
-            var li = l + ' (' + i + ')';
+            li = l + ' (' + i + ')';
           } else {
-            var li = l;
+            li = l;
           }
-  
+
           typeahead_source.push({
             uri: u,
             value: li,
@@ -259,7 +260,7 @@ bfe.define('src/lookups/lcnames', ['require', 'exports', 'module', 'src/lookups/
       // $("#dropdown-footer").text('Total Results:' + suggestions.length);
       return typeahead_source;
     };
-  
+
     exports.processATOM = function (atomjson, query) {
       var typeahead_source = [];
       for (var k in atomjson) {
@@ -282,7 +283,7 @@ bfe.define('src/lookups/lcnames', ['require', 'exports', 'module', 'src/lookups/
               typeahead_source.push({
                 uri: u,
                 source: source,
-                value: t, 
+                value: t,
                 display: d
               });
               break;
@@ -300,7 +301,7 @@ bfe.define('src/lookups/lcnames', ['require', 'exports', 'module', 'src/lookups/
       // console.log(typeahead_source);
       return typeahead_source;
     };
-  
+
     exports.simpleQuery = function (query, cache, scheme, process) {
       console.log('q is ' + query);
       q = encodeURI(query.normalize());
@@ -342,16 +343,16 @@ bfe.define('src/lookups/lcnames', ['require', 'exports', 'module', 'src/lookups/
   });
   bfe.define('src/lookups/lcsubjects', ['require', 'exports', 'module', 'src/lookups/lcshared'], function (require, exports, module) {
     var lcshared = require('src/lookups/lcshared');
-  
+
     var cache = [];
-  
+
     exports.scheme = 'http://id.loc.gov/authorities/subjects';
-  
+
     exports.source = function (query, process, formobject) {
       // console.log(JSON.stringify(formobject.store));
-  
+
       var triples = formobject.store;
-  
+
       var type = '';
       var hits = _.where(triples, {
         'p': 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type'
@@ -360,7 +361,7 @@ bfe.define('src/lookups/lcnames', ['require', 'exports', 'module', 'src/lookups/
         type = hits[0].o;
       }
       // console.log("type is " + type);
-  
+
       var scheme = 'http://id.loc.gov/authorities/subjects';
       hits = _.where(triples, {
         'p': 'http://id.loc.gov/ontologies/bibframe/authoritySource'
@@ -370,7 +371,7 @@ bfe.define('src/lookups/lcnames', ['require', 'exports', 'module', 'src/lookups/
         scheme = hits[0].o;
       }
       // console.log("scheme is " + scheme);
-  
+
       var rdftype = '';
       if (type == 'http://www.loc.gov/mads/rdf/v1#Person') {
         rdftype = 'rdftype:PersonalName';
@@ -390,7 +391,7 @@ bfe.define('src/lookups/lcnames', ['require', 'exports', 'module', 'src/lookups/
       } else if (type == 'http://id.loc.gov/ontologies/bibframe/GenreForm') {
         rdftype = 'rdftype:GenreForm';
       }
-  
+
       var q = '';
       if (scheme !== '' && rdftype !== '') {
         q = 'cs:' + scheme + ' AND ' + rdftype;
@@ -406,7 +407,7 @@ bfe.define('src/lookups/lcnames', ['require', 'exports', 'module', 'src/lookups/
       }
       // console.log('q is ' + q);
       q = encodeURI(q);
-  
+
       if (cache[q]) {
         process(cache[q]);
         return;
@@ -415,12 +416,12 @@ bfe.define('src/lookups/lcnames', ['require', 'exports', 'module', 'src/lookups/
         clearTimeout(this.searching);
         process([]);
       }
-  
+
       this.searching = setTimeout(function () {
         if (query.length > 2 && query.substr(0, 1) != '?' && !query.match(/[Ss][A-z]{0,1}\d/)) {
           suggestquery = query.normalize();
           if (rdftype !== '') { suggestquery += '&rdftype=' + rdftype.replace('rdftype:', ''); }
-  
+
           u = exports.scheme + '/suggest/?q=' + suggestquery;
           $.ajax({
             url: u,
@@ -447,9 +448,9 @@ bfe.define('src/lookups/lcnames', ['require', 'exports', 'module', 'src/lookups/
         }
       }, 300); // 300 ms
     };
-  
+
     /*
-  
+
           subjecturi hasAuthority selected.uri
           subjecturi  bf:label selected.value
       */
@@ -457,15 +458,15 @@ bfe.define('src/lookups/lcnames', ['require', 'exports', 'module', 'src/lookups/
   });
   bfe.define('src/lookups/lcgenreforms', ['require', 'exports', 'module', 'src/lookups/lcshared'], function (require, exports, module) {
     var lcshared = require('src/lookups/lcshared');
-  
+
     var cache = [];
-  
+
     exports.scheme = 'http://id.loc.gov/authorities/genreForms';
-  
+
     exports.source = function (query, process) {
       var scheme = 'http://id.loc.gov/authorities/genreForms';
       var rdftype = 'rdftype:GenreForm';
-  
+
       var q = '';
       if (scheme !== '' && rdftype !== '') {
         q = 'cs:' + scheme + ' AND ' + rdftype;
@@ -481,7 +482,7 @@ bfe.define('src/lookups/lcnames', ['require', 'exports', 'module', 'src/lookups/
       }
       console.log('q is ' + q);
       q = encodeURI(q);
-  
+
       if (cache[q]) {
         process(cache[q]);
         return;
@@ -496,9 +497,9 @@ bfe.define('src/lookups/lcnames', ['require', 'exports', 'module', 'src/lookups/
         if (query.length > 2 && !query.match(/[Gg][A-z]?\d/)) {
           suggestquery = query;
           if (rdftype !== '') { suggestquery += '&rdftype=' + rdftype.replace('rdftype:', ''); }
-  
+
           u = scheme + '/suggest/?q=' + suggestquery;
-  
+
           // u = "http://id.loc.gov/authorities/genreForms/suggest/?q=" + query;
           $.ajax({
             url: u,
@@ -508,7 +509,7 @@ bfe.define('src/lookups/lcnames', ['require', 'exports', 'module', 'src/lookups/
               cache[q] = parsedlist;
               return process(parsedlist);
             }
-  
+
           });
         } /* else if (query.length > 2 && query.match(/[Gg][A-z]?\d/)) {
           u = 'http://id.loc.gov/search/?q=cs:http://id.loc.gov/authorities/genreForms%20AND%20(' + query + ')&start=1&format=atom';
@@ -526,15 +527,15 @@ bfe.define('src/lookups/lcnames', ['require', 'exports', 'module', 'src/lookups/
         }
       }, 300); // 300 ms
     };
-  
+
     exports.getResource = lcshared.getResourceWithAAP;
   });
-  
+
   bfe.define('src/lookups/rdaformatnotemus', ['require', 'exports', 'module', 'src/lookups/lcshared'], function (require, exports, module) {
     var lcshared = require('src/lookups/lcshared');
     var cache = [];
     exports.scheme = 'http://rdaregistry.info/termList/FormatNoteMus';
-  
+
     exports.source = function (query, process) {
       console.log('q is ' + query);
       q = encodeURI(query);
@@ -546,7 +547,7 @@ bfe.define('src/lookups/lcnames', ['require', 'exports', 'module', 'src/lookups/
         clearTimeout(this.searching);
         process([]);
       }
-  
+
       this.searching = setTimeout(function () {
         if (query === '' || query === ' ') {
           u = exports.scheme + '.json-ld';
@@ -575,14 +576,14 @@ bfe.define('src/lookups/lcnames', ['require', 'exports', 'module', 'src/lookups/
         }
       }, 300); // 300 ms
     };
-  
+
     exports.getResource = lcshared.getResource;
   });
   bfe.define('src/lookups/rdamediatype', ['require', 'exports', 'module', 'src/lookups/lcshared'], function (require, exports, module) {
     var lcshared = require('src/lookups/lcshared');
     var cache = [];
     exports.scheme = 'http://rdaregistry.info/termList/RDAMediaType';
-  
+
     exports.source = function (query, process) {
       console.log('q is ' + query);
       q = encodeURI(query);
@@ -594,7 +595,7 @@ bfe.define('src/lookups/lcnames', ['require', 'exports', 'module', 'src/lookups/
         clearTimeout(this.searching);
         process([]);
       }
-  
+
       this.searching = setTimeout(function () {
         if (query === '' || query === ' ') {
           u = exports.scheme + '.json-ld';
@@ -623,14 +624,14 @@ bfe.define('src/lookups/lcnames', ['require', 'exports', 'module', 'src/lookups/
         }
       }, 300); // 300 ms
     };
-  
+
     exports.getResource = lcshared.getResource;
   });
   bfe.define('src/lookups/rdamodeissue', ['require', 'exports', 'module', 'src/lookups/lcshared'], function (require, exports, module) {
     var lcshared = require('src/lookups/lcshared');
     var cache = [];
     exports.scheme = 'http://rdaregistry.info/termList/ModeIssue';
-  
+
     exports.source = function (query, process) {
       console.log('q is ' + query);
       q = encodeURI(query);
@@ -642,7 +643,7 @@ bfe.define('src/lookups/lcnames', ['require', 'exports', 'module', 'src/lookups/
         clearTimeout(this.searching);
         process([]);
       }
-  
+
       this.searching = setTimeout(function () {
         if (query === '' || query === ' ') {
           u = exports.scheme + '.json-ld';
@@ -671,14 +672,14 @@ bfe.define('src/lookups/lcnames', ['require', 'exports', 'module', 'src/lookups/
         }
       }, 300); // 300 ms
     };
-  
+
     exports.getResource = lcshared.getResource;
   });
   bfe.define('src/lookups/rdacarriertype', ['require', 'exports', 'module', 'src/lookups/lcshared'], function (require, exports, module) {
     var lcshared = require('src/lookups/lcshared');
     var cache = [];
     exports.scheme = 'http://rdaregistry.info/termList/RDACarrierType';
-  
+
     exports.source = function (query, process) {
       console.log('q is ' + query);
       q = encodeURI(query);
@@ -690,7 +691,7 @@ bfe.define('src/lookups/lcnames', ['require', 'exports', 'module', 'src/lookups/
         clearTimeout(this.searching);
         process([]);
       }
-  
+
       this.searching = setTimeout(function () {
         if (query === '' || query === ' ') {
           u = exports.scheme + '.json-ld';
@@ -719,14 +720,14 @@ bfe.define('src/lookups/lcnames', ['require', 'exports', 'module', 'src/lookups/
         }
       }, 300); // 300 ms
     };
-  
+
     exports.getResource = lcshared.getResource;
   });
   bfe.define('src/lookups/rdacontenttype', ['require', 'exports', 'module', 'src/lookups/lcshared'], function (require, exports, module) {
     var lcshared = require('src/lookups/lcshared');
     var cache = [];
     exports.scheme = 'http://rdaregistry.info/termList/RDAContentType';
-  
+
     exports.source = function (query, process) {
       console.log('q is ' + query);
       q = encodeURI(query);
@@ -738,7 +739,7 @@ bfe.define('src/lookups/lcnames', ['require', 'exports', 'module', 'src/lookups/
         clearTimeout(this.searching);
         process([]);
       }
-  
+
       this.searching = setTimeout(function () {
         if (query === '' || query === ' ') {
           u = exports.scheme + '.json-ld';
@@ -767,14 +768,14 @@ bfe.define('src/lookups/lcnames', ['require', 'exports', 'module', 'src/lookups/
         }
       }, 300); // 300 ms
     };
-  
+
     exports.getResource = lcshared.getResource;
   });
   bfe.define('src/lookups/rdafrequency', ['require', 'exports', 'module', 'src/lookups/lcshared'], function (require, exports, module) {
     var lcshared = require('src/lookups/lcshared');
     var cache = [];
     exports.scheme = 'http://rdaregistry.info/termList/frequency';
-  
+
     exports.source = function (query, process) {
       console.log('q is ' + query);
       q = encodeURI(query);
@@ -786,7 +787,7 @@ bfe.define('src/lookups/lcnames', ['require', 'exports', 'module', 'src/lookups/
         clearTimeout(this.searching);
         process([]);
       }
-  
+
       this.searching = setTimeout(function () {
         if (query === '' || query === ' ') {
           u = exports.scheme + '.json-ld';
@@ -815,14 +816,14 @@ bfe.define('src/lookups/lcnames', ['require', 'exports', 'module', 'src/lookups/
         }
       }, 300); // 300 ms
     };
-  
+
     exports.getResource = lcshared.getResource;
   });
   bfe.define('src/lookups/rdaaspectration', ['require', 'exports', 'module', 'src/lookups/lcshared'], function (require, exports, module) {
     var lcshared = require('src/lookups/lcshared');
     var cache = [];
     exports.scheme = 'http://rdaregistry.info/termList/AspectRatio';
-  
+
     exports.source = function (query, process) {
       console.log('q is ' + query);
       q = encodeURI(query);
@@ -834,7 +835,7 @@ bfe.define('src/lookups/lcnames', ['require', 'exports', 'module', 'src/lookups/
         clearTimeout(this.searching);
         process([]);
       }
-  
+
       this.searching = setTimeout(function () {
         if (query === '' || query === ' ') {
           u = exports.scheme + '.json-ld';
@@ -863,14 +864,14 @@ bfe.define('src/lookups/lcnames', ['require', 'exports', 'module', 'src/lookups/
         }
       }, 300); // 300 ms
     };
-  
+
     exports.getResource = lcshared.getResource;
   });
   bfe.define('src/lookups/rdageneration', ['require', 'exports', 'module', 'src/lookups/lcshared'], function (require, exports, module) {
     var lcshared = require('src/lookups/lcshared');
     var cache = [];
     exports.scheme = 'http://rdaregistry.info/termList/RDAGeneration';
-  
+
     exports.source = function (query, process) {
       console.log('q is ' + query);
       q = encodeURI(query);
@@ -882,7 +883,7 @@ bfe.define('src/lookups/lcnames', ['require', 'exports', 'module', 'src/lookups/
         clearTimeout(this.searching);
         process([]);
       }
-  
+
       this.searching = setTimeout(function () {
         if (query === '' || query === ' ') {
           u = exports.scheme + '.json-ld';
@@ -911,32 +912,32 @@ bfe.define('src/lookups/lcnames', ['require', 'exports', 'module', 'src/lookups/
         }
       }, 300); // 300 ms
     };
-  
+
     exports.getResource = lcshared.getResource;
   });
-  
+
   bfe.define('src/lookups/lcorganizations', ['require', 'exports', 'module', 'src/lookups/lcshared'], function (require, exports, module) {
     var lcshared = require('src/lookups/lcshared');
     var cache = [];
-  
+
     exports.scheme = 'http://id.loc.gov/vocabulary/organizations';
-  
+
     exports.source = function (query, process) {
       return lcshared.simpleQuery(query, cache, exports.scheme, process);
     };
-  
+
     exports.getResource = lcshared.getResourceWithAAP;
   });
-  
+
   bfe.define('src/lookups/relators', ['require', 'exports', 'module', 'src/lookups/lcshared'], function (require, exports, module) {
     var lcshared = require('src/lookups/lcshared');
     var cache = [];
-  
+
     exports.scheme = 'http://id.loc.gov/vocabulary/relators';
-  
+
     exports.source = function (query, process) {
       return lcshared.simpleQuery(query, cache, exports.scheme, process);
     };
-  
+
     exports.getResource = lcshared.getResource;
   });

--- a/src/lib/aceconfig.js
+++ b/src/lib/aceconfig.js
@@ -2,7 +2,7 @@
     This file is needed to define the javascript bfe namespace.
     @deprecated 0.2.0 does not use dryice.
     From: https://github.com/ajaxorg/ace/blob/master/lib/ace/config.js
-    
+
 */
 
 /* ***** BEGIN LICENSE BLOCK *****
@@ -10,7 +10,7 @@
  *
  * Copyright (c) 2010, Ajax.org B.V.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above copyright
@@ -21,7 +21,7 @@
  *     * Neither the name of Ajax.org B.V. nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -102,7 +102,7 @@ function init(packaged) {
     for (var key in scriptOptions)
         if (typeof scriptOptions[key] !== "undefined")
             exports.set(key, scriptOptions[key]);
-};
+}
 
 exports.init = init;
 


### PR DESCRIPTION
Adds eslint and hooks it up with CI build.  It would be good for both @jgreben and @jermnelson to review.

We have to start somewhere. This is a pretty bad place to start ... but it is a way to have our CI builds fail if we have an eslint error, or if the warning count goes up.

![image](https://user-images.githubusercontent.com/96775/46390769-5051e480-c68e-11e8-8893-98a8ca2832bd.png)

As we start refactoring and changing code, we'll need to adjust the max-threshold for eslint script in package.json:

![image](https://user-images.githubusercontent.com/96775/46390832-a6268c80-c68e-11e8-8002-8e0c1a252555.png)

I felt a few linting errors were worth keeping as errors (not warnings), so I have some small tweaks to files to address these errors from linting.

595070d, the commit moving express to be a regular dependency, not a devDependency *seems* right - we need express to actually run the javascript for a user, no?  "Express is a minimal and flexible Node.js web application framework that provides a robust set of features for web and mobile applications." (http://expressjs.com/).   Kirk may do things differently ...  but the real question is ... what will our users need (in AWS?)

Happy to squash commits, etc.

Closes #27 
Closes #26