### PR TITLE
Use FormWrapper instead of PropertiesWrapper

### DIFF
--- a/__tests__/components/editor/FormWrapper.test.js
+++ b/__tests__/components/editor/FormWrapper.test.js
@@ -1,0 +1,40 @@
+// Copyright 2018 Stanford University see Apache2.txt for license
+import React from 'react'
+import { shallow } from 'enzyme'
+import PropertyTemplate from '../../../src/components/editor/PropertyTemplate'
+import FormWrapper from '../../../src/components/editor/FormWrapper'
+
+const rtProps = {
+  "propertyTemplates": [
+    [{
+      "propertyLabel": "Instance of"
+    }],
+    [{
+      "propertyLabel": "Instance of"
+    }],
+    [{
+      "propertyLabel": "Instance of"
+    }]
+  ]
+}
+
+
+describe('<FormWrapper />', () => {
+  const wrapper = shallow(<FormWrapper {...rtProps} />)
+  it('renders the FormWrapper text nodes', () => {
+    wrapper.find('div.FormWrapper > p').forEach((node) => {
+      expect(node.containsAnyMatchingElements([
+        'BEGIN FormWrapper',
+        'END FormWrapper'
+      ]))
+    })
+  })
+  it('renders FormWrapper nested component', () => {
+    expect(wrapper
+      .find('div.FormWrapper > div > PropertyTemplate').length)
+      .toEqual(1)
+  })
+  it('<form> does not contain redundant form attribute', () => {
+    expect(wrapper.find('form[role="form"]').length).toEqual(0)
+  })
+})

--- a/__tests__/components/editor/ResourceTemplate.test.js
+++ b/__tests__/components/editor/ResourceTemplate.test.js
@@ -3,6 +3,7 @@ import React from 'react'
 import { shallow } from 'enzyme'
 import ResourceTemplate from '../../../src/components/editor/ResourceTemplate'
 import PropertyTemplate from '../../../src/components/editor/PropertyTemplate'
+import FormWrapper from '../../../src/components/editor/FormWrapper'
 
 const rtProps = {
   resourceTemplates: [
@@ -34,28 +35,9 @@ describe('<ResourceTemplate />', () => {
   })
 
   // TODO: if we have more than one resourceTemplate form, they need to have unique ids (see #130)
-  it('contains <form> with id resourceTemplate', () => {
-    expect(wrapper.find('form#resourceTemplate').length).toEqual(1)
+  it('contains <div> with id resourceTemplate', () => {
+    expect(wrapper.find('div#resourceTemplate').length).toEqual(1)
   })
 
-  it('<form> does not contain redundant form attribute', () => {
-    expect(wrapper.find('form[role="form"]').length).toEqual(0)
-  })
 
-  describe('<PropertiesWrapper />', () => {
-    it('renders the PropertiesWrapper text nodes', () => {
-      wrapper.find('PropertiesWrapper').dive().find('div.PropertiesWrapper > p').forEach((node) => {
-        expect(node.containsAnyMatchingElements([
-          'BEGIN PropertiesWrapper',
-          'END PropertiesWrapper'
-        ]))
-      })
-    })
-    it('renders PropertiesWrapper nested component', () => {
-      expect(wrapper.find('PropertiesWrapper')
-        .dive()
-        .find('div.PropertiesWrapper > div > PropertyTemplate'))
-        .toHaveLength(3)
-    })
-  })
 })

--- a/src/components/editor/FormWrapper.jsx
+++ b/src/components/editor/FormWrapper.jsx
@@ -1,0 +1,32 @@
+// Copyright 2018 Stanford University see Apache2.txt for license
+import React, { Component }  from 'react'
+import PropertyTemplate from './PropertyTemplate'
+
+class FormWrapper extends Component{
+  render () {
+    console.log(this.props.propertyTemplates[0])
+    let dashedBorder = {
+      border: '1px dashed',
+      padding: '10px',
+    }
+    if (this.props.propertyTemplates.length == 0 || this.props.propertyTemplates[0] == {}) {
+      return <h1>We should have propertyTemplates but we don't.</h1>
+    } else {
+      return (
+        <form className="form-horizontal" style={dashedBorder}>
+          <div className='FormWrapper'>
+            <p>BEGIN FormWrapper</p>
+              <div>
+                {this.props.propertyTemplates[0].map(function(pt, index){
+                  return <PropertyTemplate key={index} propertyTemplates={[pt]}/>
+                })}
+              </div>
+            <p>END FormWrapper</p>
+          </div>
+        </form>
+      )
+    }
+  }
+}
+
+export default FormWrapper;

--- a/src/components/editor/FormWrapper.jsx
+++ b/src/components/editor/FormWrapper.jsx
@@ -4,13 +4,12 @@ import PropertyTemplate from './PropertyTemplate'
 
 class FormWrapper extends Component{
   render () {
-    console.log(this.props.propertyTemplates[0])
     let dashedBorder = {
       border: '1px dashed',
       padding: '10px',
     }
     if (this.props.propertyTemplates.length == 0 || this.props.propertyTemplates[0] == {}) {
-      return <h1>We should have propertyTemplates but we don't.</h1>
+      return <h1>There are no propertyTemplates - probably an error.</h1>
     } else {
       return (
         <form className="form-horizontal" style={dashedBorder}>

--- a/src/components/editor/ResourceTemplate.jsx
+++ b/src/components/editor/ResourceTemplate.jsx
@@ -10,10 +10,6 @@ class ResourceTemplate extends Component {
       border: '1px dashed',
       padding: '10px',
     }
-    let dottedBorder = {
-      border: '1px dotted',
-      padding: '10px'
-    }
     let float = {
       float: 'left',
       width:'75%'

--- a/src/components/editor/ResourceTemplate.jsx
+++ b/src/components/editor/ResourceTemplate.jsx
@@ -1,7 +1,7 @@
 // Copyright 2018 Stanford University see Apache2.txt for license
 
 import React, { Component }  from 'react'
-import PropertyTemplate from './PropertyTemplate'
+import FormWrapper from './FormWrapper'
 
 class ResourceTemplate extends Component {
 
@@ -28,37 +28,13 @@ class ResourceTemplate extends Component {
           <li>id: <strong>{this.props.resourceTemplates[0].id}</strong></li>
           <li>remark: <strong>{this.props.resourceTemplates[0].remark}</strong></li>
         </ul>
-        <form id="resourceTemplate" className="form-horizontal" style={dottedBorder}>
+        <div id="resourceTemplate">
           <h4>BEGINNING OF FORM</h4>
-          <PropertiesWrapper propertyTemplates = {[this.props.resourceTemplates[0].propertyTemplates]} />
+          <FormWrapper propertyTemplates = {[this.props.resourceTemplates[0].propertyTemplates]} />
           <h4>END OF FORM</h4>
-        </form>
+        </div>
       </div>
     )
-  }
-}
-
-class PropertiesWrapper extends Component{
-  render () {
-    let dashedBorder = {
-      border: '1px dashed',
-      padding: '10px',
-    }
-    if (this.props.propertyTemplates.length == 0 || this.props.propertyTemplates[0] == {}) {
-      return <h3 color="red">There are no propertyTemplates - probably an error.</h3>
-    } else {
-      return (
-        <div className='PropertiesWrapper' style={dashedBorder}>
-          <p>BEGIN PropertiesWrapper</p>
-            <div>
-              {this.props.propertyTemplates[0].map(function(pt, index){
-                return <PropertyTemplate key={index} propertyTemplates={[pt]}/>
-              })}
-            </div>
-          <p>END PropertiesWrapper</p>
-        </div>
-      )
-    }
   }
 }
 


### PR DESCRIPTION
hopefully this will make it easier for us to add modals / text fields / buttons when needed. This is essentially the properties wrapper, just broken out into a new component. I named it the `FormWrapper` but happy to take naming suggestions.

closes #178 