### PR TITLE
use .dockerignore file to exclude unwanted files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+__mocks__
+__tests__
+.circleci
+.git
+.gitignore
+/.eslint*.*
+build_support
+coverage
+docs
+development.html
+jest-puppeteer.config.js
+junit.xml
+npm-debug.log
+static-analysis
+setupEnzyme.js


### PR DESCRIPTION
Current root directory from container looks like:
```
$ docker exec 92c1bc4bd9d1 ls -a
.
..
.babelrc
.circleci
.eslintignore
.eslintrc-todo.yml
.eslintrc.js
.eslintrc.yml
.git
.gitignore
Dockerfile
Gruntfile.js
LICENSE.txt
README.md
__mocks__
__tests__
bfe-index.html
build_support
builds
coverage
dist
docs
index.html
jest-puppeteer.config.js
junit.xml
node_modules
package-lock.json
package.json
server.js
setupEnzyme.js
src
static
static-analysis
webpack.config.js
```

About half of that is stuff we don't want in the container.