### PR TITLE
Updating merge version 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4948,7 +4948,7 @@
       "integrity": "sha512-FIUCJz1RbuS0FKTdaAafAByGS0CPvU3R0MeHxgtl+djzCc//F8HakL8GzmVNZanasTbTAY/3DRFA0KpVqj/eAw==",
       "dev": true,
       "requires": {
-        "merge": "^1.2.0"
+        "merge": "^1.2.1"
       }
     },
     "execa": {
@@ -9437,7 +9437,7 @@
       }
     },
     "merge": {
-      "version": "1.2.0",
+      "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
       "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=",
       "dev": true


### PR DESCRIPTION
Fix security alert from Github about updating version of `merge` used in package-lock.json. 