### PR TITLE
Spoof resource templates from server

### DIFF
--- a/__tests__/sinopiaServerSpoof.test.js
+++ b/__tests__/sinopiaServerSpoof.test.js
@@ -1,0 +1,28 @@
+describe('sinopiaServerSpoof', () => {
+  let sinopiaServerSpoof  = require('../src/sinopiaServerSpoof.js')
+
+  describe('resourceTemplateIds', () => {
+    it('array of length 10', () => {
+      expect(sinopiaServerSpoof.resourceTemplateIds).toHaveLength(10)
+    })
+    it('resourceTemplateId is in expected format', () => {
+      sinopiaServerSpoof.resourceTemplateIds.forEach(id => {
+        expect(id).toMatch(/^resourceTemplate:((bf2)|(bflc)):.*/)
+      })
+    })
+  })
+
+  describe('resourceTemplateId2Json', () => {
+    it('array of length 10', () => {
+      expect(sinopiaServerSpoof.resourceTemplateId2Json).toHaveLength(10)
+    })
+    it('mapping has id', () => {
+      expect(sinopiaServerSpoof.resourceTemplateId2Json[0]['id']).toBe('resourceTemplate:bf2:Monograph:Instance')
+      expect(sinopiaServerSpoof.resourceTemplateId2Json[9]['id']).toBe('resourceTemplate:bf2:WorkVariantTitle')
+    })
+    it('mapping has json', () => {
+      expect(sinopiaServerSpoof.resourceTemplateId2Json[0]['json']).toBeDefined()
+      expect(sinopiaServerSpoof.resourceTemplateId2Json[9]['json']).toBeDefined()
+    })
+  })
+})

--- a/src/components/editor/Editor.jsx
+++ b/src/components/editor/Editor.jsx
@@ -22,7 +22,6 @@ class Editor extends Component {
   // TODO: eventually, this will do an http request to the sinopiaServer via fetch or axios
   //  Note that the spoofing uses sinopiaServerSpoof, which uses some files in static
   getResourceTemplate(rtId) {
-    // console.debug(`DEBUG: getResourceTemplate: ${rtId}`)
     var rTemplate = {propertyTemplates : [{}] }
     if (rtId != null) {
       if (sinopiaServerSpoof.resourceTemplateIds.includes(rtId)) {

--- a/src/components/editor/Editor.jsx
+++ b/src/components/editor/Editor.jsx
@@ -4,182 +4,41 @@ import React, {Component} from 'react'
 import ResourceTemplate from './ResourceTemplate'
 import EditorHeader from '../EditorHeader'
 import StartingPoints from './StartingPoints'
+const sinopiaServerSpoof = require('../../sinopiaServerSpoof.js')
 
 class Editor extends Component {
   constructor(props) {
     super(props)
-    this.state = {
-      // selecting a resource template will happen in the left-nav "Create Resource" menu, another child of this component
-      // NOTE: temporarily hardcoded here.
-      resourceTemplates: [
-        {
-          "id": "profile:bf2:Monograph:Instance",
-          "resourceLabel": "BIBFRAME Instance",
-          "resourceURI": "http://id.loc.gov/ontologies/bibframe/Instance",
-          "remark": "Can you believe we're doing this!?",
-          "propertyTemplates": [
-            {
-              "propertyLabel": "Instance of",
-              "propertyURI": "http://id.loc.gov/ontologies/bibframe/instanceOf",
-              "resourceTemplates": [],
-              "type": "resource",
-              "valueConstraint": {
-                "valueTemplateRefs": [
-                  "profile:bf2:Monograph:Work"
-                ],
-                "useValuesFrom": [],
-                "valueDataType": {},
-                "defaults": []
-              },
-              "mandatory": "false",
-              "repeatable": "true"
-            },
-            {
-              "propertyLabel": "Title Information",
-              "propertyURI": "http://id.loc.gov/ontologies/bibframe/title",
-              "resourceTemplates": [],
-              "valueConstraint": {
-                "valueTemplateRefs": [
-                  "profile:bf2:Title",
-                  "profile:bf2:Title:VarTitle",
-                  "profile:bf2:ParallelTitle",
-                  "profile:bflc:TranscribedTitle"
-                ],
-                "useValuesFrom": [],
-                "valueDataType": {
-                  "remark": ""
-                },
-                "defaults": []
-              },
-              "mandatory": "false",
-              "repeatable": "true",
-              "type": "resource",
-              "remark": ""
-            },
-            {
-              "propertyLabel": "Statement of Responsibility Relating to Title Proper (RDA 2.4.2)",
-              "remark": "http://access.rdatoolkit.org/2.4.2.html",
-              "propertyURI": "http://id.loc.gov/ontologies/bibframe/responsibilityStatement",
-              "mandatory": "false",
-              "repeatable": "true",
-              "type": "literal",
-              "resourceTemplates": [],
-              "valueConstraint": {
-                "valueTemplateRefs": [],
-                "useValuesFrom": [],
-                "valueDataType": {},
-                "defaults": []
-              }
-            },
-            {
-              "propertyURI": "http://id.loc.gov/ontologies/bibframe/issuance",
-              "propertyLabel": "Mode of Issuance (RDA 2.13)",
-              "remark": "http://access.rdatoolkit.org/2.13.html",
-              "mandatory": "false",
-              "repeatable": "true",
-              "type": "resource",
-              "resourceTemplates": [],
-              "valueConstraint": {
-                "valueTemplateRefs": [],
-                "useValuesFrom": [
-                  "http://id.loc.gov/vocabulary/issuance"
-                ],
-                "valueDataType": {
-                  "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Issuance"
-                },
-                "editable": "false",
-                "repeatable": "true",
-                "defaults": [
-                  {
-                    "defaultURI": "http://id.loc.gov/vocabulary/issuance/mono",
-                    "defaultLiteral": "single unit"
-                  }
-                ]
-              }
-            },
-            {
-              "propertyLabel": "Notes about the Instance",
-              "remark": "http://access.rdatoolkit.org/2.17.html",
-              "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-              "mandatory": "false",
-              "repeatable": "true",
-              "type": "resource",
-              "resourceTemplates": [],
-              "valueConstraint": {
-                "valueTemplateRefs": [
-                  "profile:bf2:Note"
-                ],
-                "useValuesFrom": [],
-                "valueDataType": {},
-                "defaults": []
-              }
-            },
-            {
-              "propertyLabel": "Carrier Type (RDA 3.3)",
-              "propertyURI": "http://id.loc.gov/ontologies/bibframe/carrier",
-              "repeatable": "true",
-              "resourceTemplates": [],
-              "type": "resource",
-              "valueConstraint": {
-                "valueTemplateRefs": [],
-                "useValuesFrom": [
-                  "http://id.loc.gov/vocabulary/carriers"
-                ],
-                "valueDataType": {
-                  "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Carrier"
-                },
-                "repeatable": "true",
-                "editable": "false",
-                "defaults": [
-                  {
-                    "defaultURI": "http://id.loc.gov/vocabulary/carriers/nc",
-                    "defaultLiteral": "volume"
-                  }
-                ]
-              },
-              "mandatory": "false",
-              "remark": "http://access.rdatoolkit.org/3.3.html"
-            },
-            {
-              "propertyLabel": "WITH ALL VALUE CONSTRAINTS",
-              "propertyURI": "http://id.loc.gov/ontologies/fake",
-              "repeatable": "true",
-              "resourceTemplates": [],
-              "type": "resource",
-              "valueConstraint": {
-                "defaults": [
-                  {
-                    "defaultLiteral": "DEFAULT",
-                    "defaultURI": "http://default"
-                  }
-                ],
-                "editable": "true",
-                "languageLabel": "LANGUAGE LABEL",
-                "languageURI": "http://id.loc.gov/vocabulary/languages/eng",
-                "remark": "REMARK",
-                "repeatable": "false",
-                "useValuesFrom": [
-                  "http://VALUES"
-                ],
-                "validatePattern": "PATTERN",
-                "valueDataType": {
-                  "dataTypeLabel": "Classification item number",
-                  "dataTypeLabelHint": "HINT",
-                  "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/itemPortion",
-                  "remark": "REMARK"
-                },
-                "valueLanguage": "VALUE LANGUAGE",
-                "valueTemplateRefs": [
-                  "profile:bf2:Identifiers:Barcode"
-                ]
-              },
-              "mandatory": "false",
-              "remark": "http://access.rdatoolkit.org/3.3.html"
-            }
-          ]
-        }
-      ]
+
+    this.getResourceTemplate = this.getResourceTemplate.bind(this)
+
+    // TODO: temporarily hardcoded here.
+    //  Selecting a resource template will happen in the left-nav "Starting Points" menu,
+    //   another child of the Editor component;  it will call this.getResourceTemplate
+    const defaultResourceTemplate = 'resourceTemplate:bf2:Monograph:Instance'
+    this.state = { resourceTemplates: [this.getResourceTemplate(defaultResourceTemplate)]}
+  }
+
+  // TODO: eventually, this will do an http request to the sinopiaServer via fetch or axios
+  //  Note that the spoofing uses sinopiaServerSpoof, which uses some files in static
+  getResourceTemplate(rtId) {
+    // console.debug(`DEBUG: getResourceTemplate: ${rtId}`)
+    var rTemplate = {propertyTemplates : [{}] }
+    if (rtId != null) {
+      if (sinopiaServerSpoof.resourceTemplateIds.includes(rtId)) {
+        // FIXME:  there's probably a better way to find the value in array than forEach
+        sinopiaServerSpoof.resourceTemplateId2Json.forEach( function(el) {
+          if (rtId == el.id) {
+            rTemplate = el.json
+          }
+        })
+      } else {
+        console.error(`un-spoofed resourceTemplate: ${rtId}`)
+      }
+    } else {
+      console.error(`asked for resourceTemplate with null id`)
     }
+    return rTemplate
   }
 
   render() {

--- a/src/sinopiaServerSpoof.js
+++ b/src/sinopiaServerSpoof.js
@@ -1,0 +1,37 @@
+// data structures to support spoofing Sinopia Server calls to get resource templates, etc.
+
+const monographInstanceRt = require('../static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/MonographInstance.json')
+const monographWorkRt = require('../static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/MonographWork.json')
+const noteRt = require('../static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/Note.json')
+const parallelTitleRt = require('../static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/ParallelTitle.json')
+const titleRt = require('../static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/Title.json')
+const titleNoteRt = require('../static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/TitleNote.json')
+const transcribedTitleRt = require('../static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/TranscribedTitle.json')
+const varTitleRt = require('../static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/VarTitle.json')
+const workTitleRt = require('../static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/WorkTitle.json')
+const workVariantTitleRt = require('../static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/WorkVariantTitle.json')
+const resourceTemplateId2Json = [
+  {'id': 'resourceTemplate:bf2:Monograph:Instance', 'json': monographInstanceRt},
+  {'id': 'resourceTemplate:bf2:Monograph:Work', 'json': monographWorkRt},
+  {'id': 'resourceTemplate:bf2:Note', 'json': noteRt},
+  {'id': 'resourceTemplate:bf2:ParallelTitle', 'json': parallelTitleRt},
+  {'id': 'resourceTemplate:bf2:Title', 'json': titleRt},
+  {'id': 'resourceTemplate:bf2:Title:Note', 'json': titleNoteRt},
+  {'id': 'resourceTemplate:bflc:TranscribedTitle', 'json': transcribedTitleRt},
+  {'id': 'resourceTemplate:bf2:Title:VarTitle', 'json': varTitleRt},
+  {'id': 'resourceTemplate:bf2:WorkTitle', 'json': workTitleRt},
+  {'id': 'resourceTemplate:bf2:WorkVariantTitle', 'json': workVariantTitleRt}
+]
+
+const resourceTemplateIds = []
+loadResourceTemplates()
+module.exports.resourceTemplateIds = resourceTemplateIds
+module.exports.resourceTemplateId2Json = resourceTemplateId2Json
+
+function loadResourceTemplates() {
+  if (resourceTemplateIds.length == 0) {
+    resourceTemplateId2Json.forEach(function (el) {
+      resourceTemplateIds.push(el.id)
+    })
+  }
+}

--- a/static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/MonographInstance.json
+++ b/static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/MonographInstance.json
@@ -1,0 +1,166 @@
+{
+  "id": "resourceTemplate:bf2:Monograph:Instance",
+  "resourceLabel": "BIBFRAME Instance",
+  "resourceURI": "http://id.loc.gov/ontologies/bibframe/Instance",
+  "remark": "Can you believe we're doing this!?",
+  "propertyTemplates": [
+    {
+      "propertyLabel": "Instance of",
+      "propertyURI": "http://id.loc.gov/ontologies/bibframe/instanceOf",
+      "resourceTemplates": [],
+      "type": "resource",
+      "valueConstraint": {
+        "valueTemplateRefs": [
+          "resourceTemplate:bf2:Monograph:Work"
+        ],
+        "useValuesFrom": [],
+        "valueDataType": {},
+        "defaults": []
+      },
+      "mandatory": "false",
+      "repeatable": "true"
+    },
+    {
+      "propertyLabel": "Title Information",
+      "propertyURI": "http://id.loc.gov/ontologies/bibframe/title",
+      "resourceTemplates": [],
+      "valueConstraint": {
+        "valueTemplateRefs": [
+          "resourceTemplate:bf2:Title",
+          "resourceTemplate:bf2:Title:VarTitle",
+          "resourceTemplate:bf2:ParallelTitle",
+          "resourceTemplate:bflc:TranscribedTitle"
+        ],
+        "useValuesFrom": [],
+        "valueDataType": {
+          "remark": ""
+        },
+        "defaults": []
+      },
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "resource",
+      "remark": ""
+    },
+    {
+      "propertyLabel": "Statement of Responsibility Relating to Title Proper (RDA 2.4.2)",
+      "remark": "http://access.rdatoolkit.org/2.4.2.html",
+      "propertyURI": "http://id.loc.gov/ontologies/bibframe/responsibilityStatement",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "resourceTemplates": [],
+      "valueConstraint": {
+        "valueTemplateRefs": [],
+        "useValuesFrom": [],
+        "valueDataType": {},
+        "defaults": []
+      }
+    },
+    {
+      "propertyURI": "http://id.loc.gov/ontologies/bibframe/issuance",
+      "propertyLabel": "Mode of Issuance (RDA 2.13)",
+      "remark": "http://access.rdatoolkit.org/2.13.html",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "resource",
+      "resourceTemplates": [],
+      "valueConstraint": {
+        "valueTemplateRefs": [],
+        "useValuesFrom": [
+          "http://id.loc.gov/vocabulary/issuance"
+        ],
+        "valueDataType": {
+          "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Issuance"
+        },
+        "editable": "false",
+        "repeatable": "true",
+        "defaults": [
+          {
+            "defaultURI": "http://id.loc.gov/vocabulary/issuance/mono",
+            "defaultLiteral": "single unit"
+          }
+        ]
+      }
+    },
+    {
+      "propertyLabel": "Notes about the Instance",
+      "remark": "http://access.rdatoolkit.org/2.17.html",
+      "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "resource",
+      "resourceTemplates": [],
+      "valueConstraint": {
+        "valueTemplateRefs": [
+          "resourceTemplate:bf2:Note"
+        ],
+        "useValuesFrom": [],
+        "valueDataType": {},
+        "defaults": []
+      }
+    },
+    {
+      "propertyLabel": "Carrier Type (RDA 3.3)",
+      "propertyURI": "http://id.loc.gov/ontologies/bibframe/carrier",
+      "repeatable": "true",
+      "resourceTemplates": [],
+      "type": "resource",
+      "valueConstraint": {
+        "valueTemplateRefs": [],
+        "useValuesFrom": [
+          "http://id.loc.gov/vocabulary/carriers"
+        ],
+        "valueDataType": {
+          "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Carrier"
+        },
+        "repeatable": "true",
+        "editable": "false",
+        "defaults": [
+          {
+            "defaultURI": "http://id.loc.gov/vocabulary/carriers/nc",
+            "defaultLiteral": "volume"
+          }
+        ]
+      },
+      "mandatory": "false",
+      "remark": "http://access.rdatoolkit.org/3.3.html"
+    },
+    {
+      "propertyLabel": "WITH ALL VALUE CONSTRAINTS",
+      "propertyURI": "http://id.loc.gov/ontologies/fake",
+      "repeatable": "true",
+      "resourceTemplates": [],
+      "type": "resource",
+      "valueConstraint": {
+        "defaults": [
+          {
+            "defaultLiteral": "DEFAULT",
+            "defaultURI": "http://default"
+          }
+        ],
+        "editable": "true",
+        "languageLabel": "LANGUAGE LABEL",
+        "languageURI": "http://id.loc.gov/vocabulary/languages/eng",
+        "remark": "REMARK",
+        "repeatable": "false",
+        "useValuesFrom": [
+          "http://VALUES"
+        ],
+        "validatePattern": "PATTERN",
+        "valueDataType": {
+          "dataTypeLabel": "Classification item number",
+          "dataTypeLabelHint": "HINT",
+          "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/itemPortion",
+          "remark": "REMARK"
+        },
+        "valueLanguage": "VALUE LANGUAGE",
+        "valueTemplateRefs": [
+          "profile:bf2:Identifiers:Barcode"
+        ]
+      },
+      "mandatory": "false",
+      "remark": "http://access.rdatoolkit.org/3.3.html"
+    }
+  ]
+}

--- a/static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/MonographWork.json
+++ b/static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/MonographWork.json
@@ -1,0 +1,151 @@
+{
+  "id": "resourceTemplate:bf2:Monograph:Work",
+  "resourceURI": "http://id.loc.gov/ontologies/bibframe/Work",
+  "resourceLabel": "BIBFRAME Work",
+  "propertyTemplates": [
+    {
+      "propertyURI": "http://id.loc.gov/ontologies/bibframe/title",
+      "propertyLabel": "Title Information",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "resource",
+      "resourceTemplates": [],
+      "valueConstraint": {
+        "valueTemplateRefs": [
+          "resourceTemplate:bf2:WorkTitle",
+          "resourceTemplate:bf2:WorkVariantTitle",
+          "resourceTemplate:bflc:TranscribedTitle"
+        ],
+        "useValuesFrom": [],
+        "valueDataType": {},
+        "defaults": []
+      }
+    },
+    {
+      "propertyURI": "http://id.loc.gov/ontologies/bibframe/temporalCoverage",
+      "propertyLabel": "(Time) Coverage of the Content (RDA 7.3)",
+      "remark": "http://access.rdatoolkit.org/7.3.html",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "resourceTemplates": [],
+      "valueConstraint": {
+        "valueTemplateRefs": [],
+        "useValuesFrom": [],
+        "valueDataType": {},
+        "defaults": []
+      }
+    },
+    {
+      "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+      "propertyLabel": "Notes about the Work",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "resource",
+      "resourceTemplates": [],
+      "valueConstraint": {
+        "valueTemplateRefs": [
+          "resourceTemplate:bf2:Note"
+        ],
+        "useValuesFrom": [],
+        "valueDataType": {},
+        "defaults": []
+      }
+    },
+    {
+      "propertyURI": "http://id.loc.gov/ontologies/bibframe/content",
+      "propertyLabel": "Content Type (RDA 6.9)",
+      "remark": "http://access.rdatoolkit.org/6.9.html",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "resource",
+      "resourceTemplates": [],
+      "valueConstraint": {
+        "valueTemplateRefs": [],
+        "useValuesFrom": [
+          "http://id.loc.gov/vocabulary/contentTypes"
+        ],
+        "valueDataType": {
+          "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Content"
+        },
+        "editable": "false",
+        "repeatable": "true",
+        "defaults": [
+          {
+            "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/txt",
+            "defaultLiteral": "text"
+          }
+        ]
+      }
+    },
+    {
+      "propertyURI": "http://id.loc.gov/ontologies/bibframe/illustrativeContent",
+      "propertyLabel": "Illustrative Content (RDA 7.15)",
+      "remark": "http://access.rdatoolkit.org/7.15.html",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "resource",
+      "resourceTemplates": [],
+      "valueConstraint": {
+        "valueTemplateRefs": [],
+        "useValuesFrom": [
+          "http://id.loc.gov/vocabulary/millus"
+        ],
+        "valueDataType": {
+          "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Illustration"
+        },
+        "repeatable": "true",
+        "editable": "false",
+        "defaults": []
+      }
+    },
+    {
+      "propertyURI": "http://id.loc.gov/ontologies/bibframe/colorContent",
+      "propertyLabel": "Color Content (RDA 7.17)",
+      "remark": "http://access.rdatoolkit.org/7.17.html",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "resource",
+      "resourceTemplates": [],
+      "valueConstraint": {
+        "valueTemplateRefs": [
+          "resourceTemplate:bf2:Note"
+        ],
+        "useValuesFrom": [],
+        "valueDataType": {},
+        "defaults": []
+      }
+    },
+    {
+      "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasInstance",
+      "propertyLabel": "Has BIBFRAME Instance",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "resource",
+      "resourceTemplates": [],
+      "valueConstraint": {
+        "valueTemplateRefs": [
+          "resourceTemplate:bf2:Monograph:Instance"
+        ],
+        "useValuesFrom": [],
+        "valueDataType": {},
+        "defaults": []
+      }
+    },
+    {
+      "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+      "propertyLabel": "Authorized Access Point Representing the Work (RDA 6.27.1)",
+      "remark": "http://access.rdatoolkit.org/6.27.1.html",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "resourceTemplates": [],
+      "valueConstraint": {
+        "valueTemplateRefs": [],
+        "useValuesFrom": [],
+        "valueDataType": {},
+        "defaults": []
+      }
+    }
+  ]
+}

--- a/static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/Note.json
+++ b/static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/Note.json
@@ -1,0 +1,23 @@
+{
+  "id": "resourceTemplate:bf2:Note",
+  "resourceURI": "http://id.loc.gov/ontologies/bibframe/Note",
+  "resourceLabel": "Note",
+  "propertyTemplates": [
+    {
+      "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+      "propertyLabel": "Note",
+      "mandatory": "false",
+      "repeatable": "false",
+      "type": "literal",
+      "resourceTemplates": [],
+      "valueConstraint": {
+        "valueTemplateRefs": [],
+        "useValuesFrom": [],
+        "valueDataType": {},
+        "editable": "true",
+        "repeatable": "false",
+        "defaults": []
+      }
+    }
+  ]
+}

--- a/static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/ParallelTitle.json
+++ b/static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/ParallelTitle.json
@@ -1,0 +1,54 @@
+{
+  "id": "resourceTemplate:bf2:ParallelTitle",
+  "resourceURI": "http://id.loc.gov/ontologies/bibframe/ParallelTitle",
+  "resourceLabel": "Parallel Title",
+  "propertyTemplates": [
+    {
+      "propertyLabel": "Parallel Title Proper (RDA 2.3.3)",
+      "propertyURI": "http://id.loc.gov/ontologies/bibframe/mainTitle",
+      "remark": "http://access.rdatoolkit.org/rdachp2_rda2-3695.html",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "resourceTemplates": [],
+      "valueConstraint": {
+        "valueTemplateRefs": [],
+        "useValuesFrom": [],
+        "valueDataType": {},
+        "defaults": []
+      }
+    },
+    {
+      "propertyURI": "http://id.loc.gov/ontologies/bibframe/subtitle",
+      "propertyLabel": "Parallel Other Title Information (RDA 2.3.5)",
+      "remark": "http://access.rdatoolkit.org/rdachp2_rda2-3939.html",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "resourceTemplates": [],
+      "valueConstraint": {
+        "valueTemplateRefs": [],
+        "useValuesFrom": [],
+        "valueDataType": {},
+        "defaults": []
+      }
+    },
+    {
+      "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+      "propertyLabel": "Note on Parallel Title",
+      "remark": "http://access.rdatoolkit.org/2.17.2.html",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "resource",
+      "resourceTemplates": [],
+      "valueConstraint": {
+        "valueTemplateRefs": [
+          "resourceTemplate:bf2:Title:Note"
+        ],
+        "useValuesFrom": [],
+        "valueDataType": {},
+        "defaults": []
+      }
+    }
+  ]
+}

--- a/static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/Title.json
+++ b/static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/Title.json
@@ -1,0 +1,83 @@
+{
+  "id": "resourceTemplate:bf2:Title",
+  "resourceLabel": "Instance Title",
+  "remark": "Title information relating to a resource: work title, preferred title, instance title, transcribed title, translated title, variant form of title, etc.",
+  "resourceURI": "http://id.loc.gov/ontologies/bibframe/Title",
+  "propertyTemplates": [
+    {
+      "propertyURI": "http://id.loc.gov/ontologies/bibframe/mainTitle",
+      "propertyLabel": "Title Proper (RDA 2.3.2) (BIBFRAME: Main title)",
+      "remark": "http://access.rdatoolkit.org/rdachp2_rda2-3376.html",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "resourceTemplates": [],
+      "valueConstraint": {
+        "valueTemplateRefs": [],
+        "useValuesFrom": [],
+        "valueDataType": {},
+        "defaults": []
+      }
+    },
+    {
+      "propertyURI": "http://id.loc.gov/ontologies/bibframe/subtitle",
+      "propertyLabel": "Other Title Information (RDA 2.3.4) (BIBFRAME: Subtitle)",
+      "remark": "http://access.rdatoolkit.org/rdachp2_rda2-3782.html",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "resourceTemplates": [],
+      "valueConstraint": {
+        "valueTemplateRefs": [],
+        "useValuesFrom": [],
+        "valueDataType": {},
+        "defaults": []
+      }
+    },
+    {
+      "propertyLabel": "Part number",
+      "propertyURI": "http://id.loc.gov/ontologies/bibframe/partNumber",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "resourceTemplates": [],
+      "valueConstraint": {
+        "valueTemplateRefs": [],
+        "useValuesFrom": [],
+        "valueDataType": {},
+        "defaults": []
+      }
+    },
+    {
+      "propertyLabel": "Part name",
+      "propertyURI": "http://id.loc.gov/ontologies/bibframe/partName",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "resourceTemplates": [],
+      "valueConstraint": {
+        "valueTemplateRefs": [],
+        "useValuesFrom": [],
+        "valueDataType": {},
+        "defaults": []
+      }
+    },
+    {
+      "propertyLabel": "Note on title",
+      "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+      "remark": "http://access.rdatoolkit.org/2.17.2.html",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "resource",
+      "resourceTemplates": [],
+      "valueConstraint": {
+        "valueTemplateRefs": [
+          "resourceTemplate:bf2:Title:Note"
+        ],
+        "useValuesFrom": [],
+        "valueDataType": {},
+        "defaults": []
+      }
+    }
+  ]
+}

--- a/static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/TitleNote.json
+++ b/static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/TitleNote.json
@@ -1,0 +1,21 @@
+{
+  "id": "resourceTemplate:bf2:Title:Note",
+  "resourceURI": "http://id.loc.gov/ontologies/bibframe/Note",
+  "resourceLabel": "Title note",
+  "propertyTemplates": [
+    {
+      "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+      "propertyLabel": "Note Text",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "resourceTemplates": [],
+      "valueConstraint": {
+        "valueTemplateRefs": [],
+        "useValuesFrom": [],
+        "valueDataType": {},
+        "defaults": []
+      }
+    }
+  ]
+}

--- a/static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/TranscribedTitle.json
+++ b/static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/TranscribedTitle.json
@@ -1,0 +1,38 @@
+{
+  "id": "resourceTemplate:bflc:TranscribedTitle",
+  "resourceURI": "http://id.loc.gov/ontologies/bflc/TransliteratedTitle",
+  "resourceLabel": "Transliterated Title",
+  "propertyTemplates": [
+    {
+      "propertyURI": "http://id.loc.gov/ontologies/bibframe/mainTitle",
+      "propertyLabel": "Title",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "resourceTemplates": [],
+      "valueConstraint": {
+        "valueTemplateRefs": [],
+        "useValuesFrom": [],
+        "valueDataType": {},
+        "defaults": []
+      }
+    },
+    {
+      "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+      "propertyLabel": "Note on title",
+      "remark": "http://access.rdatoolkit.org/2.17.2.html",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "resource",
+      "resourceTemplates": [],
+      "valueConstraint": {
+        "valueTemplateRefs": [
+          "resourceTemplate:bf2:Title:Note"
+        ],
+        "useValuesFrom": [],
+        "valueDataType": {},
+        "defaults": []
+      }
+    }
+  ]
+}

--- a/static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/VarTitle.json
+++ b/static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/VarTitle.json
@@ -1,0 +1,36 @@
+{
+  "id": "resourceTemplate:bf2:Title:VarTitle",
+  "resourceURI": "http://id.loc.gov/ontologies/bibframe/VariantTitle",
+  "resourceLabel": "Variant Title",
+  "propertyTemplates": [
+    {
+      "propertyURI": "http://id.loc.gov/ontologies/bibframe/mainTitle",
+      "propertyLabel": "Variant Title (RDA 2.3.6)",
+      "remark": "http://access.rdatoolkit.org/rdachp2_rda2-4013.html",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "resourceTemplates": [],
+      "valueConstraint": {
+        "valueTemplateRefs": [],
+        "useValuesFrom": [],
+        "valueDataType": {},
+        "defaults": []
+      }
+    },
+    {
+      "propertyURI": "http://id.loc.gov/ontologies/bibframe/variantType",
+      "propertyLabel": "Variant title type",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "resourceTemplates": [],
+      "valueConstraint": {
+        "valueTemplateRefs": [],
+        "useValuesFrom": [],
+        "valueDataType": {},
+        "defaults": []
+      }
+    }
+  ]
+}

--- a/static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/WorkTitle.json
+++ b/static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/WorkTitle.json
@@ -1,0 +1,66 @@
+{
+  "id": "resourceTemplate:bf2:WorkTitle",
+  "resourceLabel": "Work Title",
+  "resourceURI": "http://id.loc.gov/ontologies/bibframe/Title",
+  "propertyTemplates": [
+    {
+      "propertyURI": "http://id.loc.gov/ontologies/bibframe/mainTitle",
+      "propertyLabel": "Preferred Title for Work (RDA 6.2.2, RDA 6.14.2) (BIBFRAME: Main title)",
+      "remark": "http://access.rdatoolkit.org/rdachp6_rda6-2036.html",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "resourceTemplates": [],
+      "valueConstraint": {
+        "valueTemplateRefs": [],
+        "useValuesFrom": [],
+        "valueDataType": {},
+        "defaults": []
+      }
+    },
+    {
+      "propertyURI": "http://id.loc.gov/ontologies/bibframe/partName",
+      "propertyLabel": "Part name",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "resourceTemplates": [],
+      "valueConstraint": {
+        "valueTemplateRefs": [],
+        "useValuesFrom": [],
+        "valueDataType": {},
+        "defaults": []
+      }
+    },
+    {
+      "propertyURI": "http://id.loc.gov/ontologies/bibframe/partNumber",
+      "propertyLabel": "Part number",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "resourceTemplates": [],
+      "valueConstraint": {
+        "valueTemplateRefs": [],
+        "useValuesFrom": [],
+        "valueDataType": {},
+        "defaults": []
+      }
+    },
+    {
+      "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+      "propertyLabel": "Note on title",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "resource",
+      "resourceTemplates": [],
+      "valueConstraint": {
+        "valueTemplateRefs": [
+          "resourceTemplate:bf2:Title:Note"
+        ],
+        "useValuesFrom": [],
+        "valueDataType": {},
+        "defaults": []
+      }
+    }
+  ]
+}

--- a/static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/WorkVariantTitle.json
+++ b/static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/WorkVariantTitle.json
@@ -1,0 +1,38 @@
+{
+  "id": "resourceTemplate:bf2:WorkVariantTitle",
+  "resourceLabel": "Work Title Variation",
+  "resourceURI": "http://id.loc.gov/ontologies/bibframe/VariantTitle",
+  "propertyTemplates": [
+    {
+      "propertyLabel": "Variant Title for Work (RDA 6.2.3, 6.14.3 (Music))",
+      "remark": "http://access.rdatoolkit.org/rdachp6_rda6-2658.html",
+      "propertyURI": "http://id.loc.gov/ontologies/bibframe/mainTitle",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "resourceTemplates": [],
+      "valueConstraint": {
+        "valueTemplateRefs": [],
+        "useValuesFrom": [],
+        "valueDataType": {},
+        "defaults": []
+      }
+    },
+    {
+      "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+      "propertyLabel": "Note on title",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "resource",
+      "resourceTemplates": [],
+      "valueConstraint": {
+        "valueTemplateRefs": [
+          "resourceTemplate:bf2:Title:Note"
+        ],
+        "useValuesFrom": [],
+        "valueDataType": {},
+        "defaults": []
+      }
+    }
+  ]
+}


### PR DESCRIPTION
spoof calls to sinopiaServer to retrieve a resource template with a data structure that gets appropriate JSON from files in our `static` directory.  

Note that the approach taken here works for our tests, works for running the webpack server, and works when we run the express server as well.

Eventually, we will want to make an HTTP request out to the sinopia server, presumably using "fetch" or "axios" and we will have to figure out how to deal with the async nature of that call while rendering components.

Closes #125