### PR TITLE
Editor tab testing of default profile menu and submenus

### DIFF
--- a/__tests__/integration/editorTab.test.js
+++ b/__tests__/integration/editorTab.test.js
@@ -1,0 +1,61 @@
+describe('Editor Tab', () => {
+  beforeAll(async () => {
+    await page.goto('http://127.0.0.1:8000/');
+    await expect(page).toClick('a[href="#create"]', { text: 'Editor' })
+    await page.waitFor(1000)
+  })
+
+  it('checks for headline', async () => {
+    const h3 = await page.$eval('#bfeditor-menudiv > h3', e => e.textContent)
+    await expect(h3).toMatch(/Create Resource/)
+  })
+
+  it('checks for default menu of profiles', async () => {
+    const monograph = await page.$eval('#bfeditor-menudiv > ul:nth-child(2) > li > a', e => e.textContent)
+    await expect(monograph).toMatch(/Monograph/)
+    const notated_music = await page.$eval('#bfeditor-menudiv > ul:nth-child(3) > li > a', e => e.textContent)
+    await expect(notated_music).toMatch(/Notated Music/)
+    const serial = await page.$eval('#bfeditor-menudiv > ul:nth-child(4) > li > a', e => e.textContent)
+    await expect(serial).toMatch(/Serial/)
+    const map = await page.$eval('#bfeditor-menudiv > ul:nth-child(5) > li > a', e => e.textContent)
+    await expect(map).toMatch(/Cartographic/)
+    const cd = await page.$eval('#bfeditor-menudiv > ul:nth-child(6) > li > a', e => e.textContent)
+    await expect(cd).toMatch(/Sound Recording: Audio CD/)
+    const cd_r = await page.$eval('#bfeditor-menudiv > ul:nth-child(7) > li > a', e => e.textContent)
+    await expect(cd_r).toMatch(/Sound Recording: Audio CD-R/)
+    const recording_analog = await page.$eval('#bfeditor-menudiv > ul:nth-child(8) > li > a', e => e.textContent)
+    await expect(recording_analog).toMatch(/Sound Recording: Analog/)
+    const blu_ray = await page.$eval('#bfeditor-menudiv > ul:nth-child(9) > li > a', e => e.textContent)
+    await expect(blu_ray).toMatch(/Moving Image: BluRay DVD/)
+    const moving_img_35 = await page.$eval('#bfeditor-menudiv > ul:nth-child(10) > li > a',  e => e.textContent)
+    await expect(moving_img_35).toMatch(/Moving Image: 35mm Feature Film/)
+    const print_photos = await page.$eval('#bfeditor-menudiv > ul:nth-child(11) > li > a', e => e.textContent)
+    await expect(print_photos).toMatch(/Prints and Photographs/)
+    const rare = await page.$eval('#bfeditor-menudiv > ul:nth-child(12) > li > a', e => e.textContent)
+    await expect(rare).toMatch(/Rare Materials/)
+    const authorities = await page.$eval('#bfeditor-menudiv > ul:nth-child(13) > li > a', e => e.textContent)
+    await expect(authorities).toMatch(/Authorities/)
+  })
+
+  it('checks for profile sub-menu', async () => {
+    const monograph_instance = await page.$eval('#sp-0_0', e => e.textContent)
+    const monograph_work = await page.$eval('#sp-0_1', e => e.textContent)
+    await expect(monograph_instance).toMatch(/Instance/)
+    await expect(monograph_work).toMatch(/Work/)
+    const print_physical_desc = await page.$eval('#sp-9_0', e => e.textContent)
+    await expect(print_physical_desc).toMatch(/Physical Description/)
+  })
+
+  it('checks for authorities sub-menu', async () => {
+    const person = await page.$eval('#sp-11_0', e => e.textContent)
+    await expect(person).toMatch(/Person/)
+    const family = await page.$eval('#sp-11_1', e => e.textContent)
+    await expect(family).toMatch(/Family/)
+    const corporate_body = await page.$eval('#sp-11_2', e => e.textContent)
+    await expect(corporate_body).toMatch(/Corporate Body/)
+    const conference = await page.$eval('#sp-11_3', e => e.textContent)
+    await expect(conference).toMatch(/Conference/)
+    const jurisdiction = await page.$eval('#sp-11_4', e => e.textContent)
+    await expect(jurisdiction).toMatch(/Jurisdiction/)
+  })
+})


### PR DESCRIPTION
Checks for initial hard-coded profiles menu in the editor tab as a startingPoint.  Monograph, Prints and Photographs,  and Authorities sub-menus are also tested.

Fixes #52