### PR TITLE
circleci uses appropriate docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,12 @@
-# Javascript Node CircleCI 2.0 configuration file
+# Node.js Javascript CircleCI 2.0 configuration file
 #
-# Check https://circleci.com/docs/2.0/language-javascript/ for more details
+# Check https://hub.docker.com/r/circleci/node/ for more details
 #
 version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:10.11.0
+      - image: circleci/node:10.11-browsers
 
     working_directory: ~/sinopia_editor
 
@@ -17,9 +17,6 @@ jobs:
           command: 'sudo npm install -g npm@latest'
       - restore_cache:
           key: dependency-cache-{{ checksum "package.json" }}
-      - run:
-          name: Workaround for GoogleChrome/puppeteer#290
-          command: 'sh .circleci/setup_puppeteer.sh'
       - run:
           name: Run "npm install"
           command: npm install

--- a/.circleci/setup_puppeteer.sh
+++ b/.circleci/setup_puppeteer.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-sudo apt-get update
-sudo apt-get install -yq gconf-service libasound2 libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 \
-  libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 \
-  libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 \
-  libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 \
-ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget


### PR DESCRIPTION
I found out that we can avoid that setup_puppeteer.sh script by using a circle/node docker image that already has chromedriver installed. W00t!

Fixes #32