### PR TITLE
Adds components to render resource template value constraint properties

### DIFF
--- a/__tests__/components/editor/ValueConstraints.test.js
+++ b/__tests__/components/editor/ValueConstraints.test.js
@@ -1,0 +1,199 @@
+import React from 'react'
+import { mount } from 'enzyme';
+import ValueConstraints from '../../../src/components/editor/ValueConstraints'
+
+const jsdom = require("jsdom");
+
+setUpDomEnvironment();
+
+const vcProps = {
+  "propertyTemplates": [
+    {
+      "valueConstraint": {
+        "defaults": [
+          {
+            "defaultLiteral": "DEFAULT",
+            "defaultURI": "http://default"
+          }
+        ],
+        "editable": "true",
+        "languageLabel": "LANGUAGE LABEL",
+        "languageURI": "http://id.loc.gov/vocabulary/languages/eng",
+        "remark": "REMARK",
+        "repeatable": "false",
+        "useValuesFrom": [
+          "http://VALUES"
+        ],
+        "validatePattern": "PATTERN",
+        "valueDataType": {
+          "dataTypeLabel": "Classification item number",
+          "dataTypeLabelHint": "HINT",
+          "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/itemPortion",
+          "remark": "REMARK"
+        },
+        "valueLanguage": "VALUE LANGUAGE",
+        "valueTemplateRefs": [
+          "profile:bf2:Identifiers:Barcode"
+        ]
+      }
+    }
+  ]
+}
+
+const props = {}
+const vcProp = vcProps.propertyTemplates[0].valueConstraint
+props.defaults = vcProp.defaults
+props.editable = vcProp.editable
+props.languageLabel = vcProp.languageLabel
+props.languageURI = vcProp.languageURI
+props.remark = vcProp.remark
+props.repeatable = vcProp.repeatable
+props.useValuesFrom = vcProp.useValuesFrom
+props.validatePattern = vcProp.validatePattern
+props.valueDataType = vcProp.valueDataType
+props.valueLanguage = vcProp.valueLanguage
+props.valueTemplateRefs = vcProp.valueTemplateRefs
+
+let wrapper = mount(<ValueConstraints {...props} />)
+
+describe('<ValueConstraints />', () => {
+  it('has div with class "ValueConstraints"', () => {
+    expect(wrapper.find('h6').text()).toEqual('VALUE CONSTRAINTS')
+    expect(wrapper.find('div.ValueConstraints > ul > li')).toHaveLength(11)
+    wrapper.find('div.ValueConstraints > ul > li').filterWhere(n => n.children().length === 0).forEach((node) => {
+      expect(node.containsAnyMatchingElements([
+        'editable: true',
+        'languageLabel: LANGUAGE LABEL',
+        'languageURI: http://id.loc.gov/vocabulary/languages/eng',
+        'remark: REMARK',
+        'repeatable: false',
+        'validatePattern: PATTERN',
+        'valueLanguage: VALUE LANGUAGE'
+      ]))
+    })
+  })
+})
+
+describe('when values are present', () => {
+
+  describe('<Defaults />', () => {
+    it('has defaults', () => {
+      expect(wrapper.find('Defaults > div > ul > li').length).toBe(2)
+      wrapper.find('Defaults > div > ul > li').forEach((node) => {
+        expect(node.containsAnyMatchingElements([
+          'defaultURI: http://default',
+          'defaultLiteral: DEFAULT'
+        ]))
+      })
+    })
+  })
+
+  describe('<ValueTemplateRefs />', () => {
+    it('has valueTemplateRefs', () => {
+      expect(wrapper.find('ValueTemplateRefs > div > ul > li').text()).toEqual('profile:bf2:Identifiers:Barcode')
+    })
+  })
+
+  describe('<UseValuesFrom />', () => {
+    it('has useValuesFrom', () => {
+      expect(wrapper.find('UseValuesFrom > div > ul > li').text()).toEqual('http://VALUES')
+    })
+  })
+
+  describe('<ValueDataTypes />', () => {
+    it('has valueDataTypes', () => {
+      expect(wrapper.find('ValueDataTypes > div > ul > li').length).toBe(4)
+      wrapper.find('ValueDataTypes > div > ul > li').forEach((node) => {
+        expect(node.containsAnyMatchingElements([
+          'dataTypeLabel: Classification item number',
+          'dataTypeLabelHint: HINT',
+          'dataTypeURI: http://id.loc.gov/ontologies/bibframe/itemPortion',
+          'remark: REMARK'
+        ]))
+      })
+    })
+  })
+
+})
+
+describe('reset', () => {
+})
+
+describe('when values are not present', () => {
+  delete props.editable
+  delete props.languageLabel
+  delete props.languageURI
+  delete props.remark
+  delete props.repeatable
+  delete props.validatePattern
+  delete props.valueLanguage
+
+  props.defaults = ''
+  props.useValuesFrom = ''
+  props.valueDataType = ''
+  props.valueTemplateRefs = ''
+
+  let valueConstraints = (
+    <ValueConstraints {...props} />
+  )
+
+  let wrapper = mount(valueConstraints)
+
+  describe('<ValueConstraints />', () => {
+    it('does not render the li for base ValueConstraints values if there are no props', () => {
+      expect(wrapper.find('ValueConstraints > div > ul > li').length).toBe(0)
+    })
+  })
+
+  describe('<Defaults />', () => {
+    it('does not render the li for Defaults if there are no values', () => {
+      expect(wrapper.find('Defaults > div > ul > li').length).toBe(0)
+    })
+  })
+
+  describe('<ValueTemplateRefs />', () => {
+    it('does not render the li for valueTemplateRefs if there is no value', () => {
+      expect(wrapper.find('ValueTemplateRefs > div > ul > li').length).toBe(0)
+    })
+  })
+
+  describe('<UseValuesFrom />', () => {
+    it('does not render the li for useValuesFrom if there is no value', () => {
+      expect(wrapper.find('UseValuesFrom > div > ul > li').length).toBe(0)
+    })
+  })
+
+  describe('<ValueDataTypes />', () => {
+    it('does not render the li for valueDataTypes if there is no value', () => {
+      expect(wrapper.find('ValueDataTypes > div > ul > li').length).toBe(0)
+    })
+  })
+
+})
+
+describe('cleanup', () => {
+  it('unmounts the wrapper', () => {
+    expect(wrapper.debug().length).toBeGreaterThanOrEqual(1)
+    wrapper.unmount();
+    expect(wrapper.debug().length).toBe(0)
+  })
+})
+
+function setUpDomEnvironment() {
+  const { JSDOM } = jsdom;
+  const dom = new JSDOM('<!doctype html><html><body></body></html>', {url: 'http://localhost/'});
+  const { window } = dom;
+
+  global.window = window;
+  global.document = window.document;
+  global.navigator = {
+    userAgent: 'node.js',
+  };
+  copyProps(window, global);
+}
+function copyProps(src, target) {
+  const props = Object.getOwnPropertyNames(src)
+    .filter(prop => typeof target[prop] === 'undefined')
+    .map(prop => Object.getOwnPropertyDescriptor(src, prop));
+  Object.defineProperties(target, props);
+}

--- a/src/components/editor/Editor.jsx
+++ b/src/components/editor/Editor.jsx
@@ -136,6 +136,42 @@ class Editor extends Component {
               },
               "mandatory": "false",
               "remark": "http://access.rdatoolkit.org/3.3.html"
+            },
+            {
+              "propertyLabel": "WITH ALL VALUE CONSTRAINTS",
+              "propertyURI": "http://id.loc.gov/ontologies/fake",
+              "repeatable": "true",
+              "resourceTemplates": [],
+              "type": "resource",
+              "valueConstraint": {
+                "defaults": [
+                  {
+                    "defaultLiteral": "DEFAULT",
+                    "defaultURI": "http://default"
+                  }
+                ],
+                "editable": "true",
+                "languageLabel": "LANGUAGE LABEL",
+                "languageURI": "http://id.loc.gov/vocabulary/languages/eng",
+                "remark": "REMARK",
+                "repeatable": "false",
+                "useValuesFrom": [
+                  "http://VALUES"
+                ],
+                "validatePattern": "PATTERN",
+                "valueDataType": {
+                  "dataTypeLabel": "Classification item number",
+                  "dataTypeLabelHint": "HINT",
+                  "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/itemPortion",
+                  "remark": "REMARK"
+                },
+                "valueLanguage": "VALUE LANGUAGE",
+                "valueTemplateRefs": [
+                  "profile:bf2:Identifiers:Barcode"
+                ]
+              },
+              "mandatory": "false",
+              "remark": "http://access.rdatoolkit.org/3.3.html"
             }
           ]
         }

--- a/src/components/editor/Editor.jsx
+++ b/src/components/editor/Editor.jsx
@@ -110,6 +110,32 @@ class Editor extends Component {
                 "valueDataType": {},
                 "defaults": []
               }
+            },
+            {
+              "propertyLabel": "Carrier Type (RDA 3.3)",
+              "propertyURI": "http://id.loc.gov/ontologies/bibframe/carrier",
+              "repeatable": "true",
+              "resourceTemplates": [],
+              "type": "resource",
+              "valueConstraint": {
+                "valueTemplateRefs": [],
+                "useValuesFrom": [
+                  "http://id.loc.gov/vocabulary/carriers"
+                ],
+                "valueDataType": {
+                  "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Carrier"
+                },
+                "repeatable": "true",
+                "editable": "false",
+                "defaults": [
+                  {
+                    "defaultURI": "http://id.loc.gov/vocabulary/carriers/nc",
+                    "defaultLiteral": "volume"
+                  }
+                ]
+              },
+              "mandatory": "false",
+              "remark": "http://access.rdatoolkit.org/3.3.html"
             }
           ]
         }

--- a/src/components/editor/PropertyTemplate.jsx
+++ b/src/components/editor/PropertyTemplate.jsx
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import ValueConstraints from './ValueConstraints'
 
 class PropertyTemplate extends Component {
   render() {
@@ -16,11 +17,15 @@ class PropertyTemplate extends Component {
           <li>mandatory: <strong>{this.props.propertyTemplates[0].mandatory}</strong></li>
           <li>repeatable: <strong>{this.props.propertyTemplates[0].repeatable}</strong></li>
           <li>contained resourceTemplates[] length: <strong>{this.props.propertyTemplates[0].resourceTemplates.length}</strong></li>
+          <li>
+            <ValueConstraints {...this.props.propertyTemplates[0].valueConstraint} />
+          </li>
         </ul>
         <h5>END of PropertyTemplate elements</h5>
       </div>
     )
   }
 }
+
 
 export default PropertyTemplate

--- a/src/components/editor/ValueConstraints.jsx
+++ b/src/components/editor/ValueConstraints.jsx
@@ -1,0 +1,143 @@
+import React, { Component } from 'react'
+
+class ValueConstraints extends Component {
+  render() {
+    let dashedBorder = {
+      border: '1px dashed',
+      padding: '10px',
+    }
+
+    const hasDefaults = this.props.defaults.length > 0
+    const hasEditable = typeof(this.props.editable) !== 'undefined'
+    const hasLanguageLabel = typeof(this.props.languageLabel) !== 'undefined'
+    const hasLanguageURI = typeof(this.props.languageURI) !== 'undefined'
+    const hasRemark = typeof(this.props.remark) !== 'undefined'
+    const hasRepeatable = typeof(this.props.repeatable) !== 'undefined'
+    const hasUseValuesFrom = this.props.useValuesFrom.length > 0
+    const hasValidatePattern = typeof(this.props.validatePattern) !== 'undefined'
+    const hasValueDataTypes = hasValues(this.props.valueDataType)
+    const hasValueLanguage = typeof(this.props.valueLanguage) !== 'undefined'
+    const hasValueTemplateRefs = this.props.valueTemplateRefs.length > 0
+
+    return(
+      <div className="ValueConstraints" style={dashedBorder}>
+        <h6>VALUE CONSTRAINTS</h6>
+        <ul>
+          { hasDefaults? (<li>defaults: <Defaults defaults = {this.props.defaults} /></li>) : null }
+          { hasEditable? (<li>editable: {this.props.editable}</li>) : null }
+          { hasLanguageLabel? (<li>languageLabel: {this.props.languageLabel}</li>) : null }
+          { hasLanguageURI? (<li>languageURI: {this.props.languageURI}</li>) : null }
+          { hasRemark? (<li>remark: {this.props.remark}</li>) : null }
+          { hasRepeatable? (<li>repeatable: {this.props.repeatable}</li>) : null }
+          { hasUseValuesFrom? (<li>useValuesFrom: <UseValuesFrom useValuesFrom = {this.props.useValuesFrom} /></li>) : null }
+          { hasValidatePattern? (<li>validatePattern: {this.props.validatePattern}</li>) : null }
+          { hasValueDataTypes? ( <li>valueDataType: <ValueDataTypes valueDataTypes = {[this.props.valueDataType]} /></li>) : null }
+          { hasValueLanguage? (<li>valueLanguage: {this.props.valueLanguage}</li>) : null }
+          { hasValueTemplateRefs? (<li>valueTemplateRefs: <ValueTemplateRefs valueTemplateRefs = {this.props.valueTemplateRefs} /></li>) : null }
+        </ul>
+      </div>
+    )
+  }
+}
+
+class ValueDataTypes extends Component {
+  render() {
+    const obj = this.props.valueDataTypes
+    if(hasValues(obj[0])){
+      const hasRemark = obj[0].remark
+      const hasDataTypeLabel = obj[0].dataTypeLabel
+      const hasDataTypeLabelHint = obj[0].dataTypeLabelHint
+      const hasDataTypeURI = obj[0].dataTypeURI
+      return(
+        <div>
+          <ul>
+            { hasRemark? (<li><em>remark: </em>{obj[0].remark}</li>) : null }
+            { hasDataTypeLabel? (<li><em>data type label: </em>{obj[0].dataTypeLabel}</li>) : null }
+            { hasDataTypeLabelHint? (<li><em>data type label hint: </em>{obj[0].dataTypeLabelHint}</li>) : null }
+            { hasDataTypeURI? (<li><em>data type URI: </em>{obj[0].dataTypeURI}</li>) : null }
+          </ul>
+        </div>
+      )
+    } else {
+     return(
+       <span />
+     )
+    }
+  }
+}
+
+class Defaults extends Component {
+  render() {
+    const obj = this.props.defaults[0]
+    if (hasValues(obj)){
+      return(
+        <div>
+          <ul>
+            <li><em>defaultURI: </em>{obj.defaultURI}</li>
+            <li><em>defaultLiteral: </em>{obj.defaultLiteral}</li>
+          </ul>
+        </div>
+      )
+    } else {
+      return(
+        <div />
+      )
+    }
+  }
+}
+
+class UseValuesFrom extends Component {
+  render() {
+    const obj = this.props.useValuesFrom
+    if(obj.length > 0) {
+      return(
+        <div>
+          <ul>
+            {obj.map(function(val, i){
+              return(
+                <li key={i}>{val}</li>
+              )
+            })}
+          </ul>
+        </div>
+      )
+    } else {
+      return(
+        <div />
+      )
+    }
+  }
+}
+
+class ValueTemplateRefs extends Component {
+  render() {
+    const obj = this.props.valueTemplateRefs
+    if(obj.length > 0) {
+      return(
+        <div>
+          <ul>
+            {obj.map(function(val, i){
+              return(
+                <li key={i}>{val}</li>
+              )
+            })}
+          </ul>
+        </div>
+      )
+    } else {
+      return(
+        <div />
+      )
+    }
+  }
+}
+
+function hasValues(obj) {
+  for(var key in obj) {
+    if(obj.hasOwnProperty(key) && obj[key].length > 0)
+      return true
+  }
+  return false
+}
+
+export default ValueConstraints


### PR DESCRIPTION
Fixes #123 

- adds carrier property to static resource template json in Editor.jsx
- adds a new `<ValueConstraints />` component with sub-components:
  - `<ValueTemplateRefs />`
  - `<UseValuesFrom />`
  - `<ValueDataTypes />`
  - `<Defaults />`
- function to check whether a hash has a key/value pair, used for conditional display
- test that uses enzyme full rendering with `mount` and a way to test a component's properties directly.