### PR TITLE
make eslint more useful

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,11 +2,10 @@ build_support/*
 builds/*
 coverage/*
 docs/*
-static/css/*
-static/images/*
-static/js/jsonld-vis.js
-static/js/n3-browser.min.js
-static/js/r*
-static/js/short-uuid.min.js
-static/js/twitter-typeahead-0.10.2.js
+src/bfe.js
+src/bfelogging.js
+src/bfelookups.js
+src/bfestore.js
+src/lib/aceconfig.js
+static/*
 static-analysis/*

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,7 +29,7 @@ module.exports = {
     "browser": true,
     "node": true
   },
-  plugins: ["react", "import", "jsx-a11y"],
+  plugins: ["import", "jsx-a11y"],
 
   overrides: [
     {
@@ -40,23 +40,7 @@ module.exports = {
       plugins: ["jest", "security"],
       rules: {
         "no-console": "off",
-        "no-redeclare": "warn", // FIXME: want this to be error, but don't want to address in 5000 line bfe.js
-        "no-undef": "warn",
-        "no-unused-vars": "warn",
-        "no-useless-escape": "warn",
         "node/no-unsupported-features/es-syntax": "warn" // FIXME: want this to be error
-      },
-      globals: {
-        // FIXME: this is a cheap way to reduce warnings, but perhaps code practices should improve for our own stuff?
-        "$": true,
-        "bfe": true,
-        "bfeditor": true,
-        "bfelog": true,
-        "config": true,
-        "document": true,
-        "jQuery": true,
-        "page": true,
-        "window": true
       }
     }
   ]

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,7 +9,7 @@ module.exports = {
     "plugin:security/recommended"
   ],
   "parserOptions": {
-    "ecmaVersion": 2018,
+    "ecmaVersion": 2019,
     "sourceType": "module",
     "ecmaFeatures": {
         "jsx": true

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -43,7 +43,7 @@ module.exports = {
     "jsx-a11y/anchor-is-valid": "warn",
     "jsx-a11y/label-has-for": "warn",
     "no-console": "warn",
-    "no-extra-semi": "warn",
+    "no-extra-semi": "off", // because it isn't that important
     "no-unused-vars": "warn",
     "react/jsx-no-target-blank": "warn",
     "react/prop-types": "warn"

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -42,7 +42,6 @@ module.exports = {
   rules: {
     "jsx-a11y/anchor-is-valid": "warn",
     "jsx-a11y/label-has-for": "warn",
-    "jsx-a11y/no-redundant-roles": "warn",
     "no-console": "warn",
     "no-extra-semi": "warn",
     "no-unused-vars": "warn",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -42,7 +42,6 @@ module.exports = {
   rules: {
     "jsx-a11y/anchor-is-valid": "warn",
     "jsx-a11y/label-has-for": "warn",
-    "jsx-a11y/alt-text": "warn",
     "jsx-a11y/no-redundant-roles": "warn",
     "no-console": "warn",
     "no-extra-semi": "warn",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,6 +8,7 @@ module.exports = {
     "plugin:jsx-a11y/recommended",
     "plugin:security/recommended"
   ],
+  "parser": "babel-eslint",
   "parserOptions": {
     "ecmaVersion": 2019,
     "sourceType": "module",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,10 +1,18 @@
 // Copyright 2018 Stanford University see Apache2.txt for license
 module.exports = {
+  plugins: [
+    "import",
+    "jest",
+    "jsx-a11y",
+    "react",
+    "security"
+  ],
   extends: [
     "eslint:recommended",
     "plugin:node/recommended",
     "plugin:react/recommended",
     "plugin:import/errors",
+    "plugin:import/warnings",
     "plugin:jsx-a11y/recommended",
     "plugin:security/recommended"
   ],
@@ -27,23 +35,28 @@ module.exports = {
     }
   },
   env: {
-    "es6": true,
     "browser": true,
+    "jest": true,
     "node": true
   },
-  plugins: ["import", "jsx-a11y", "security"],
-
+  rules: {
+    "jsx-a11y/anchor-is-valid": "warn",
+    "jsx-a11y/label-has-for": "warn",
+    "jsx-a11y/alt-text": "warn",
+    "jsx-a11y/no-redundant-roles": "warn",
+    "no-console": "warn",
+    "no-extra-semi": "warn",
+    "no-unused-vars": "warn",
+    "react/jsx-no-target-blank": "warn",
+    "react/no-unescaped-entities": "warn",
+    "react/prop-types": "warn"
+  },
   overrides: [
     {
-      files: "**/*.js",
-      env: {
-        jest: true
-      },
-      plugins: ["jest", "security"],
-      rules: {
-        "no-console": "off",
-        "node/no-unsupported-features/es-syntax": "warn" // FIXME: want this to be error
+      "files": ["**/*.jsx", "src/index.js"],
+      "rules": {
+        "node/no-unsupported-features/es-syntax": "off" // FIXME: getting these "Import and export declarations are not supported yet"
       }
     }
   ]
-};
+}

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,6 +19,9 @@ module.exports = {
       "node": {
         "extensions": ['.js','.jsx']
       }
+    },
+    "react": {
+      "version": "16.6"
     }
   },
   env: {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,7 +5,8 @@ module.exports = {
     "plugin:node/recommended",
     "plugin:react/recommended",
     "plugin:import/errors",
-    "plugin:jsx-a11y/recommended"
+    "plugin:jsx-a11y/recommended",
+    "plugin:security/recommended"
   ],
   "parserOptions": {
     "ecmaVersion": 2018,
@@ -29,7 +30,7 @@ module.exports = {
     "browser": true,
     "node": true
   },
-  plugins: ["import", "jsx-a11y"],
+  plugins: ["import", "jsx-a11y", "security"],
 
   overrides: [
     {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -40,19 +40,21 @@ module.exports = {
     "node": true
   },
   rules: {
-    "jsx-a11y/anchor-is-valid": "warn",
-    "jsx-a11y/label-has-for": "warn",
+    "jsx-a11y/anchor-is-valid": "warn", // see #172
+    "jsx-a11y/label-has-for": "warn", // see #173
     "no-console": "warn",
     "no-extra-semi": "off", // because it isn't that important
-    "no-unused-vars": "warn",
-    "react/jsx-no-target-blank": "warn",
-    "react/prop-types": "warn"
+    "react/jsx-no-target-blank": "warn", // see #174
+    "react/prop-types": "warn" // see #175
   },
   overrides: [
     {
       "files": ["**/*.jsx", "src/index.js"],
       "rules": {
-        "node/no-unsupported-features/es-syntax": "off" // FIXME: getting these "Import and export declarations are not supported yet"
+        // See https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/no-unsupported-features/es-syntax.md
+        //   rule supposedly matches ECMA version with node
+        //   we get: "Import and export declarations are not supported yet"
+        "node/no-unsupported-features/es-syntax": "off"
       }
     }
   ]

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -46,7 +46,6 @@ module.exports = {
     "no-extra-semi": "warn",
     "no-unused-vars": "warn",
     "react/jsx-no-target-blank": "warn",
-    "react/no-unescaped-entities": "warn",
     "react/prop-types": "warn"
   },
   overrides: [

--- a/__tests__/components/Header.test.js
+++ b/__tests__/components/Header.test.js
@@ -11,6 +11,10 @@ describe('<Header />', () => {
     expect(wrapper.find("img").prop('src')).toEqual(SinopiaLogo)
   })
 
+  it('has alt text for the image', () => {
+    expect(wrapper.find("img").prop('alt')).toEqual('Sinopia logo')
+  })
+
   it ('renders a ".navbar"', () => {
     expect(wrapper.find('.navbar').length).toBe(1)
   })

--- a/__tests__/components/editor/ResourceTemplate.test.js
+++ b/__tests__/components/editor/ResourceTemplate.test.js
@@ -38,6 +38,10 @@ describe('<ResourceTemplate />', () => {
     expect(wrapper.find('form#resourceTemplate').length).toEqual(1)
   })
 
+  it('<form> does not contain redundant form attribute', () => {
+    expect(wrapper.find('form[role="form"]').length).toEqual(0)
+  })
+
   describe('<PropertiesWrapper />', () => {
     it('renders the PropertiesWrapper text nodes', () => {
       wrapper.find('PropertiesWrapper').dive().find('div.PropertiesWrapper > p').forEach((node) => {

--- a/__tests__/components/editor/ResourceTemplate.test.js
+++ b/__tests__/components/editor/ResourceTemplate.test.js
@@ -33,6 +33,11 @@ describe('<ResourceTemplate />', () => {
     expect(wrapper.find('div.ResourceTemplate').length).toEqual(1)
   })
 
+  // TODO: if we have more than one resourceTemplate form, they need to have unique ids (see #130)
+  it('contains <form> with id resourceTemplate', () => {
+    expect(wrapper.find('form#resourceTemplate').length).toEqual(1)
+  })
+
   describe('<PropertiesWrapper />', () => {
     it('renders the PropertiesWrapper text nodes', () => {
       wrapper.find('PropertiesWrapper').dive().find('div.PropertiesWrapper > p').forEach((node) => {
@@ -49,27 +54,4 @@ describe('<ResourceTemplate />', () => {
         .toHaveLength(3)
     })
   })
-
-  // TODO: if we have more than one resourceTemplate form, they need to have unique ids (see #130)
-  it('contains <form> with id resourceTemplate', () => {
-    expect(wrapper.find('form#resourceTemplate').length).toEqual(1)
-  })
-
 })
-
-
-// TODO: see #132 - testing PropertiesWrapper
-// describe('<PropertiesWrapper />', () => {
-//   const wrapper = shallow(<PropertiesWrapper {...rtProps} />)
-//
-//   it('contains div with class PropertiesWrapper', () => {
-//     expect(wrapper.find('div.PropertiesWrapper').length).toBe(1)
-//   })
-//
-//   // it('renders <PropertyTemplate /> component for each property', () => {
-//   //   expect(wrapper.find(PropertyTemplate)).toHaveLength(3)
-//   //   expect(wrapper.find('.propertyTemplate')).toHaveLength(3)
-//   //   // expect(wrapper.find(PropertyTemplate).length).toBe(1)
-//   // })
-//
-// })

--- a/package.json
+++ b/package.json
@@ -68,8 +68,7 @@
     "dev-build": "webpack --progress --mode development",
     "dev-build-test": "npm run dev-build && npm run test",
     "dev-start": "webpack-dev-server --config ./webpack.config.js --mode development",
-    "eslint": "eslint --max-warnings 775 --color -c .eslintrc.js ./src",
-    "install-build": "npm install && npm run build",
+    "eslint": "eslint --max-warnings 600 --color -c .eslintrc.js --ext js,jsx ./src",
     "jest-cov": "jest --coverage --colors",
     "jest-ci": "jest --ci --runInBand --coverage --reporters=default --reporters=jest-junit --colors  && cat ./coverage/lcov.info | coveralls",
     "test": "jest --colors"

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "dev-build": "webpack --progress --mode development",
     "dev-build-test": "npm run dev-build && npm run test",
     "dev-start": "webpack-dev-server --config ./webpack.config.js --mode development",
-    "eslint": "eslint --max-warnings 600 --color -c .eslintrc.js --ext js,jsx ./src",
+    "eslint": "eslint --max-warnings 100 --color -c .eslintrc.js --ext js,jsx ./src",
     "jest-cov": "jest --coverage --colors",
     "jest-ci": "jest --ci --runInBand --coverage --reporters=default --reporters=jest-junit --colors  && cat ./coverage/lcov.info | coveralls",
     "test": "jest --colors"

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -10,7 +10,7 @@ class Header extends Component {
       <div className="navbar homepage-navbar">
         <div className="navbar-header">
           <a className="navbar-brand" href="https://google.com">
-            <img src={SinopiaLogo} height="55px" />
+            <img src={SinopiaLogo} height="55px" alt="Sinopia logo" />
           </a>
         </div>
         <ul className= "nav navbar-nav pull-right">

--- a/src/components/editor/PropertyTemplate.jsx
+++ b/src/components/editor/PropertyTemplate.jsx
@@ -10,9 +10,9 @@ class PropertyTemplate extends Component {
       padding: '10px'
     }
     if (this.props.propertyTemplates.length == 0) {
-      return <h1>We should have propertyTemplates but we don't.</h1>
+      return <h3 color="red">There are no propertyTemplates - probably an error.</h3>
     } else if (this.props.propertyTemplates[0].resourceTemplates == undefined ) {
-      return <h1>We should have propertyTemplate contents but we don't.</h1>
+      return <h3 color="red">There are no propertyTemplate contents - probably an error.</h3>
     } else {
       return (
         <div className='PropertyTemplate' style={dottedBorder}>

--- a/src/components/editor/ResourceTemplate.jsx
+++ b/src/components/editor/ResourceTemplate.jsx
@@ -28,7 +28,7 @@ class ResourceTemplate extends Component {
           <li>id: <strong>{this.props.resourceTemplates[0].id}</strong></li>
           <li>remark: <strong>{this.props.resourceTemplates[0].remark}</strong></li>
         </ul>
-        <form id="resourceTemplate" className="form-horizontal" role="form" style={dottedBorder}>
+        <form id="resourceTemplate" className="form-horizontal" style={dottedBorder}>
           <h4>BEGINNING OF FORM</h4>
           <PropertiesWrapper propertyTemplates = {[this.props.resourceTemplates[0].propertyTemplates]} />
           <h4>END OF FORM</h4>

--- a/src/components/editor/ResourceTemplate.jsx
+++ b/src/components/editor/ResourceTemplate.jsx
@@ -45,7 +45,7 @@ class PropertiesWrapper extends Component{
       padding: '10px',
     }
     if (this.props.propertyTemplates.length == 0 || this.props.propertyTemplates[0] == {}) {
-      return <h1>We should have propertyTemplates but we don't.</h1>
+      return <h3 color="red">There are no propertyTemplates - probably an error.</h3>
     } else {
       return (
         <div className='PropertiesWrapper' style={dashedBorder}>


### PR DESCRIPTION
I had eslint ignore the BFE code, and then I fixed our eslint configuration to include jsx files and use the plugins that we've npm installed, specifically jsx-a11y (accessibility) and security ... and react, now that jsx files are in play.   Even with the new configuration, our warnings went down to 86 or so, so I dialed that max down for our CI builds.

Next I addressed some simple a11y rule violations, and turned off the rule that cares about semicolons (not worth our time to be 100% conformant).

This PR has many commits, but they are all small.  I recommend reviewing by commit.

Note that THESE eslint rules tell us useful stuff in the warnings.   It caused me to create 4 tickets:  #172, #173, #174, #175 -- each is referenced by a bespoke rule configuration in .eslintrc.js