### PR TITLE
.eslintignore: add static-analysis directory

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -9,3 +9,4 @@ static/js/n3-browser.min.js
 static/js/r*
 static/js/short-uuid.min.js
 static/js/twitter-typeahead-0.10.2.js
+static-analysis/*


### PR DESCRIPTION
discovered this problem running it locally - gah.  Luckily static analysis runs last in circleci.