### PR TITLE
Include "dist" for container, not "builds"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,12 @@ jobs:
       - restore_cache:
           key: dependencies-ci-{{ checksum "package.json" }}
       - run: npm run eslint
-      - run: npm run grunt
+      - run: npm run grunt # eventually, this goes away
+      - run: npm run build
+      - persist_to_workspace:
+          root: .
+          paths:
+            - dist # ignoring ./builds (producted by grunt)
       - run:
           command: npm run jest-ci
           environment:
@@ -58,7 +63,7 @@ jobs:
       - restore_cache: # gives us back matching node_modules
           key: dependencies-prod-{{ checksum "package.json" }}
       - attach_workspace:
-          at: dist
+          at: .
       - run:
           name: Build & Register Image
           command: |

--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,7 @@ __tests__
 .gitignore
 /.eslint*.*
 build_support
+builds
 coverage
 docs
 development.html


### PR DESCRIPTION
The container will only include the webpack artifacts, not the legacy grunt artifacts.

The built container now contains the same files that webpack produces in`dist`:
    
```
docker pull ld4p/sinopia_editor
docker run ld4p/sinopia_editor ls dist
    42e18bb8ebabfb8bcfd5967540c0b88e.png
    b62e74f0c408aa3c9a20fc0e71b16e9a.png
    bundle.js
    index.html
```


This relates to #28
Fixes #106 