### PR TITLE
server.js, bfe-index.html and other housekeeping

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -29,7 +29,7 @@ module.exports = function(grunt) {
       static_mappings: {
         files: [
           // note:  also need index.html, static/css and static/images files
-          {src: 'server-bfe.js', dest: 'builds/server-bfe.js'},
+          {src: 'server.js', dest: 'builds/server.js'},
           {src: 'static/js/config.js', dest: 'builds/config.js'},
           {src: 'static/js/jsonld-vis.js', dest: 'builds/jsonld-vis.js'},
           {src: 'static/js/n3-browser.min.js', dest: 'builds/n3-browser.min.js'},

--- a/README.md
+++ b/README.md
@@ -37,7 +37,11 @@ Technical documentation specific to the Sinopia BIBFRAME Editor may also be foun
 
 ## Running the code
 
-Follow installation instructions, then run `node server-bfe.js`.  This will start up the editor at http://localhost:8000
+`npm start`
+
+Follow installation instructions, then run `npm start` or `node server.js`.  This will start up the code at http://localhost:8000, loading `index.html` which shows the Sinopia home page.
+
+TEMP: The Sinopia Editor is currently available via http://localhost:8000/bfe-index.html.
 
 ## Developers
 

--- a/README.md
+++ b/README.md
@@ -37,11 +37,15 @@ Technical documentation specific to the Sinopia BIBFRAME Editor may also be foun
 
 ## Running the code
 
+WIP here -- things in flux ...
+
 `npm start`
 
-Follow installation instructions, then run `npm start` or `node server.js`.  This will start up the code at http://localhost:8000, loading `index.html` which shows the Sinopia home page.
+Follow installation instructions, then run `npm start` or `node server.js`.  This will start up the code at http://localhost:8000.  
 
 TEMP: The Sinopia Editor is currently available via http://localhost:8000/bfe-index.html.
+
+TEMP:  Note that `index.html` is meant to show the Sinopia home page via React.
 
 ## Developers
 
@@ -118,29 +122,6 @@ support is currently listed.  It has been developed primarily using Chrome.
 It has been tested in both Chrome and Safari mobile versions.
 
 
-Roadmap
-----------
-v0.2.x
-* Support LC Bibframe Pilot
-* Request.js has been deprecated
-* Dryice build has been replaced with Grunt.
-
-v0.3.x
-* Implement BF 2.0 Ontology
-* LC Bibframe Pilot 2.0 support.
-* Implement save/load api
-
-v0.4.x
-* Additional features to support LC Bibframe Pilot 2.0
-* Additional features to support requirements for LD4P2
-
-v1.x
-* Support for LD4P2 requirements
-* Refactor into MVC
-* Implement common javascript framework (React, Angular, etc)
-* Implement automated testing.
-
-
 Developers
 ----------
 
@@ -181,7 +162,6 @@ Specification][profilespec].
 [Bootstrap]: http://getbootstrap.com/
 [typeahead.js]: https://github.com/twitter/typeahead.js
 [require.js]: http://requirejs.org/
-[dryice]: https://github.com/mozilla/dryice
 [ace]: https://github.com/ajaxorg/ace
 [Zepheira]: https://zepheira.com/
 [profilespec]: http://bibframe.org/documentation/bibframe-profilespec/

--- a/README.md
+++ b/README.md
@@ -33,17 +33,16 @@ Technical documentation specific to the Sinopia BIBFRAME Editor may also be foun
 4.  Get latest npm: `npm install -g npm@latest`
 5.  Run `npm install grunt-cli` to install grunt-cli.
 6.  Run `npm install`. This installs everything needed for the build to run successfully.
-7.  Run `grunt` to build the code.
+7.  Run `npm run build` to build the code.  (TEMP: Run `npm run grunt` or `grunt` to build the BFE code.)
 
 ## Running the code
 
-WIP here -- things in flux ...
-
 `npm start`
 
-Follow installation instructions, then run `npm start` or `node server.js`.  This will start up the code at http://localhost:8000.  
+Follow installation instructions, then run `npm start` or `node server.js` to start the web server using Express.
+This will start up the code at http://localhost:8000.
 
-TEMP: The Sinopia Editor is currently available via http://localhost:8000/bfe-index.html.
+TEMP: The Sinopia Editor code is currently available via http://localhost:8000/bfe-index.html.
 
 TEMP:  Note that `index.html` is meant to show the Sinopia home page via React.
 
@@ -52,11 +51,29 @@ TEMP:  Note that `index.html` is meant to show the Sinopia home page via React.
 - See `package.json` for npm package dependencies.
 - The web server used is `express` web framework for node.js
 
-### Build with grunt
+### Run the server with webpack-dev-webserver
 
-The javascript code uses grunt as a build tool. See `Gruntfile.js` for build dependencies and configuration.
+`npm run dev-start`
 
-- To build the code, `grunt` or `npm run grunt`
+This runs the webpack-dev-server, allowing immediate loading of live code changes without having to restart the server.
+
+### Build with webpack
+
+`npm run build`
+
+We are using webpack as a build tool.  See `webapck.config.js` for build dependencies and configuration.
+
+#### TEMP: Build with grunt
+
+The inherited javascript code uses grunt as a build tool. See `Gruntfile.js` for those build dependencies and configuration.
+
+- To build the inherited (non-react) code, `grunt` or `npm run grunt`.  This is needed for `bfe-index.html` to work.
+
+### NPM && build
+
+`npm run install-build`
+
+This does `npm install` following by `npm run grunt` in a single step.
 
 ### Linter for JavaScript
 

--- a/README.md
+++ b/README.md
@@ -100,18 +100,6 @@ Twitter's [Bootstrap] and a few additional custom CSS declarations.
 [bfi]: http://www.loc.gov/bibframe/
 [profilespec]: http://bibframe.org/documentation/bibframe-profilespec/
 
-Getting Started
----------------
-`bfe` is currently submodule of [recto](http://github.com/lcnetdev/recto), an express-based webserver, which uses [verso](http://github.com/lcnetdev/verso) a loopback-based server for backend data. The current recommendation is to install recto and verso and use bfe as part of the demonstration environment.
-
-`bfe` can be run as a demo or development version using a simple express-based server - found in the main `bfe` directory -
-that ships with `bfe`:
-
-```bash
-node server-bfe.js
-```
-
-
 Browser Support
 ---------------
 

--- a/bfe-index.html
+++ b/bfe-index.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="en">
+
+  <head>
+    <title>(Bibliographic Framework Initiative Technical Site - BIBFRAME.ORG)</title>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="shortcut icon" type="image/png" href="/static/images/favicon.ico"/>
+    <!-- Latest compiled and minified CSS -->
+    <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
+
+    <!-- Optional theme -->
+    <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap-theme.min.css">
+
+    <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
+    <!--[if lt IE 9]>
+      <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
+      <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
+    <![endif]-->
+
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.0/jquery.min.js"></script>
+    <script src="https://code.jquery.com/jquery-migrate-1.2.1.js"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>
+
+    <script src="https://cdn.datatables.net/1.10.9/js/jquery.dataTables.js"></script>
+    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.10.9/css/jquery.dataTables.min.css">
+
+    <script src="https://cdn.jsdelivr.net/g/es6-promise@1.0.0"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jsonld/0.3.15/jsonld.js"></script>
+
+    <script src="builds/short-uuid.min.js"></script>
+    <script src="builds/twitter-typeahead-0.10.2.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/2.4.1/lodash.min.js"></script>
+
+    <script type="text/javascript" src="builds/n3-browser.min.js"></script>
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.17/d3.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/d3-tip/0.6.7/d3-tip.min.js"></script>
+
+    <script type="text/javascript" src="builds/jsonld-vis.js"></script>
+    <link rel="stylesheet" type="text/css" href="static/css/jsonld-vis.css" />
+
+    <script type="text/javascript" src="builds/bfe.min.js"></script>
+    <link rel="stylesheet" type="text/css" href="builds/css/bfe.min.css" />
+
+    <style>
+      @media screen {
+        body {
+          padding-top: 50px;
+          padding-bottom: 20px;
+        }
+      }
+      @media print {
+        a[href]:after {
+          content: none;
+        }
+      }
+      .popover { max-width: none }
+    </style>
+
+  </head>
+
+  <body>
+
+    <nav class="navbar navbar-inverse navbar-fixed-top" role="navigation">
+        <div class="container-fluid">
+            <div class="navbar-header">
+                <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1">
+                    <span class="sr-only">Toggle navigation</span>
+                    <span class="icon-bar"></span>
+                    <span class="icon-bar"></span>
+                    <span class="icon-bar"></span>
+                </button>
+                <a class="navbar-brand" href="/bibliomata/bfe/development.html">BIBFRAME Editor Demo</a>
+            </div>
+            <div class="collapse navbar-collapse visible-print" id="bs-example-navbar-collapse-1">
+                <ul class="nav navbar-nav navbar-right">
+                    <li class="divider"></li>
+                    <li><a href="http://www.loc.gov/bibframe/">&laquo; Back to LC BIBFRAME Site</a></li>
+                    <li class="divider"></li>
+                </ul>
+            </div>
+        </div>
+    </nav>
+
+    <!-- Breadcrumbs -->
+    <ol class="breadcrumb">
+    <li><a href = "/bibliomata/">Home</a></li>
+    <li><a href = "/bibliomata/bfe/development.html">Editor</a></li>
+    </ol>
+
+    <div id="bfeditor" class="container-fluid">
+      <div id="iealert"></div>
+    </div>
+
+    <script type="text/javascript">
+      function reloadJs(src) {
+        src = $('script[src$="' + src + '"]').attr("src");
+        $('script[src$="' + src + '"]').remove();
+        $('<script/>').attr('src', src).appendTo('body');
+      }
+    </script>
+    <script type="text/javascript" src="static/js/config.js"></script>
+    <br/><br/><br/>
+
+    <hr>
+    <footer class="bs-footer" role="contentinfo">
+    <div class="container">
+      <p>This is a development view of the Bibliographic Framework Initiative project's editor. For more information, go to  <a href="http://www.loc.gov/bibframe/">www.loc.gov/bibframe</a>.</p>
+    </div>
+   </footer>
+  </body>
+</html>

--- a/jest-puppeteer.config.js
+++ b/jest-puppeteer.config.js
@@ -4,7 +4,7 @@ module.exports = {
     'args' : [ '--disable-web-security' ],
   },
   server: {
-    command: 'node server-bfe.js',
+    command: 'node server.js',
     port: 8000,
   },
 };

--- a/package.json
+++ b/package.json
@@ -72,14 +72,15 @@
     "doc": "docs"
   },
   "scripts": {
-    "dev-start": "webpack-dev-server --config ./webpack.config.js --mode development",
+    "analysis": "es6-plato -d static-analysis -n -e .eslintrc.js src src/lib static/js/config.js static/js/config-dev.js",
     "build": "webpack -p --progress",
-    "grunt": "grunt",
+    "dev-start": "webpack-dev-server --config ./webpack.config.js --mode development",
     "eslint": "eslint --max-warnings 775 --color -c .eslintrc.js ./src",
-    "test": "jest --colors",
+    "grunt": "grunt",
+    "install-build": "npm install && npm run build && npm run grunt",
     "jest-cov": "jest --coverage --colors",
     "jest-ci": "jest --ci --runInBand --coverage --reporters=default --reporters=jest-junit --colors  && cat ./coverage/lcov.info | coveralls",
-    "analysis": "es6-plato -d static-analysis -n -e .eslintrc.js src src/lib static/js/config.js static/js/config-dev.js"
+    "test": "jest --colors"
   },
   "license": "ISC",
   "dependencies": {

--- a/server.js
+++ b/server.js
@@ -1,13 +1,13 @@
-//   Minimal BIBFRAME Editor Node.js server. To run from the command-line:
-//   node server-bfe.js
+// Minimal BIBFRAME Editor Node.js server. To run from the command-line:
+//  npm start  or node server.js
 
 var port = 8000;
 var express = require('express');
- 
+
 var app = express();
- 
+
 app.use(express.static(__dirname + '/'));
 app.listen(port);
 
 console.log('BIBFRAME Editor running on ' + port);
-console.log('Press Ctrl + C to stop.'); 
+console.log('Press Ctrl + C to stop.');


### PR DESCRIPTION
- Renamed `server-bfe.js` to `server.js` to be more standard
- Restored original `index.html` as `bfe-index.html` for an easy way to look at BFF while we work on getting react trappings
- added npm `install-build` script and sorted scripts by name in package.json
- updated README

Closes #66