### PR TITLE
integration test can affirm that profile is loaded

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,14 +13,23 @@ module.exports = {
       },
       plugins: ["jest", "security"],
       rules: {
-        "no-console": "warn",
+        "no-console": "off",
         "no-redeclare": "warn", // FIXME: want this to be error, but don't want to address in 5000 line bfe.js
         "no-undef": "warn",
         "no-unused-vars": "warn",
         "no-useless-escape": "warn"
       },
       globals: {
-        "page": true
+        // FIXME: this is a cheap way to reduce warnings, but perhaps code practices should improve for our own stuff?
+        "$": true,
+        "bfe": true,
+        "bfeditor": true,
+        "bfelog": true,
+        "config": true,
+        "document": true,
+        "jQuery": true,
+        "page": true,
+        "window": true
       }
     }
   ]

--- a/__tests__/__fixtures__/instance_ontology.json
+++ b/__tests__/__fixtures__/instance_ontology.json
@@ -1,0 +1,1082 @@
+[
+  {
+    "@id": "http://id.loc.gov/ontologies/bibframe/instanceOf",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/Instance"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/Work"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "Work the Instance described instantiates or manifests. For use to connect Instances to Works in the BIBFRAME structure."
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subPropertyOf": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/relatedTo"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Instance of"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#inverseOf": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/hasInstance"
+      }
+    ],
+    "http://purl.org/dc/terms/modified": [
+      {
+        "@value": "2016-04-21 (New)"
+      },
+      {
+        "@value": "2016-04-29 (added inverse)"
+      }
+    ]
+  },
+  {
+    "@id": "http://id.loc.gov/ontologies/bibframe/appliedMaterial",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/Instance"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/AppliedMaterial"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "Physical or chemical substance applied to a base material of a resource."
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Applied material"
+      }
+    ],
+    "http://purl.org/dc/terms/modified": [
+      {
+        "@value": "2016-04-21 (New)"
+      }
+    ]
+  },
+  {
+    "@id": "http://id.loc.gov/ontologies/bibframe/provisionActivity",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/Instance"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/ProvisionActivity"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "Place, name, and/or date information relating to the publication, printing, distribution, issue, release, production, etc. of a resource."
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Provision activity"
+      }
+    ],
+    "http://purl.org/dc/terms/modified": [
+      {
+        "@value": "2016-04-21 (New)"
+      },
+      {
+        "@value": "2017-02-03 (revised label and slightly revised definition)"
+      }
+    ]
+  },
+  {
+    "@id": "http://id.loc.gov/ontologies/bibframe/fontSize",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/Instance"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/FontSize"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "Size of the type used to represent the characters and symbols in a resource."
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Font size"
+      }
+    ],
+    "http://purl.org/dc/terms/modified": [
+      {
+        "@value": "2016-04-21 (New)"
+      }
+    ]
+  },
+  {
+    "@id": "http://id.loc.gov/ontologies/bibframe/hasItem",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/Instance"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/Item"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "Item which is an example of the described Instance."
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subPropertyOf": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/relatedTo"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Has holding"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#inverseOf": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/itemOf"
+      }
+    ],
+    "http://purl.org/dc/terms/modified": [
+      {
+        "@value": "2016-04-21 (New)"
+      },
+      {
+        "@value": "2016-04-29 (added inverse)"
+      },
+      {
+        "@value": "2017-02-07 (slight revision of definition)"
+      }
+    ]
+  },
+  {
+    "@id": "http://id.loc.gov/ontologies/bibframe/polarity",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/Instance"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/Polarity"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "Relationship of the colors and tones in an image to the colors and tones of the object reproduced."
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Polarity"
+      }
+    ],
+    "http://purl.org/dc/terms/modified": [
+      {
+        "@value": "2016-04-21 (New)"
+      }
+    ]
+  },
+  {
+    "@id": "http://id.loc.gov/ontologies/bibframe/reductionRatio",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/Instance"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/ReductionRatio"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "Size of a micro-image in relation to the original from which it was produced."
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Reduction ratio"
+      }
+    ],
+    "http://purl.org/dc/terms/modified": [
+      {
+        "@value": "2016-04-21 (New)"
+      }
+    ]
+  },
+  {
+    "@id": "http://id.loc.gov/ontologies/bibframe/provisionActivityStatement",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/Instance"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "http://www.w3.org/2000/01/rdf-schema#Literal"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "Statement relating to providers of a resource; usually transcribed."
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Provider statement"
+      }
+    ],
+    "http://purl.org/dc/terms/modified": [
+      {
+        "@value": "2016-04-21 (New)"
+      }
+    ]
+  },
+  {
+    "@id": "http://id.loc.gov/ontologies/bibframe/reproductionOf",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/Instance"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/Instance"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "Resource that is a reproduction of another Resource."
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subPropertyOf": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/hasEquivalent"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Reproduction of"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#inverseOf": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/hasReproduction"
+      }
+    ],
+    "http://purl.org/dc/terms/modified": [
+      {
+        "@value": "2016-04-21 (New)"
+      },
+      {
+        "@value": "2016-04-29 (added inverse)"
+      }
+    ]
+  },
+  {
+    "@id": "http://id.loc.gov/ontologies/bibframe/soundCharacteristic",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/Instance"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/SoundCharacteristic"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "Technical specification relating to the encoding of sound in a resource."
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Sound characteristic"
+      }
+    ],
+    "http://purl.org/dc/terms/modified": [
+      {
+        "@value": "2016-04-21 (New)"
+      },
+      {
+        "@value": "2016-04-21 (fixed name and range typos)"
+      }
+    ]
+  },
+  {
+    "@id": "http://id.loc.gov/ontologies/bibframe/Instance",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Instance"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "Resource reflecting an individual, material embodiment of a Work."
+      }
+    ],
+    "http://purl.org/dc/terms/modified": [
+      {
+        "@value": "2016-04-21 (New)"
+      }
+    ]
+  },
+  {
+    "@id": "http://id.loc.gov/ontologies/bibframe/baseMaterial",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/Instance"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/BaseMaterial"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "Underlying physical material of a resource."
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Base material"
+      }
+    ],
+    "http://purl.org/dc/terms/modified": [
+      {
+        "@value": "2016-04-21 (New)"
+      }
+    ]
+  },
+  {
+    "@id": "http://id.loc.gov/ontologies/bibframe/subseriesStatement",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/Instance"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "http://www.w3.org/2000/01/rdf-schema#Literal"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "Statement of the subseries the resource is in; usually transcribed; includes the ISSN if applicable."
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Subseries statement"
+      }
+    ],
+    "http://purl.org/dc/terms/modified": [
+      {
+        "@value": "2016-04-21 (New)"
+      }
+    ]
+  },
+  {
+    "@id": "http://id.loc.gov/ontologies/bibframe/productionMethod",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/Instance"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/ProductionMethod"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "Process used to produce a resource."
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Production method"
+      }
+    ],
+    "http://purl.org/dc/terms/modified": [
+      {
+        "@value": "2016-04-21 (New)"
+      }
+    ]
+  },
+  {
+    "@id": "http://id.loc.gov/ontologies/bibframe/layout",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/Instance"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/Layout"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "Arrangement of text, images, tactile notation, etc., in a resource."
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Layout"
+      }
+    ],
+    "http://purl.org/dc/terms/modified": [
+      {
+        "@value": "2016-04-21 (New)"
+      }
+    ]
+  },
+  {
+    "@id": "http://id.loc.gov/ontologies/bibframe/hasReproduction",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/Instance"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/Instance"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "Resource that reproduces another Resource."
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subPropertyOf": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/hasEquivalent"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Reproduced as"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#inverseOf": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/reproductionOf"
+      }
+    ],
+    "http://purl.org/dc/terms/modified": [
+      {
+        "@value": "2016-04-21 (New)"
+      },
+      {
+        "@value": "2016-04-29 (added inverse)"
+      }
+    ]
+  },
+  {
+    "@id": "http://id.loc.gov/ontologies/bibframe/seriesEnumeration",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/Instance"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "http://www.w3.org/2000/01/rdf-schema#Literal"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "Series enumeration of the resource; usually transcribed."
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Series enumeration"
+      }
+    ],
+    "http://purl.org/dc/terms/modified": [
+      {
+        "@value": "2016-04-21 (New)"
+      }
+    ]
+  },
+  {
+    "@id": "http://id.loc.gov/ontologies/bibframe/editionEnumeration",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/Instance"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "http://www.w3.org/2000/01/rdf-schema#Literal"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "Enumeration of the edition; usually transcribed."
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Edition enumeration"
+      }
+    ],
+    "http://purl.org/dc/terms/modified": [
+      {
+        "@value": "2016-04-21 (New)"
+      }
+    ]
+  },
+  {
+    "@id": "http://id.loc.gov/ontologies/bibframe/editionStatement",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/Instance"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "http://www.w3.org/2000/01/rdf-schema#Literal"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "Information identifying the edition or version of the resource and associated statements of responsibility for the edition; usually transcribed."
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Edition statement"
+      }
+    ],
+    "http://purl.org/dc/terms/modified": [
+      {
+        "@value": "2016-04-21 (New)"
+      }
+    ]
+  },
+  {
+    "@id": "http://id.loc.gov/ontologies/bibframe/seriesStatement",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/Instance"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "http://www.w3.org/2000/01/rdf-schema#Literal"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "Statement of the series the resource is in; usually transcribed; includes the ISSN if applicable."
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Series statement"
+      }
+    ],
+    "http://purl.org/dc/terms/modified": [
+      {
+        "@value": "2016-04-21 (New)"
+      }
+    ]
+  },
+  {
+    "@id": "http://id.loc.gov/ontologies/bibframe/systemRequirement",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/Instance"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/SystemRequirement"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "Equipment or system requirement beyond what is normal and obvious for the type of carrier or type of file, such as make and model of equipment or hardware, operating system, amount of memory, programming language, other necessary software, any plug-ins or peripherals required to play, view, or run the resource, etc."
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Equipment or system requirements"
+      }
+    ],
+    "http://purl.org/dc/terms/modified": [
+      {
+        "@value": "2016-04-21 (New)"
+      },
+      {
+        "@value": "2017-02-06 (Changed from data to object property, changed property name from plural to singular)"
+      }
+    ]
+  },
+  {
+    "@id": "http://id.loc.gov/ontologies/bibframe/subseriesEnumeration",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/Instance"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "http://www.w3.org/2000/01/rdf-schema#Literal"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "Subseries enumeration of the resource; usually transcribed."
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Subseries enumeration"
+      }
+    ],
+    "http://purl.org/dc/terms/modified": [
+      {
+        "@value": "2016-04-21 (New)"
+      }
+    ]
+  },
+  {
+    "@id": "http://id.loc.gov/ontologies/bibframe/emulsion",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/Instance"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/Emulsion"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "Suspension of light-sensitive chemicals used as a coating on a microfilm or microfiche, e.g., silver halide."
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Emulsion"
+      }
+    ],
+    "http://purl.org/dc/terms/modified": [
+      {
+        "@value": "2016-04-21 (New)"
+      }
+    ]
+  },
+  {
+    "@id": "http://id.loc.gov/ontologies/bibframe/mount",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/Instance"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/Mount"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "Physical material used for the support or backing to which the base material of a resource has been attached."
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Mount material"
+      }
+    ],
+    "http://purl.org/dc/terms/modified": [
+      {
+        "@value": "2016-04-21 (New)"
+      }
+    ]
+  },
+  {
+    "@id": "http://id.loc.gov/ontologies/bibframe/bookFormat",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/Instance"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/BookFormat"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "Result of folding a printed sheet to form a gathering of leaves."
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Book format"
+      }
+    ],
+    "http://purl.org/dc/terms/modified": [
+      {
+        "@value": "2016-04-21 (New)"
+      }
+    ]
+  },
+  {
+    "@id": "http://id.loc.gov/ontologies/bibframe/videoCharacteristic",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/Instance"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/VideoCharacteristic"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "Technical specification relating to the encoding of video images in a resource"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Video characteristic"
+      }
+    ],
+    "http://purl.org/dc/terms/modified": [
+      {
+        "@value": "2016-04-21 (New)"
+      }
+    ]
+  },
+  {
+    "@id": "http://id.loc.gov/ontologies/bibframe/extent",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/Instance"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/Extent"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "Number and type of units and/or subunits making up a resource."
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Extent"
+      }
+    ],
+    "http://purl.org/dc/terms/modified": [
+      {
+        "@value": "2016-04-21 (New)"
+      }
+    ]
+  },
+  {
+    "@id": "http://id.loc.gov/ontologies/bibframe/carrier",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/Instance"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/Carrier"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "Categorization reflecting the format of the storage medium and housing of a carrier."
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Carrier type"
+      }
+    ],
+    "http://purl.org/dc/terms/modified": [
+      {
+        "@value": "2016-04-21 (New)"
+      }
+    ]
+  },
+  {
+    "@id": "http://id.loc.gov/ontologies/bibframe/responsibilityStatement",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/Instance"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "http://www.w3.org/2000/01/rdf-schema#Literal"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "Statement relating to any persons, families, or corporate bodies responsible for the creation of, or contributing to the content of a resource; usually transcribed."
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Creative responsibility statement"
+      }
+    ],
+    "http://purl.org/dc/terms/modified": [
+      {
+        "@value": "2016-04-21 (New)"
+      }
+    ]
+  },
+  {
+    "@id": "http://id.loc.gov/ontologies/bibframe/dimensions",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/Instance"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "http://www.w3.org/2000/01/rdf-schema#Literal"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "Measurements of the carrier or carriers and/or the container of a resource."
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Dimensions"
+      }
+    ],
+    "http://purl.org/dc/terms/modified": [
+      {
+        "@value": "2016-04-21 (New)"
+      }
+    ]
+  },
+  {
+    "@id": "http://id.loc.gov/ontologies/bibframe/projectionCharacteristic",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/Instance"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/ProjectionCharacteristic"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "Technical specification relating to the projection of a motion picture film."
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Projection characteristic"
+      }
+    ],
+    "http://purl.org/dc/terms/modified": [
+      {
+        "@value": "2016-04-21 (New)"
+      },
+      {
+        "@value": "2017-02-03 (fixed typo in property name)"
+      }
+    ]
+  },
+  {
+    "@id": "http://id.loc.gov/ontologies/bibframe/digitalCharacteristic",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/Instance"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/DigitalCharacteristic"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "Technical specification relating to the digital encoding of text, image, audio, video, and other types of data in a resource."
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Digital characteristic"
+      }
+    ],
+    "http://purl.org/dc/terms/modified": [
+      {
+        "@value": "2016-04-21 (New)"
+      }
+    ]
+  },
+  {
+    "@id": "http://id.loc.gov/ontologies/bibframe/generation",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/Instance"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/Generation"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "Relationship between an original carrier and the carrier of a reproduction made from the original."
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Generation"
+      }
+    ],
+    "http://purl.org/dc/terms/modified": [
+      {
+        "@value": "2016-04-21 (New)"
+      }
+    ]
+  }
+]

--- a/__tests__/__fixtures__/verso_profile_response_short.json
+++ b/__tests__/__fixtures__/verso_profile_response_short.json
@@ -1,0 +1,2106 @@
+[
+  {
+    "id": "00a2aca2-1109-4240-a833-520757ed0eaf",
+    "name": "BIBFRAME 2.0 Notated Music",
+    "configType": "profile",
+    "json": {
+      "Profile": {
+        "resourceTemplates": [
+          {
+            "propertyTemplates": [
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [],
+                  "useValuesFrom": [
+                    "http://mlvlp04.loc.gov:8230/resources/works"
+                  ],
+                  "valueDataType": {
+                    "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
+                  }
+                },
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/Work",
+                "propertyLabel": "Lookup BIBFRAME works"
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [
+                    "profile:bflc:Agents:PrimaryContribution"
+                  ],
+                  "useValuesFrom": [],
+                  "valueDataType": {
+                    "dataTypeURI": "http://id.loc.gov/ontologies/bflc/PrimaryContribution"
+                  }
+                },
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
+                "propertyLabel": "Creator of Work (RDA 19.2)",
+                "remark": "http://access.rdatoolkit.org/19.2.html"
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [
+                    "profile:bf2:WorkTitle",
+                    "profile:bf2:WorkVariantTitle",
+                    "profile:bflc:TranscribedTitle"
+                  ],
+                  "useValuesFrom": [],
+                  "valueDataType": {}
+                },
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/title",
+                "propertyLabel": "Title Information (RDA 6.14.2, RDA 6.14.3)"
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [
+                    "profile:bf2:PMOMedPerf:DecMedTest"
+                  ],
+                  "useValuesFrom": [],
+                  "valueDataType": {}
+                },
+                "propertyURI": "http://performedmusicontology.org/ontology/hasMedium",
+                "propertyLabel": "Declared Medium Test"
+              }
+            ],
+            "id": "profile:bf2:NotatedMusic:Work",
+            "resourceURI": "http://id.loc.gov/ontologies/bibframe/Work",
+            "resourceLabel": "New BIBFRAME Work"
+          },
+          {
+            "propertyTemplates": [
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [],
+                  "useValuesFrom": [
+                    "http://mlvlp04.loc.gov:8230/resources/works"
+                  ],
+                  "valueDataType": {
+                    "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
+                  }
+                },
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/expressionOf",
+                "propertyLabel": "Search Existing RDA/BIBFRAME Work"
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [
+                    "profile:bf2:NotatedMusic:Instance2"
+                  ],
+                  "useValuesFrom": [],
+                  "valueDataType": {}
+                },
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasInstance",
+                "propertyLabel": "Add BIBFRAME Instance"
+              }
+            ],
+            "id": "profile:bf2:NotatedMusic:Expression",
+            "resourceURI": "http://id.loc.gov/ontologies/bibframe/Work",
+            "resourceLabel": "Search Existing BIBFRAME Work and Add Expression Elements to Create New BIBFRAME Work"
+          }
+        ]
+      }
+    },
+    "metadata": {
+      "createDate": "2018-08-28T16:47:47.920Z",
+      "updateDate": "2018-08-28T16:47:47.920Z"
+    }
+  },
+  {
+    "id": "4af68062-8c00-41cb-b311-fb6c450054f6",
+    "name": "BIBFRAME 2.0 Monograph",
+    "configType": "profile",
+    "json": {
+      "Profile": {
+        "resourceTemplates": [
+          {
+            "propertyTemplates": [
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [],
+                  "useValuesFrom": [
+                    "http://mlvlp04.loc.gov:8230/resources/works"
+                  ],
+                  "valueDataType": {
+                    "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
+                  },
+                  "defaults": []
+                },
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/Work",
+                "propertyLabel": "Lookup"
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [
+                    "profile:bflc:Agents:PrimaryContribution"
+                  ],
+                  "useValuesFrom": [],
+                  "valueDataType": {
+                    "dataTypeURI": "http://id.loc.gov/ontologies/bflc/PrimaryContribution"
+                  },
+                  "defaults": []
+                },
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
+                "propertyLabel": "Creator of Work (RDA 19.2)",
+                "remark": "http://access.rdatoolkit.org/19.2.html"
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [
+                    "profile:bf2:WorkTitle",
+                    "profile:bf2:WorkVariantTitle",
+                    "profile:bflc:TranscribedTitle"
+                  ],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/title",
+                "propertyLabel": "Title Information"
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [
+                    "profile:bf2:Form"
+                  ],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm",
+                "propertyLabel": "Form of Work"
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "literal",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/originDate",
+                "propertyLabel": "Date of Work (RDA 6.4)",
+                "remark": "http://access.rdatoolkit.org/6.4.html"
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [
+                    "profile:bf2:Place"
+                  ],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/originPlace",
+                "propertyLabel": "Place of Origin of the Work (RDA 6.5)",
+                "remark": "http://access.rdatoolkit.org/6.5.html"
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [
+                    "profile:bf2:Form:Geog"
+                  ],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/geographicCoverage",
+                "propertyLabel": "(Geographic) Coverage of the Content"
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "literal",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/temporalCoverage",
+                "propertyLabel": "(Time) Coverage of the Content (RDA 7.3)",
+                "remark": "http://access.rdatoolkit.org/7.3.html"
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [
+                    "profile:bf2:Monograph:Audience"
+                  ],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/intendedAudience",
+                "propertyLabel": "Intended Audience"
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [
+                    "profile:bf2:Agents:Contribution"
+                  ],
+                  "useValuesFrom": [],
+                  "valueDataType": {
+                    "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Contribution"
+                  },
+                  "defaults": []
+                },
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
+                "propertyLabel": "Contribution (RDA 19.3 and 20.2)",
+                "remark": "http://access.rdatoolkit.org/19.3.html"
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [
+                    "profile:bf2:TopicSearch",
+                    "profile:bf2:Components",
+                    "profile:bf2:TopicInput"
+                  ],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/subject",
+                "propertyLabel": "Subject of the Work (RDA Chapter 23)",
+                "remark": "http://access.rdatoolkit.org/rdachp23_rda23-12.html"
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [
+                    "profile:bf2:Note"
+                  ],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                "propertyLabel": "Notes about the Work"
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [
+                    "profile:bf2:Monograph:Dissertation"
+                  ],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/dissertation",
+                "propertyLabel": "Dissertation (RDA 7.9)",
+                "remark": "http://access.rdatoolkit.org/7.9.html"
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [
+                    "profile:bf2:Monograph:Contents"
+                  ],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/tableOfContents",
+                "propertyLabel": "Contents (LC-PCC PS 25.1)"
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [
+                    "profile:bf2:Monograph:Summary"
+                  ],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/summary",
+                "propertyLabel": "Summary"
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [
+                    "profile:bf2:LCC",
+                    "profile:bf2:DDC"
+                  ],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/classification",
+                "propertyLabel": "Classification numbers"
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [],
+                  "useValuesFrom": [
+                    "http://id.loc.gov/vocabulary/contentTypes"
+                  ],
+                  "valueDataType": {
+                    "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Content"
+                  },
+                  "editable": "false",
+                  "repeatable": "true",
+                  "defaults": [
+                    {
+                      "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/txt",
+                      "defaultLiteral": "text"
+                    }
+                  ]
+                },
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/content",
+                "propertyLabel": "Content Type (RDA 6.9)",
+                "remark": "http://access.rdatoolkit.org/6.9.html"
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [
+                    "profile:bf2:Language2"
+                  ],
+                  "useValuesFrom": [],
+                  "valueDataType": {
+                    "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Language"
+                  },
+                  "editable": "false",
+                  "repeatable": "true",
+                  "defaults": []
+                },
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/language",
+                "propertyLabel": "Language",
+                "remark": ""
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [
+                    "profile:bf2:Script"
+                  ],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/notation",
+                "propertyLabel": "Script (RDA 7.13.2)",
+                "remark": "http://access.rdatoolkit.org/7.13.2.html"
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [],
+                  "useValuesFrom": [
+                    "http://id.loc.gov/vocabulary/millus"
+                  ],
+                  "valueDataType": {
+                    "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Illustration"
+                  },
+                  "repeatable": "true",
+                  "editable": "false",
+                  "defaults": []
+                },
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/illustrativeContent",
+                "propertyLabel": "Illustrative Content (RDA 7.15)",
+                "remark": "http://access.rdatoolkit.org/7.15.html"
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [
+                    "profile:bf2:Monograph:SupplContent"
+                  ],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/supplementaryContent",
+                "propertyLabel": "Supplementary Content"
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [
+                    "profile:bf2:Note"
+                  ],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/colorContent",
+                "propertyLabel": "Color Content (RDA 7.17)",
+                "remark": "http://access.rdatoolkit.org/7.17.html"
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [
+                    "profile:bf2:RelatedWork"
+                  ],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "propertyURI": "http://id.loc.gov/ontologies/bflc/relationship",
+                "propertyLabel": "Related Works (RDA Chapter 25, Appendix J)",
+                "remark": "http://access.rdatoolkit.org/rdachp25_rda25-65.html"
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [
+                    "profile:bf2:RelatedExpression"
+                  ],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasExpression",
+                "propertyLabel": "Related Expressions (RDA Chapter 26, Appendix J)",
+                "remark": "http://access.rdatoolkit.org/rdachp26_rda26-25.html"
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [
+                    "profile:bf2:Monograph:Instance"
+                  ],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasInstance",
+                "propertyLabel": "Has BIBFRAME Instance"
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "literal",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                "propertyLabel": "Authorized Access Point Representing the Work (RDA 6.27.1)",
+                "remark": "http://access.rdatoolkit.org/6.27.1.html"
+              }
+            ],
+            "id": "profile:bf2:Monograph:Work",
+            "resourceURI": "http://id.loc.gov/ontologies/bibframe/Work",
+            "resourceLabel": "BIBFRAME Work"
+          },
+          {
+            "id": "profile:bf2:Monograph:Instance",
+            "propertyTemplates": [
+              {
+                "propertyLabel": "Instance of",
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/instanceOf",
+                "resourceTemplates": [],
+                "type": "resource",
+                "valueConstraint": {
+                  "valueTemplateRefs": [
+                    "profile:bf2:Monograph:Work"
+                  ],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "mandatory": "false",
+                "repeatable": "true"
+              },
+              {
+                "propertyLabel": "Title Information",
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/title",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [
+                    "profile:bf2:Title",
+                    "profile:bf2:Title:VarTitle",
+                    "profile:bf2:ParallelTitle",
+                    "profile:bflc:TranscribedTitle"
+                  ],
+                  "useValuesFrom": [],
+                  "valueDataType": {
+                    "remark": ""
+                  },
+                  "defaults": []
+                },
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource",
+                "remark": ""
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "literal",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "propertyLabel": "Statement of Responsibility Relating to Title Proper (RDA 2.4.2)",
+                "remark": "http://access.rdatoolkit.org/2.4.2.html",
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/responsibilityStatement"
+              },
+              {
+                "propertyLabel": "Edition Statement (RDA 2.5)",
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/editionStatement",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "literal",
+                "remark": "http://access.rdatoolkit.org/2.5.html"
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [
+                    "profile:bf2:PublicationInformation",
+                    "profile:bf2:DistributionInformation",
+                    "profile:bf2:ManufactureInformation"
+                  ],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/provisionActivity",
+                "propertyLabel": "Publication, Distribution, Manufacture Statements",
+                "remark": ""
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "literal",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/copyrightDate",
+                "propertyLabel": "Copyright Date (RDA 2.11)",
+                "remark": "http://access.rdatoolkit.org/2.11.html"
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [
+                    "profile:bf2:SeriesInformation"
+                  ],
+                  "useValuesFrom": [],
+                  "valueDataType": {
+                    "dataTypeLabelHint": ""
+                  },
+                  "defaults": []
+                },
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasSeries",
+                "propertyLabel": "Series Statement",
+                "remark": ""
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [],
+                  "useValuesFrom": [
+                    "http://id.loc.gov/vocabulary/issuance"
+                  ],
+                  "valueDataType": {
+                    "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Issuance"
+                  },
+                  "editable": "false",
+                  "repeatable": "true",
+                  "defaults": [
+                    {
+                      "defaultURI": "http://id.loc.gov/vocabulary/issuance/mono",
+                      "defaultLiteral": "single unit"
+                    }
+                  ]
+                },
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/issuance",
+                "propertyLabel": "Mode of Issuance (RDA 2.13)",
+                "remark": "http://access.rdatoolkit.org/2.13.html"
+              },
+              {
+                "propertyLabel": "Identifiers",
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
+                "resourceTemplates": [],
+                "type": "resource",
+                "valueConstraint": {
+                  "valueTemplateRefs": [
+                    "profile:bf2:Identifiers:ISBN",
+                    "profile:bf2:Identifiers:Other",
+                    "profile:bf2:Identifiers:Local"
+                  ],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "mandatory": "false",
+                "repeatable": "true",
+                "remark": ""
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [
+                    "profile:bf2:Note"
+                  ],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "propertyLabel": "Notes about the Instance",
+                "remark": "http://access.rdatoolkit.org/2.17.html",
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/note"
+              },
+              {
+                "propertyLabel": "Media type (RDA 3.2)",
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/media",
+                "repeatable": "true",
+                "resourceTemplates": [],
+                "type": "resource",
+                "valueConstraint": {
+                  "valueTemplateRefs": [],
+                  "useValuesFrom": [
+                    "http://id.loc.gov/vocabulary/mediaTypes"
+                  ],
+                  "valueDataType": {
+                    "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Media"
+                  },
+                  "editable": "false",
+                  "repeatable": "true",
+                  "defaults": [
+                    {
+                      "defaultURI": "http://id.loc.gov/vocabulary/mediaTypes/n",
+                      "defaultLiteral": "unmediated"
+                    }
+                  ]
+                },
+                "mandatory": "false",
+                "remark": "http://access.rdatoolkit.org/3.2.html"
+              },
+              {
+                "propertyLabel": "Extent",
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/extent",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [
+                    "profile:bf2:Monograph:Extent"
+                  ],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource",
+                "remark": ""
+              },
+              {
+                "propertyLabel": "Dimensions (RDA 3.5)",
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/dimensions",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "literal",
+                "remark": "http://access.rdatoolkit.org/3.5.html"
+              },
+              {
+                "propertyLabel": "Carrier Type (RDA 3.3)",
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/carrier",
+                "repeatable": "true",
+                "resourceTemplates": [],
+                "type": "resource",
+                "valueConstraint": {
+                  "valueTemplateRefs": [],
+                  "useValuesFrom": [
+                    "http://id.loc.gov/vocabulary/carriers"
+                  ],
+                  "valueDataType": {
+                    "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Carrier"
+                  },
+                  "repeatable": "true",
+                  "editable": "false",
+                  "defaults": [
+                    {
+                      "defaultURI": "http://id.loc.gov/vocabulary/carriers/nc",
+                      "defaultLiteral": "volume"
+                    }
+                  ]
+                },
+                "mandatory": "false",
+                "remark": "http://access.rdatoolkit.org/3.3.html"
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [
+                    "profile:bf2:Monograph:RelatedInstance"
+                  ],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "propertyURI": "http://id.loc.gov/ontologies/bflc/relationship",
+                "propertyLabel": "Related Manifestation",
+                "remark": ""
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [
+                    "profile:bf2:Monograph:Item"
+                  ],
+                  "useValuesFrom": [],
+                  "valueDataType": {
+                    "dataTypeLabelHint": ""
+                  },
+                  "defaults": []
+                },
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasItem",
+                "propertyLabel": "Has Item",
+                "remark": "Item which is an example of the described Instance."
+              },
+              {
+                "propertyLabel": "Uniform Resource Locator (RDA 4.6)",
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/electronicLocator",
+                "resourceTemplates": [],
+                "type": "literal",
+                "valueConstraint": {
+                  "valueTemplateRefs": [],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "mandatory": "false",
+                "repeatable": "true",
+                "remark": "http://access.rdatoolkit.org/4.6.html"
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [
+                    "profile:bf2:Identifiers:LCCN"
+                  ],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
+                "propertyLabel": "LC Control Number for the Manifestation (RDA 2.15)",
+                "remark": "http://access.rdatoolkit.org/2.15.html"
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [
+                    "profile:bf2:AdminMetadata"
+                  ],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/adminMetadata",
+                "propertyLabel": "Administrative Metadata for Instance"
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "false",
+                "type": "literal",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": [],
+                  "validatePattern": "\\d{4}"
+                },
+                "propertyURI": "http://id.loc.gov/ontologies/bflc/projectedProvisionDate",
+                "propertyLabel": "Projected publication date (YYMM)",
+                "remark": "http://id.loc.gov/ontologies/bflc.html#p_projectedProvisionDate"
+              }
+            ],
+            "resourceLabel": "BIBFRAME Instance",
+            "resourceURI": "http://id.loc.gov/ontologies/bibframe/Instance",
+            "remark": ""
+          },
+          {
+            "id": "profile:bf2:Monograph:Item",
+            "propertyTemplates": [
+              {
+                "propertyLabel": "Held by",
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/heldBy",
+                "resourceTemplates": [],
+                "type": "literal",
+                "valueConstraint": {
+                  "valueTemplateRefs": [],
+                  "useValuesFrom": [],
+                  "valueDataType": {
+                    "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Agent"
+                  },
+                  "defaults": [
+                    {
+                      "defaultURI": "http://id.loc.gov/vocabulary/organizations/dlc",
+                      "defaultLiteral": "DLC"
+                    }
+                  ]
+                },
+                "mandatory": "false",
+                "repeatable": "true"
+              },
+              {
+                "propertyLabel": "Shelving call numbers",
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [
+                    "profile:bf2:Identifiers:LC"
+                  ],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource"
+              },
+              {
+                "propertyLabel": "Electronic location",
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/electronicLocator",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "literal"
+              },
+              {
+                "propertyLabel": "Held in sublocation",
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/sublocation",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "literal"
+              },
+              {
+                "propertyLabel": "Barcode",
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [
+                    "profile:bf2:Identifiers:Barcode"
+                  ],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource"
+              },
+              {
+                "propertyLabel": "Notes about the Item",
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [
+                    "profile:bf2:Note"
+                  ],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource"
+              },
+              {
+                "propertyLabel": "Lending, Reproduction, and Retention Policies",
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/usageAndAccessPolicy",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [
+                    "profile:bf2:Item:Access",
+                    "profile:bf2:Item:Use",
+                    "profile:bf2:Item:Retention"
+                  ],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource"
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [
+                    "profile:bf2:Item:Enumeration",
+                    "profile:bf2:Item:Chronology"
+                  ],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "propertyLabel": "Enumeration And Chronology of Item",
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/enumerationAndChronology"
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "literal",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "remark": "http://access.rdatoolkit.org/2.18.html",
+                "propertyLabel": "Custodial History of Item (RDA 2.18)",
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/custodialHistory"
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [
+                    "profile:bf2:Item:ImmAcqSource"
+                  ],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/immediateAcquisition",
+                "propertyLabel": "Immediate Source of Acquisition of Item",
+                "remark": ""
+              }
+            ],
+            "resourceLabel": "BIBFRAME Item",
+            "resourceURI": "http://id.loc.gov/ontologies/bibframe/Item"
+          },
+          {
+            "propertyTemplates": [
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "literal",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
+                "propertyLabel": "Related Manifestations (RDA 27)",
+                "remark": "http://access.rdatoolkit.org/27.1.html"
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "literal",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "propertyLabel": "Also issued in another format as:",
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasEquivalent",
+                "remark": "http://access.rdatoolkit.org/J.4.2.html"
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "literal",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/accompaniedBy",
+                "propertyLabel": "Accompanied by (manifestation):",
+                "remark": "http://access.rdatoolkit.org/J.4.5.html"
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "literal",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "propertyLabel": "Reprinted as (manifestation):",
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasEquivalent",
+                "remark": "http://access.rdatoolkit.org/J.4.2.html"
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "literal",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "remark": "http://access.rdatoolkit.org/J.4.2.html",
+                "propertyLabel": "Reprint of (manifestation)",
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasEquivalent"
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "literal",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "propertyLabel": "Record Relationship Designator for Related Manifestation (RDA Appendix J)",
+                "propertyURI": "http://id.loc.gov/ontologies/bflc/relation",
+                "remark": "http://access.rdatoolkit.org/J.4.html"
+              }
+            ],
+            "id": "profile:bf2:Monograph:RelatedInstance",
+            "resourceURI": "http://id.loc.gov/ontologies/bflc/Relationship",
+            "resourceLabel": "Related Manifestation"
+          },
+          {
+            "propertyTemplates": [
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "literal",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                "propertyLabel": "Contents note",
+                "remark": "http://access.rdatoolkit.org/lcpschp25_lcps25-354.html"
+              }
+            ],
+            "resourceURI": "http://id.loc.gov/ontologies/bibframe/TableOfContents",
+            "id": "profile:bf2:Monograph:Contents",
+            "resourceLabel": "Contents note"
+          },
+          {
+            "propertyTemplates": [
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "literal",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                "propertyLabel": "Summary note",
+                "remark": "http://access.rdatoolkit.org/7.10.html"
+              }
+            ],
+            "id": "profile:bf2:Monograph:Summary",
+            "resourceURI": "http://id.loc.gov/ontologies/bibframe/Summary",
+            "resourceLabel": "Summary note"
+          },
+          {
+            "propertyTemplates": [
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "target",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [],
+                  "useValuesFrom": [
+                    "http://id.loc.gov/vocabulary/maudience"
+                  ],
+                  "valueDataType": {
+                    "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/IntendedAudience"
+                  },
+                  "editable": "true",
+                  "repeatable": "true",
+                  "defaults": []
+                },
+                "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
+                "propertyLabel": "Intended Audience (RDA 7.7)",
+                "remark": "http://access.rdatoolkit.org/7.7.html"
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [
+                    "profile:bf2:Note"
+                  ],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                "propertyLabel": "Note about Audience",
+                "remark": ""
+              }
+            ],
+            "id": "profile:bf2:Monograph:Audience",
+            "resourceURI": "http://id.loc.gov/ontologies/bibframe/IntendedAudience",
+            "resourceLabel": "Intended Audience"
+          },
+          {
+            "propertyTemplates": [
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "literal",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/degree",
+                "propertyLabel": "Degree"
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "literal",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [],
+                  "useValuesFrom": [
+                    ""
+                  ],
+                  "valueDataType": {
+                    "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Agent"
+                  },
+                  "defaults": []
+                },
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/grantingInstitution",
+                "propertyLabel": "Institution"
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "literal",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/date",
+                "propertyLabel": "Date"
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [
+                    "profile:bf2:Note"
+                  ],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                "propertyLabel": "Dissertation note"
+              }
+            ],
+            "id": "profile:bf2:Monograph:Dissertation",
+            "resourceURI": "http://id.loc.gov/ontologies/bibframe/Dissertation",
+            "resourceLabel": "Dissertation"
+          },
+          {
+            "propertyTemplates": [
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "literal",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                "propertyLabel": "Extent (RDA 3.4)",
+                "remark": "http://access.rdatoolkit.org/3.4.html"
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [
+                    "profile:bf2:Note"
+                  ],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                "propertyLabel": "Note on extent"
+              }
+            ],
+            "id": "profile:bf2:Monograph:Extent",
+            "resourceURI": "http://id.loc.gov/ontologies/bibframe/Extent",
+            "resourceLabel": "Extent"
+          },
+          {
+            "propertyTemplates": [
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "literal",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [],
+                  "useValuesFrom": [],
+                  "valueDataType": {
+                    "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/SupplementaryContent"
+                  },
+                  "defaults": []
+                },
+                "propertyLabel": "Supplementary Content (RDA 7.16)",
+                "remark": "http://access.rdatoolkit.org/7.16.html",
+                "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label"
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "literal",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
+                "propertyLabel": "URI for Supplementary Content"
+              }
+            ],
+            "id": "profile:bf2:Monograph:SupplContent",
+            "resourceURI": "http://id.loc.gov/ontologies/bibframe/SupplementaryContent",
+            "resourceLabel": "Supplementary Content"
+          },
+          {
+            "id": "profile:bf2:Monograph:WorkOld",
+            "propertyTemplates": [
+              {
+                "propertyLabel": "Lookup",
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/Work",
+                "resourceTemplates": [],
+                "type": "resource",
+                "valueConstraint": {
+                  "valueTemplateRefs": [],
+                  "useValuesFrom": [
+                    "http://mlvlp04.loc.gov:8230/resources/works"
+                  ],
+                  "valueDataType": {
+                    "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
+                  },
+                  "defaults": []
+                },
+                "mandatory": "false",
+                "repeatable": "true"
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [
+                    "profile:bflc:Agents:PrimaryContribution"
+                  ],
+                  "useValuesFrom": [],
+                  "valueDataType": {
+                    "dataTypeURI": "http://id.loc.gov/ontologies/bflc/PrimaryContribution"
+                  },
+                  "defaults": []
+                },
+                "propertyLabel": "Creator of Work (RDA 19.2)",
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
+                "remark": "http://access.rdatoolkit.org/19.2.html"
+              },
+              {
+                "propertyLabel": "Title Information",
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/title",
+                "remark": "",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [
+                    "profile:bf2:WorkTitle",
+                    "profile:bf2:WorkVariantTitle",
+                    "profile:bflc:TranscribedTitle"
+                  ],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource"
+              },
+              {
+                "propertyLabel": "Form of Work",
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm",
+                "resourceTemplates": [],
+                "type": "resource",
+                "valueConstraint": {
+                  "valueTemplateRefs": [
+                    "profile:bf2:Form"
+                  ],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "remark": "",
+                "mandatory": "false",
+                "repeatable": "true"
+              },
+              {
+                "propertyLabel": "Date of Work (RDA 6.4)",
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/originDate",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "remark": "http://access.rdatoolkit.org/6.4.html",
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "literal"
+              },
+              {
+                "propertyLabel": "Place of Origin of the Work (RDA 6.5)",
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/originPlace",
+                "resourceTemplates": [],
+                "type": "resource",
+                "valueConstraint": {
+                  "valueTemplateRefs": [
+                    "profile:bf2:Place"
+                  ],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "remark": "http://access.rdatoolkit.org/6.5.html",
+                "mandatory": "false",
+                "repeatable": "true"
+              },
+              {
+                "propertyLabel": "(Geographic) Coverage of the Content",
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/geographicCoverage",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [
+                    "profile:bf2:Form:Geog"
+                  ],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "remark": "",
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource"
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "literal",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/temporalCoverage",
+                "propertyLabel": "(Time) Coverage of the Content (RDA 7.3)",
+                "remark": "http://access.rdatoolkit.org/7.3.html"
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [
+                    "profile:bf2:Monograph:Audience"
+                  ],
+                  "useValuesFrom": [],
+                  "valueDataType": {
+                    "dataTypeURI": ""
+                  },
+                  "defaults": []
+                },
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/intendedAudience",
+                "propertyLabel": "Intended Audience",
+                "remark": ""
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [
+                    "profile:bf2:Agents:Contribution"
+                  ],
+                  "useValuesFrom": [],
+                  "valueDataType": {
+                    "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Contribution"
+                  },
+                  "defaults": []
+                },
+                "propertyLabel": "Other Agent Associated with Work (RDA 19.3)",
+                "remark": "http://access.rdatoolkit.org/19.3.html",
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution"
+              },
+              {
+                "propertyLabel": "Subject of the Work (RDA Chapter 23)",
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/subject",
+                "resourceTemplates": [],
+                "type": "resource",
+                "valueConstraint": {
+                  "valueTemplateRefs": [
+                    "profile:bf2:Topic"
+                  ],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "remark": "http://access.rdatoolkit.org/rdachp23_rda23-12.html",
+                "mandatory": "false",
+                "repeatable": "true"
+              },
+              {
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [
+                    "profile:bf2:Note"
+                  ],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                "propertyLabel": "Notes about the Work",
+                "remark": "",
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource"
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [
+                    "profile:bf2:Monograph:Dissertation"
+                  ],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/dissertation",
+                "propertyLabel": "Dissertation (RDA 7.9)",
+                "remark": "http://access.rdatoolkit.org/7.9.html"
+              },
+              {
+                "propertyLabel": "Contents (LC-PCC PS 25.1)",
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/tableOfContents",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [
+                    "profile:bf2:Monograph:Contents"
+                  ],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource",
+                "remark": ""
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [
+                    "profile:bf2:LCC",
+                    "profile:bf2:DDC"
+                  ],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "propertyLabel": "Classification numbers",
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/classification"
+              },
+              {
+                "propertyLabel": "Related Works (RDA Chapter 25 and Appendix J)",
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/relatedTo",
+                "resourceTemplates": [],
+                "type": "resource",
+                "valueConstraint": {
+                  "valueTemplateRefs": [
+                    "profile:bf2:RelatedWork"
+                  ],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "remark": "http://access.rdatoolkit.org/rdachp25_rda25-65.html",
+                "mandatory": "false",
+                "repeatable": "true"
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [
+                    "profile:bf2:RelatedExpression"
+                  ],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasExpression",
+                "propertyLabel": "Related Expressions"
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [
+                    "profile:bf2:Monograph:Expression"
+                  ],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasExpression",
+                "propertyLabel": "Expression elements"
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [
+                    "profile:bf2:Monograph:Instance"
+                  ],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasInstance",
+                "propertyLabel": "Has BIBFRAME Instance"
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "literal",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "propertyLabel": "Authorized Access Point Representing the Work (RDA 6.27.1)",
+                "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                "remark": "http://access.rdatoolkit.org/6.27.1.html"
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "literal",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "propertyURI": "http://id.loc.gov/ontologies/bflc/comment",
+                "propertyLabel": "Your Windows ID and Comments"
+              }
+            ],
+            "resourceLabel": "BIBFRAME Work (RDA Work Elements)",
+            "resourceURI": "http://id.loc.gov/ontologies/bibframe/Work"
+          },
+          {
+            "propertyTemplates": [
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [],
+                  "useValuesFrom": [
+                    "http://mlvlp04.loc.gov:8230/resources/works"
+                  ],
+                  "valueDataType": {
+                    "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
+                  },
+                  "defaults": []
+                },
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/expressionOf",
+                "propertyLabel": "Expression of",
+                "remark": "Expression has a related work. For use to connect Works under FRBR/RDA rules."
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [
+                    "profile:bf2:WorkTitle"
+                  ],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/title",
+                "propertyLabel": "Title Information"
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [],
+                  "useValuesFrom": [
+                    "http://id.loc.gov/vocabulary/contentTypes"
+                  ],
+                  "valueDataType": {
+                    "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Content"
+                  },
+                  "editable": "true",
+                  "defaults": [
+                    {
+                      "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/txt",
+                      "defaultLiteral": "text"
+                    }
+                  ]
+                },
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/content",
+                "propertyLabel": "Content Type (RDA 6.9)",
+                "remark": "http://access.rdatoolkit.org/6.9.html"
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "literal",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/originDate",
+                "propertyLabel": "Date of Expression (RDA 6.10)",
+                "remark": "http://access.rdatoolkit.org/6.10.html"
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [],
+                  "useValuesFrom": [
+                    "http://id.loc.gov/vocabulary/languages"
+                  ],
+                  "valueDataType": {
+                    "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Language"
+                  },
+                  "defaults": []
+                },
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/language",
+                "propertyLabel": "Language of Expression (RDA 6.11)",
+                "remark": "http://access.rdatoolkit.org/6.11.html"
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [
+                    "profile:bf2:Monograph:Summary"
+                  ],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "propertyLabel": "Summary",
+                "remark": "",
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/summary"
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [
+                    "profile:bf2:Language:Note"
+                  ],
+                  "useValuesFrom": [],
+                  "valueDataType": {
+                    "dataTypeURI": ""
+                  },
+                  "defaults": []
+                },
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/language",
+                "propertyLabel": "Language of Content (RDA 7.12)",
+                "remark": "http://access.rdatoolkit.org/7.12.html"
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "literal",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "propertyLabel": "Script (RDA 7.13.2)",
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/notation",
+                "remark": "http://access.rdatoolkit.org/7.13.2.html"
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [],
+                  "useValuesFrom": [
+                    "http://id.loc.gov/vocabulary/millus"
+                  ],
+                  "valueDataType": {
+                    "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Illustration"
+                  },
+                  "defaults": []
+                },
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/illustrativeContent",
+                "propertyLabel": "Illustrative Content (RDA 7.15)",
+                "remark": "http://access.rdatoolkit.org/7.15.html"
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [
+                    "profile:bf2:Monograph:SupplContent"
+                  ],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/supplementaryContent",
+                "propertyLabel": "Supplementary Content",
+                "remark": ""
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [
+                    "profile:bf2:Note"
+                  ],
+                  "useValuesFrom": [],
+                  "valueDataType": {
+                    "dataTypeURI": ""
+                  },
+                  "defaults": []
+                },
+                "propertyLabel": "Color Content (RDA 7.17)",
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/colorContent",
+                "remark": "http://access.rdatoolkit.org/7.17.html"
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [
+                    "profile:bf2:Agents:Contribution"
+                  ],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
+                "remark": "http://access.rdatoolkit.org/20.2.html",
+                "propertyLabel": "Contributor (RDA 20.2)"
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "resource",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [
+                    "profile:bf2:Note"
+                  ],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                "propertyLabel": "Notes about the Expression",
+                "remark": ""
+              },
+              {
+                "mandatory": "false",
+                "repeatable": "true",
+                "type": "literal",
+                "resourceTemplates": [],
+                "valueConstraint": {
+                  "valueTemplateRefs": [],
+                  "useValuesFrom": [],
+                  "valueDataType": {},
+                  "defaults": []
+                },
+                "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                "propertyLabel": "Authorized Access Point for the Expression (RDA 6.27.3)",
+                "remark": "http://access.rdatoolkit.org/6.27.3.html"
+              }
+            ],
+            "id": "profile:bf2:Monograph:ExpressionOld",
+            "resourceURI": "http://id.loc.gov/ontologies/bibframe/Work",
+            "resourceLabel": "BIBFRAME Work (RDA Expression Elements)"
+          }
+        ],
+        "contact": "NDMSO",
+        "date": "2017-05-26",
+        "description": "Work, Expression, Instance for Monographs",
+        "id": "profile:bf2:Monograph",
+        "title": "BIBFRAME 2.0 Monograph",
+        "remark": ""
+      }
+    },
+    "metadata": {
+      "createDate": "2018-08-28T16:47:47.920Z",
+      "updateDate": "2018-09-24T14:10:10.171Z",
+      "updateUser": "1"
+    }
+  }
+]

--- a/__tests__/integration/index.html
+++ b/__tests__/integration/index.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="en">
+
+  <head>
+    <title>(Bibliographic Framework Initiative Technical Site - BIBFRAME.ORG)</title>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="shortcut icon" type="image/png" href="/static/images/favicon.ico"/>
+    <!-- Latest compiled and minified CSS -->
+    <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
+
+    <!-- Optional theme -->
+    <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap-theme.min.css">
+
+    <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
+    <!--[if lt IE 9]>
+      <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
+      <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
+    <![endif]-->
+
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.0/jquery.min.js"></script>
+    <script src="https://code.jquery.com/jquery-migrate-1.2.1.js"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>
+
+    <script src="https://cdn.datatables.net/1.10.9/js/jquery.dataTables.js"></script>
+    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.10.9/css/jquery.dataTables.min.css">
+
+    <script src="https://cdn.jsdelivr.net/g/es6-promise@1.0.0"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jsonld/0.3.15/jsonld.js"></script>
+
+    <script src="../../builds/short-uuid.min.js"></script>
+    <script src="../../builds/twitter-typeahead-0.10.2.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/2.4.1/lodash.min.js"></script>
+
+    <script type="text/javascript" src="../../builds/n3-browser.min.js"></script>
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.17/d3.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/d3-tip/0.6.7/d3-tip.min.js"></script>
+
+    <script type="text/javascript" src="../../builds/jsonld-vis.js"></script>
+    <link rel="stylesheet" type="text/css" href="../../static/css/jsonld-vis.css" />
+
+    <script type="text/javascript" src="../../builds/bfe.min.js"></script>
+    <link rel="stylesheet" type="text/css" href="../../builds/css/bfe.min.css" />
+
+    <style>
+        @media screen {
+            body {
+                padding-top: 50px;
+                padding-bottom: 20px;
+            }
+        }
+        @media print {
+            a[href]:after {
+                content: none;
+            }
+        }
+        .popover { max-width: none }
+    </style>
+
+  </head>
+
+  <body>
+
+
+    <nav class="navbar navbar-inverse navbar-fixed-top" role="navigation">
+        <div class="container-fluid">
+            <div class="navbar-header">
+                <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1">
+                    <span class="sr-only">Toggle navigation</span>
+                    <span class="icon-bar"></span>
+                    <span class="icon-bar"></span>
+                    <span class="icon-bar"></span>
+                </button>
+                <a class="navbar-brand" href="/bibliomata/bfe/development.html">BIBFRAME Editor Demo</a>
+            </div>
+            <div class="collapse navbar-collapse visible-print" id="bs-example-navbar-collapse-1">
+                <ul class="nav navbar-nav navbar-right">
+                    <li class="divider"></li>
+                    <li><a href="http://www.loc.gov/bibframe/">&laquo; Back to LC BIBFRAME Site</a></li>
+                    <li class="divider"></li>
+                </ul>
+            </div>
+        </div>
+    </nav>
+<!-- Breadcrumbs -->
+<ol class="breadcrumb">
+<li><a href = "/bibliomata/">Home</a></li>
+<li><a href = "/bibliomata/bfe/development.html">Editor</a></li>
+</ol>
+
+<div id="bfeditor" class="container-fluid">
+    <div id="iealert"></div>
+</div>
+
+<script type="text/javascript">
+    function reloadJs(src) {
+        src = $('script[src$="' + src + '"]').attr("src");
+        $('script[src$="' + src + '"]').remove();
+        $('<script/>').attr('src', src).appendTo('body');
+    }
+</script>
+<script type="text/javascript" src="test-config.js"></script>
+<br/><br/><br/>
+
+<hr>
+   <footer class="bs-footer" role="contentinfo">
+    <div class="container">
+          <p>This is a development view of the Bibliographic Framework Initiative project's editor. For more information, go to  <a href="http://www.loc.gov/bibframe/">www.loc.gov/bibframe</a>.</p>
+    </div>
+   </footer>
+  </body>
+</html>

--- a/__tests__/integration/profilesLoad.test.js
+++ b/__tests__/integration/profilesLoad.test.js
@@ -1,0 +1,26 @@
+describe('Profiles load', () => {
+
+  beforeAll(async () => {
+    // page.on('console', msg => console.log('PAGE LOG:', msg.text()));
+    await page.goto('http://127.0.0.1:8000/__tests__/integration/index.html');
+    await expect(page).toClick('a[href="#create"]', { text: 'Editor' })
+    await page.waitFor(1000)
+  });
+
+  it('loads profile for Monograph Instance', async () => {
+
+    const monograph_sel = 'ul.nav-sidebar > li:first-child > a:first-child'
+    await expect(page).toClick(monograph_sel, { text: 'Monograph' })
+
+    const instance_sel = 'a#sp-0_0'
+    await expect(page).toClick(instance_sel, { text: 'Instance' })
+
+    await page.waitFor(1000)
+
+    // await page.screenshot({path: 'screenshot.png', fullPage: true})
+
+    const ptitle_sel = 'div#bfeditor-formdiv > form > div > h4'
+    const profile_title = await page.$eval(ptitle_sel, e => e.textContent)
+    await expect(profile_title).toMatch(/BIBFRAME Instance/)
+  })
+})

--- a/__tests__/integration/test-config.js
+++ b/__tests__/integration/test-config.js
@@ -1,0 +1,494 @@
+var ie = (function(){
+    var undef,
+        v = 3,
+        div = document.createElement('div'),
+        all = div.getElementsByTagName('i');
+    while (
+      div.innerHTML = '<!--[if gt IE ' + (++v) + ']><i></i><![endif]-->',
+      all[0]
+    );
+    return v > 4 ? v : undef;
+  }());
+
+  if (ie < 10) {
+    $("#iealert").addClass("alert alert-danger");
+    $("#iealert").html("Sorry, but the BIBFRAME Editor will not work in IE8 or IE9.")
+  }
+
+  function myCB(data) {
+    document.body.scrollTop = document.documentElement.scrollTop = 0;
+  }
+
+  function csrfSafeMethod(method) {
+    // these HTTP methods do not require CSRF protection
+    return (/^(GET|HEAD|OPTIONS|TRACE)$/.test(method));
+  }
+
+  function getCSRF(){
+    //eventually you'll have to login
+    var cookieValue = null;
+    if (document.cookie && document.cookie != '') {
+      var cookies = document.cookie.split(';');
+      for (var i = 0; i < cookies.length; i++) {
+        var cookie = jQuery.trim(cookies[i]);
+        var name = "csrftoken";
+        if (cookie.substring(0, name.length + 1) == (name + '=')) {
+          cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+          break;
+        }
+      }
+    }
+    return cookieValue;
+  }
+
+  function setCSRF(xhr, settings, csrf) {
+    if (!csrfSafeMethod(settings.type) && !this.crossDomain) {
+      xhr.setRequestHeader("X-CSRFToken", csrf);
+    }
+  }
+
+  function save(data, csrf, bfelog, callback){
+    var $messagediv = $('<div>', {id: "bfeditor-messagediv", class:"col-md-10 main"});
+
+    var url = config.url + "/verso/api/bfs/upsertWithWhere?where=%7B%22name%22%3A%20%22"+data.name+"%22%7D";
+
+    $.ajax({
+      url: url,
+      type: "POST",
+      data:JSON.stringify(data),
+      csrf: csrf,
+      dataType: "json",
+      contentType: "application/json; charset=utf-8"
+    }).done(function (data) {
+      document.body.scrollTop = document.documentElement.scrollTop = 0;
+      bfelog.addMsg(new Error(), "INFO", "Saved " + data.id);
+      var $messagediv = $('<div>', {id: "bfeditor-messagediv"});
+      var decimaltranslator = window.ShortUUID("0123456789");
+      var resourceName = "e" + decimaltranslator.fromUUID(data.name);
+      $messagediv.append('<div class="alert alert-info"><strong>Description saved:</strong><a href='+data.url+'>'+resourceName+'</a></div>')
+      $('#bfeditor-formdiv').empty();
+      $('#save-btn').remove();
+      $messagediv.insertBefore('.nav-tabs');
+      $('#bfeditor-previewPanel').remove();
+      $('.nav-tabs a[href="#browse"]').tab('show')
+      bfeditor.bfestore.store = [];
+      window.location.hash = "";
+      callback(true, data.name);
+    }).fail(function (XMLHttpRequest, textStatus, errorThrown){
+      bfelog.addMsg(new Error(), "ERROR", "FAILED to save");
+      bfelog.addMsg(new Error(), "ERROR", "Request status: " + textStatus + "; Error msg: " + errorThrown);
+      $messagediv.append('<div class="alert alert-danger"><strong>Save Failed:</strong>'+errorThrown+'</span>');
+      $messagediv.insertBefore('.nav-tabs');
+    }).always(function(){
+      $('#table_id').DataTable().ajax.reload();
+    });
+  }
+
+  function publish(data, rdfxml, savename, bfelog, callback){
+    var $messagediv = $('<div>', {id: "bfeditor-messagediv", class:"col-md-10 main"});
+
+    //var url = "http://mlvlp04.loc.gov:8201/bibrecs/bfe2mets.xqy";
+    var url = config.url + "/profile-edit/server/publish";
+    var saveurl = "/verso/api/bfs/upsertWithWhere?where=%7B%22name%22%3A%20%22"+savename+"%22%7D";
+
+    var savedata = {};
+    savedata.name = savename;
+    savedata.profile = data.profile;
+    savedata.url = data.url;
+    savedata.created = data.created;
+    savedata.modified = data.modified;
+    savedata.status = data.status;
+    savedata.rdf = data.rdf;
+
+    data.rdfxml = JSON.stringify(rdfxml);
+
+    $.when(
+      $.ajax({
+        url: saveurl,
+        type: "POST",
+        data:JSON.stringify(savedata),
+        dataType: "json",
+        contentType: "application/json; charset=utf-8"
+      }),
+      $.ajax({
+        url: url,
+        type: "POST",
+        data: JSON.stringify(data),
+        dataType: "json",
+        contentType: "application/json; charset=utf-8"
+      })).done(function (savedata, publishdata) {
+        document.body.scrollTop = document.documentElement.scrollTop = 0;
+        bfelog.addMsg(new Error(), "INFO", "Published " + publishdata[0].name);
+        var $messagediv = $('<div>', {id: "bfeditor-messagediv"});
+        $messagediv.append('<div class="alert alert-info"><strong>Description submitted for posting:</strong><a href=' + config.basedbURI + "/" + publishdata[0].objid+'>'+publishdata[0].lccn+'</a></div>');
+        $('#bfeditor-formdiv').empty();
+        $('#save-btn').remove();
+        $messagediv.insertBefore('.nav-tabs');
+        $('#bfeditor-previewPanel').remove();
+        $('.nav-tabs a[href="#browse"]').tab('show')
+        bfeditor.bfestore.store = [];
+        window.location.hash = "";
+        callback(true, data.name);
+      }).fail(function (XMLHttpRequest, textStatus, errorThrown){
+        bfelog.addMsg(new Error(), "ERROR", "FAILED to save");
+        bfelog.addMsg(new Error(), "ERROR", "Request status: " + textStatus + "; Error msg: " + errorThrown);
+        $messagediv.append('<div class="alert alert-danger"><strong>Save Failed:</strong>'+errorThrown+'</span>');
+        $messagediv.insertBefore('#bfeditor-previewPanel');
+      }).always(function(){
+        $('#table_id').DataTable().ajax.reload();
+      });
+  }
+
+
+  function retrieve(uri, bfestore, loadtemplates, bfelog, callback){
+    var $messagediv = $('<div>', {id: "bfeditor-messagediv", class:"col-md-10 main"});
+    // var url = config.url + "/profile-edit/server/whichrt";
+    // var url = https://gist.githubusercontent.com/ndushay/12d703259da878ab686dc54cae8c8089/raw/35bdf898247fdf24c55d3cadc4c6a7e154ff89e3/bibframe_instance.json
+    var url = 'http://127.0.0.1:8000/__tests__/__fixtures__/instance_ontology.json';
+    var dType = (bfestore.state == 'loadmarc') ? 'xml' : 'json';
+
+    $.ajax({
+      dataType: dType,
+      type: "GET",
+      async: false,
+      data: { uri: uri},
+      url: url,
+      success: function (data) {
+        bfelog.addMsg(new Error(), "INFO", "Fetched external source baseURI " + uri);
+        bfelog.addMsg(new Error(), "DEBUG", "Source data", data);
+
+        if (dType == 'xml') {
+          var recCount = $('zs\\:numberOfRecords', data).text();
+          if (recCount != '0') {
+            var rdfrec  = $('zs\\:recordData', data).html();
+            var recid = $('bf\\:Local > rdf\\:value', data).html()
+            recid = recid.padStart(9, '0');
+            bfestore.rdfxml2store(rdfrec, loadtemplates, recid, callback);
+          } else {
+            var q = uri.replace(/.+query=(.+?)&.+/, "$1");
+            $nohits = $('<div class="modal" tabindex="-1" role="dialog" id="nohits"><div class="modal-dialog" role="document"><div class="modal-content"> \
+            <div class="modal-header">No Record Found!</div><div class="modal-body"><p>Query: "' + q + '"</p></div> \
+            <div class="modal-footer"><button type="button" class="btn btn-primary" data-dismiss="modal">OK</button></div></div></div></div>');
+            $nohits.modal('show');
+          }
+        } else {
+          bfestore.store = bfestore.jsonldcompacted2store(data, function(expanded) {
+            bfestore.store = [];
+            tempstore = bfestore.jsonld2store(expanded);
+            callback(loadtemplates);
+          });
+        }
+        //bfestore.n32store(data, url, tempstore, callback);
+      },
+      error: function(XMLHttpRequest, textStatus, errorThrown) {
+        bfelog.addMsg(new Error(), "ERROR", "FAILED to load external source: " + url);
+        bfelog.addMsg(new Error(), "ERROR", "Request status: " + textStatus + "; Error msg: " + errorThrown);
+      }
+    });
+  }
+
+  function retrieveLDS(uri, bfestore, loadtemplates, bfelog, callback){
+
+    var url = config.url + "/profile-edit/server/retrieveLDS";
+
+    $.ajax({
+      dataType: "json",
+      type: "GET",
+      async: false,
+      data: { uri: uri},
+      url: url,
+      success: function (data) {
+        bfelog.addMsg(new Error(), "INFO", "Fetched external source baseURI" + url);
+        bfelog.addMsg(new Error(), "DEBUG", "Source data", data);
+        bfestore.store = bfestore.jsonldcompacted2store(data, function(expanded) {
+          bfestore.store = [];
+          tempstore = bfestore.jsonld2store(expanded);
+          bfestore.storeDedup();
+          callback(loadtemplates);
+        });
+        //bfestore.n32store(data, url, tempstore, callback);
+      },
+      error: function(XMLHttpRequest, textStatus, errorThrown) {
+        bfelog.addMsg(new Error(), "ERROR", "FAILED to load external source: " + url);
+        bfelog.addMsg(new Error(), "ERROR", "Request status: " + textStatus + "; Error msg: " + errorThrown);
+      }
+    });
+  }
+
+
+  function deleteId(id, csrf, bfelog){
+    var url = config.url + "/verso/api/bfs/" + id;
+
+    //$.ajaxSetup({
+    //    beforeSend: function(xhr, settings){getCSRF(xhr, settings, csrf);}
+    //});
+
+    $.ajax({
+      type: "DELETE",
+      url: url,
+      dataType: "json",
+      csrf: csrf,
+      success: function (data) {
+        bfelog.addMsg(new Error(), "INFO", "Deleted " + id);
+      },
+      error: function(XMLHttpRequest, textStatus, errorThrown) {
+        bfelog.addMsg(new Error(), "ERROR", "FAILED to delete: " + url);
+        bfelog.addMsg(new Error(), "ERROR", "Request status: " + textStatus + "; Error msg: " + errorThrown);
+      }
+    });
+
+  }
+
+  /* Config object profiles
+   * Editor profiles are read from a WS endpoint
+   * The data are expected to be in a JSON array, with each object
+   * in the array containing a "json" property that has the profile
+   * itself. The "versoURL" variable is a convenience for setting the
+   * base URL of verso in the "config" definition below.
+   */
+  var rectoBase = "http://bibframe.org/bibliomata";
+
+  // The following line is for local developement
+  // rectoBase = "http://localhost:3000";
+  var versoURL = rectoBase + "/verso/api";
+
+  console.log(`DEBUG: in test-config.js`)
+  var config = {
+                /* "logging": {
+                  "level": "DEBUG",
+                  "toConsole": false
+                }, */
+    "url" : rectoBase,
+    "baseURI": "http://id.loc.gov/",
+    "basedbURI": "http://mlvlp04.loc.gov:8230",
+    "resourceURI": "http://mlvlp04.loc.gov:8230/resources",
+    "profiles": [
+       // versoURL + "/configs?filter[where][configType]=profile"
+       'http://127.0.0.1:8000/__tests__/__fixtures__/verso_profile_response_short.json'
+       // 'https://gist.githubusercontent.com/ndushay/ad3d33de8f2c082b4fc55a80b1c2d724/raw/264bffaea54600443a340aa57d1ed8a66b6a105b/verso_profiles.json'
+    ],
+    "startingPoints": [
+      {"menuGroup": "Monograph",
+       "menuItems": [
+         {
+           label: "Instance",
+           type: ["http://id.loc.gov/ontologies/bibframe/Instance"],
+           useResourceTemplates: [ "profile:bf2:Monograph:Instance" ]
+         },
+         {
+           label: "Work",
+           type: ["http://id.loc.gov/ontologies/bibframe/Work"],
+           useResourceTemplates: [ "profile:bf2:Monograph:Work" ]
+         }
+
+       ]},
+      {"menuGroup": "Notated Music",
+       "menuItems": [
+         {
+           label: "Create Work",
+           type: ["http://id.loc.gov/ontologies/bibframe/Work"],
+           useResourceTemplates: [ "profile:bf2:NotatedMusic:Work" ]
+         },
+         {
+           label: "Create RDA Expression",
+           type: ["http://id.loc.gov/ontologies/bibframe/Work"],
+           useResourceTemplates: [ "profile:bf2:NotatedMusic:Expression" ]
+         },
+         {
+           label: "Create Instance",
+           type: ["http://id.loc.gov/ontologies/bibframe/Instance"],
+           useResourceTemplates: [ "profile:bf2:NotatedMusic:Instance" ]
+         }
+      //  ]},
+      // {"menuGroup": "Serial",
+      //  "menuItems": [
+      //    {
+      //      label: "Instance",
+      //      type: ["http://id.loc.gov/ontologies/bibframe/Serial"],
+      //      useResourceTemplates: [ "profile:bf2:Serial:Instance" ]
+      //    },
+      //    {
+      //      label: "Work",
+      //      type: ["http://id.loc.gov/ontologies/bibframe/Text"],
+      //      useResourceTemplates: [ "profile:bf2:Serial:Work" ]
+      //    }
+      //
+      //  ]},
+      // {"menuGroup": "Cartographic",
+      //  "menuItems": [
+      //    {
+      //      label: "Instance",
+      //      type: ["http://id.loc.gov/ontologies/bibframe/Instance"],
+      //      useResourceTemplates: [ "profile:bf2:Cartographic:Instance" ]
+      //    },
+      //    {
+      //      label: "Work",
+      //      type: ["http://id.loc.gov/ontologies/bibframe/Work"],
+      //      useResourceTemplates: [ "profile:bf2:Cartographic:Work" ]
+      //    }
+      //
+      //  ]},
+      // {"menuGroup": "Sound Recording: Audio CD",
+      //  "menuItems": [
+      //    {
+      //      label: "Instance",
+      //      type: ["http://id.loc.gov/ontologies/bibframe/Instance"],
+      //      useResourceTemplates: [ "profile:bf2:SoundRecording:Instance" ]
+      //    },
+      //    {
+      //      label: "Work",
+      //      type: ["http://id.loc.gov/ontologies/bibframe/Work"],
+      //      useResourceTemplates: [ "profile:bf2:SoundRecording:Work" ]
+      //    }
+      //
+      //  ]},
+      // {"menuGroup": "Sound Recording: Audio CD-R",
+      //  "menuItems": [
+      //    {
+      //      label: "Instance",
+      //      type: ["http://id.loc.gov/ontologies/bibframe/Instance"],
+      //      useResourceTemplates: [ "profile:bf2:SoundCDR:Instance" ]
+      //    },
+      //    {
+      //      label: "Work",
+      //      type: ["http://id.loc.gov/ontologies/bibframe/Work"],
+      //      useResourceTemplates: [ "profile:bf2:SoundCDR:Work" ]
+      //    }
+      //
+      //  ]},
+      // {"menuGroup": "Sound Recording: Analog",
+      //  "menuItems": [
+      //    {
+      //      label: "Instance",
+      //      type: ["http://id.loc.gov/ontologies/bibframe/Instance"],
+      //      useResourceTemplates: [ "profile:bf2:Analog:Instance" ]
+      //    },
+      //    {
+      //      label: "Work",
+      //      type: ["http://id.loc.gov/ontologies/bibframe/Work"],
+      //      useResourceTemplates: [ "profile:bf2:Analog:Work" ]
+      //    }
+      //
+      //  ]},
+      // {"menuGroup": "Moving Image: BluRay DVD",
+      //  "menuItems": [
+      //    {
+      //      label: "Instance",
+      //      type: ["http://id.loc.gov/ontologies/bibframe/Instance"],
+      //      useResourceTemplates: [ "profile:bf2:MIBluRayDVD:Instance" ]
+      //    },
+      //    {
+      //      label: "Work",
+      //      type: ["http://id.loc.gov/ontologies/bibframe/Work"],
+      //      useResourceTemplates: [ "profile:bf2:MIBluRayDVD:Work" ]
+      //    }
+      //
+      //  ]},
+      // {"menuGroup": "Moving Image: 35mm Feature Film",
+      //  "menuItems": [
+      //    {
+      //      label: "Instance",
+      //      type: ["http://id.loc.gov/ontologies/bibframe/Instance"],
+      //      useResourceTemplates: [ "profile:bf2:35mmFeatureFilm:Instance" ]
+      //    },
+      //    {
+      //      label: "Work",
+      //      type: ["http://id.loc.gov/ontologies/bibframe/Work"],
+      //      useResourceTemplates: [ "profile:bf2:35mmFeatureFilm:Work" ]
+      //    }
+      //
+      //  ]},
+      // {"menuGroup": "Prints and Photographs",
+      //  "menuItems": [
+      //    {
+      //      label: "Physical Description",
+      //      type: ["http://id.loc.gov/ontologies/bibframe/Instance"],
+      //      useResourceTemplates: [ "profile:bf2:Graphics:Description" ]
+      //    },
+      //    {
+      //      label: "Work",
+      //      type: ["http://id.loc.gov/ontologies/bibframe/Work"],
+      //      useResourceTemplates: [ "profile:bf2:Graphics:Work" ]
+      //    }
+      //
+      //  ]},
+      // {"menuGroup": "Rare Materials",
+      //  "menuItems": [
+      //    {
+      //      label: "Instance",
+      //      type: ["http://id.loc.gov/ontologies/bibframe/Instance"],
+      //      useResourceTemplates: [ "profile:bf2:RareMat:Instance" ]
+      //    },
+      //    {
+      //      label: "Work",
+      //      type: ["http://id.loc.gov/ontologies/bibframe/Work"],
+      //      useResourceTemplates: [ "profile:bf2:RareMat:Work" ]
+      //    }
+      //
+      //  ]},
+      // {"menuGroup": "Authorities",
+      //  "menuItems": [
+      //    {
+      //      label: "Person",
+      //      type: ["http://www.loc.gov/standards/mads/rdf/v1.html#PersonalName"],
+      //      useResourceTemplates: [ "profile:bf2:Agent:Person" ]
+      //    },
+      //    {
+      //      label: "Family",
+      //      type: ["http://www.loc.gov/standards/mads/rdf/v1.html#FamilyName"],
+      //      useResourceTemplates: [ "profile:bf2:Agent:Family" ]
+      //    },
+      //    {
+      //      label: "Corporate Body",
+      //      type: ["http://www.loc.gov/standards/mads/rdf/v1.html#CorporateName"],
+      //      useResourceTemplates: [ "profile:bf2:Agent:CorporateBody" ]
+      //    },
+      //    {
+      //      label: "Conference",
+      //      type: ["http://www.loc.gov/standards/mads/rdf/v1.html#Conference"],
+      //      useResourceTemplates: [ "profile:bf2:Agent:Conference" ]
+      //    },
+      //    {
+      //      label: "Jurisdiction",
+      //      type: ["http://www.loc.gov/standards/mads/rdf/v1.html#Territory"],
+      //      useResourceTemplates: [ "profile:bf2:Agent:Jurisdiction" ]
+      //    }
+       ]}
+
+    ],
+    "save": {
+      "callback": save
+    },
+    "publish": {
+      "callback": publish
+    },
+    "retrieveLDS": {
+      "callback":retrieveLDS
+    },
+    "retrieve": {
+      "callback": retrieve
+    },
+    "deleteId": {
+      "callback": deleteId
+    },
+    "getCSRF":{
+      "callback": getCSRF
+    },
+    /*            "load": [
+                  {
+                  "templateID": ["profile:bf:Work:Monograph", "profile:bf:Instance:Monograph", "profile:bf:Annotation:AdminMeta"],
+                  "defaulturi": "http://id.loc.gov/resources/bibs/5226",
+                  "_remark": "Source must be JSONLD expanded, so only jsonp and json are possible requestTypes",
+                  "source": {
+                  "location": "http://id.loc.gov/resources/bibs/5226.bibframe_raw.jsonp",
+                  "requestType": "jsonp",
+                  "data": "UNUSED, BUT REMEMBER IT"
+                  }
+                  }
+                  ],*/
+    "return": {
+      "format": "jsonld-expanded",
+      "callback": myCB
+    }
+  }
+  var bfeditor = bfe.fulleditor(config, "bfeditor");

--- a/jest-puppeteer.config.js
+++ b/jest-puppeteer.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   launch: {
-    headless: process.env.CI === 'true'
+    headless: process.env.HEADLESS !== 'false',
+    'args' : [ '--disable-web-security' ],
   },
   server: {
     command: 'node server-bfe.js',

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "reporters": [
       "default",
       "jest-junit"
-    ]
+    ],
+    "testPathIgnorePatterns" : ["/node_modules/", "test-config.js"]
   }
 }

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   },
   "scripts": {
     "grunt": "grunt",
-    "eslint": "eslint --max-warnings 1423 --color -c .eslintrc.js .",
+    "eslint": "eslint --max-warnings 775 --color -c .eslintrc.js .",
     "test": "jest --colors",
     "jest-cov": "jest --coverage --colors",
     "jest-ci": "jest --ci --runInBand --coverage --reporters=default --reporters=jest-junit --colors  && cat ./coverage/lcov.info | coveralls",


### PR DESCRIPTION
Aside from writing the test code itself, this involved:

- adding some fixture json files to be accessed via local url
- a testing copy of config.js (__tests__/integration/test-config.js)
    - changes hardcoded url for config.profiles from verso to localhost for short(er) profiles fixture json
    - changes the hardcoded url in "retrieve" function to localhost for instance ontology fixture json
- a testing copy of index.html using test-config.js
- turning off web security (CORS) when running puppeteer in order to be able to get localhost json
- tweaked eslint globals (got busted on my test code!)


This approach is brittle on a few counts:
- test-config.js will drift from actual config.js
- test index.html will drift from actual index.html
- hardcoding only allows retrieval of bibframe instance ontology resource template, no others.
- can't run server locally, as CORS will prevent profiles and resource template from loading

However, it is a test showing that a profile is loaded, and it's a start.

Also created tickets
-  #70 - a small refactoring of config.js to greatly improve code testability
- #71 - split the config code from the data - have a json (or yml or whatever) file populating menu, not part of code itself

Closes #49
Closes #46
