### PR TITLE
Moves EditorHeader component to component 'editor' folder

### DIFF
--- a/__tests__/components/editor/Editor.test.js
+++ b/__tests__/components/editor/Editor.test.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { shallow } from 'enzyme'
 import Editor from '../../../src/components/editor/Editor'
 import ResourceTemplate from '../../../src/components/editor/ResourceTemplate'
-import EditorHeader from '../../../src/components/EditorHeader'
+import Header from '../../../src/components/editor/Header'
 
 describe('<Editor />', () => {
   const wrapper = shallow(<Editor />)
@@ -14,7 +14,7 @@ describe('<Editor />', () => {
     expect(wrapper.find(ResourceTemplate).length).toBe(1)
   })
 
-  it('renders <EditorHeader />', () => {
-    expect(wrapper.find(EditorHeader).length).toBe(1)
+  it('renders <Header />', () => {
+    expect(wrapper.find(Header).length).toBe(1)
   })
 })

--- a/__tests__/components/editor/Header.test.js
+++ b/__tests__/components/editor/Header.test.js
@@ -2,10 +2,10 @@
 
 import React from 'react'
 import { shallow } from 'enzyme'
-import EditorHeader from '../../src/components/EditorHeader'
+import Header from '../../../src/components/editor/Header'
 
-describe('<EditorHeader />', () => {
-  const wrapper = shallow(<EditorHeader />)
+describe('<Header />', () => {
+  const wrapper = shallow(<Header />)
   it ('displays the Sinopia text', () => {
     expect(wrapper.find("h1.editor-logo").text()).toBe("SINOPIA")
   })

--- a/src/components/editor/Editor.jsx
+++ b/src/components/editor/Editor.jsx
@@ -2,7 +2,7 @@
 
 import React, {Component} from 'react'
 import ResourceTemplate from './ResourceTemplate'
-import EditorHeader from '../EditorHeader'
+import Header from './Header'
 import StartingPoints from './StartingPoints'
 const sinopiaServerSpoof = require('../../sinopiaServerSpoof.js')
 
@@ -43,7 +43,7 @@ class Editor extends Component {
   render() {
     return(
       <div id="editor">
-        <EditorHeader triggerEditorMenu={this.props.triggerHandleOffsetMenu}/>
+        <Header triggerEditorMenu={this.props.triggerHandleOffsetMenu}/>
         <h1> Editor Page </h1>
         <p>The selected resource template is <strong>{this.state.resourceTemplates[0].id}</strong></p>
         <StartingPoints/>

--- a/src/components/editor/Header.jsx
+++ b/src/components/editor/Header.jsx
@@ -1,8 +1,6 @@
 // Copyright 2018 Stanford University see Apache2.txt for license
 
 import React, { Component } from 'react'
-import SinopiaLogo from '../../styles/editorsinopialogo.png'
-import { Link } from 'react-router-dom'
 
 class Header extends Component {
   render() {

--- a/src/components/editor/Header.jsx
+++ b/src/components/editor/Header.jsx
@@ -1,10 +1,10 @@
 // Copyright 2018 Stanford University see Apache2.txt for license
 
 import React, { Component } from 'react'
-import SinopiaLogo from '../styles/editorsinopialogo.png'
+import SinopiaLogo from '../../styles/editorsinopialogo.png'
 import { Link } from 'react-router-dom'
 
-class EditorHeader extends Component {
+class Header extends Component {
   render() {
     return (
       <div className="navbar editor-navbar">
@@ -26,4 +26,4 @@ class EditorHeader extends Component {
   }
 }
 
-export default EditorHeader
+export default Header


### PR DESCRIPTION
Fixes #145 

The cool thing was that WebStorm made all the changes for me. All I had to do was drop and drag the file...