### PR TITLE
Unmounts renderRoutes component in App.test.js

### DIFF
--- a/__tests__/components/App.test.js
+++ b/__tests__/components/App.test.js
@@ -42,4 +42,9 @@ describe("#routes", () => {
     const component = renderRoutes("/blah")
     expect(component.contains(<h1>404</h1>)).toEqual(true)
   })
+
+  afterAll(() => {
+    renderRoutes.unmount()
+  })
+
 })


### PR DESCRIPTION
Unmount `renderRoutes` component in the App.test.js. 

Fixes #131