### PR TITLE
SinopiaServerSpoof: exports getResourceTemplate so it can be used anywhere

### DIFF
--- a/__tests__/components/editor/ResourceTemplate.test.js
+++ b/__tests__/components/editor/ResourceTemplate.test.js
@@ -38,6 +38,4 @@ describe('<ResourceTemplate />', () => {
   it('contains <div> with id resourceTemplate', () => {
     expect(wrapper.find('div#resourceTemplate').length).toEqual(1)
   })
-
-
 })

--- a/__tests__/sinopiaServerSpoof.test.js
+++ b/__tests__/sinopiaServerSpoof.test.js
@@ -25,4 +25,33 @@ describe('sinopiaServerSpoof', () => {
       expect(sinopiaServerSpoof.resourceTemplateId2Json[9]['json']).toBeDefined()
     })
   })
+
+  describe('getResourceTemplate', () => {
+    it('known id: returns JSON for resource template', () => {
+      expect(sinopiaServerSpoof.getResourceTemplate('resourceTemplate:bf2:Title').id).toEqual('resourceTemplate:bf2:Title')
+      expect(sinopiaServerSpoof.getResourceTemplate('resourceTemplate:bf2:Title').resourceLabel).toEqual('Instance Title')
+    })
+    it('unknown id: returns empty resource template and logs error', () => {
+      let output = ''
+      let storeErr = inputs => (output += inputs)
+      console["error"] = jest.fn(storeErr)
+      expect(sinopiaServerSpoof.getResourceTemplate('not:there')).toEqual({"propertyTemplates": [{}]})
+      expect(output).toEqual('ERROR: un-spoofed resourceTemplate: not:there')
+    })
+    it('null id: returns empty resource template and logs error', () => {
+      let output = ''
+      let storeErr = inputs => (output += inputs)
+      console["error"] = jest.fn(storeErr)
+      expect(sinopiaServerSpoof.getResourceTemplate()).toEqual({"propertyTemplates": [{}]})
+      expect(output).toEqual('ERROR: asked for resourceTemplate with null id')
+      output = ''
+      expect(sinopiaServerSpoof.getResourceTemplate(null)).toEqual({"propertyTemplates": [{}]})
+      expect(output).toEqual('ERROR: asked for resourceTemplate with null id')
+      output = ''
+      expect(sinopiaServerSpoof.getResourceTemplate(undefined)).toEqual({"propertyTemplates": [{}]})
+      expect(output).toEqual('ERROR: asked for resourceTemplate with null id')
+      expect(sinopiaServerSpoof.getResourceTemplate('')).toEqual({"propertyTemplates": [{}]})
+    })
+
+  })
 })

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "dev-build": "webpack --progress --mode development",
     "dev-build-test": "npm run dev-build && npm run test",
     "dev-start": "webpack-dev-server --config ./webpack.config.js --mode development",
-    "eslint": "eslint --max-warnings 65 --color -c .eslintrc.js --ext js,jsx ./src",
+    "eslint": "eslint --max-warnings 60 --color -c .eslintrc.js --ext js,jsx ./src",
     "jest-cov": "jest --coverage --colors",
     "jest-ci": "jest --ci --runInBand --coverage --reporters=default --reporters=jest-junit --colors  && cat ./coverage/lcov.info | coveralls",
     "test": "jest --colors"

--- a/src/components/editor/Editor.jsx
+++ b/src/components/editor/Editor.jsx
@@ -4,40 +4,17 @@ import React, {Component} from 'react'
 import ResourceTemplate from './ResourceTemplate'
 import Header from './Header'
 import StartingPoints from './StartingPoints'
-const sinopiaServerSpoof = require('../../sinopiaServerSpoof.js')
+const { getResourceTemplate } = require('../../sinopiaServerSpoof.js')
 
 class Editor extends Component {
   constructor(props) {
     super(props)
 
-    this.getResourceTemplate = this.getResourceTemplate.bind(this)
-
     // TODO: temporarily hardcoded here.
     //  Selecting a resource template will happen in the left-nav "Starting Points" menu,
-    //   another child of the Editor component;  it will call this.getResourceTemplate
+    //   another child of the Editor component;  it will set state.resourceTemplates
     const defaultResourceTemplate = 'resourceTemplate:bf2:Monograph:Instance'
-    this.state = { resourceTemplates: [this.getResourceTemplate(defaultResourceTemplate)]}
-  }
-
-  // TODO: eventually, this will do an http request to the sinopiaServer via fetch or axios
-  //  Note that the spoofing uses sinopiaServerSpoof, which uses some files in static
-  getResourceTemplate(rtId) {
-    var rTemplate = {propertyTemplates : [{}] }
-    if (rtId != null) {
-      if (sinopiaServerSpoof.resourceTemplateIds.includes(rtId)) {
-        // FIXME:  there's probably a better way to find the value in array than forEach
-        sinopiaServerSpoof.resourceTemplateId2Json.forEach( function(el) {
-          if (rtId == el.id) {
-            rTemplate = el.json
-          }
-        })
-      } else {
-        console.error(`un-spoofed resourceTemplate: ${rtId}`)
-      }
-    } else {
-      console.error(`asked for resourceTemplate with null id`)
-    }
-    return rTemplate
+    this.state = { resourceTemplates: [getResourceTemplate(defaultResourceTemplate)]}
   }
 
   render() {

--- a/src/components/editor/Editor.jsx
+++ b/src/components/editor/Editor.jsx
@@ -4,7 +4,6 @@ import React, {Component} from 'react'
 import ResourceTemplate from './ResourceTemplate'
 import Header from './Header'
 import StartingPoints from './StartingPoints'
-const { getResourceTemplate } = require('../../sinopiaServerSpoof.js')
 
 class Editor extends Component {
   constructor(props) {
@@ -12,9 +11,9 @@ class Editor extends Component {
 
     // TODO: temporarily hardcoded here.
     //  Selecting a resource template will happen in the left-nav "Starting Points" menu,
-    //   another child of the Editor component;  it will set state.resourceTemplates
-    const defaultResourceTemplate = 'resourceTemplate:bf2:Monograph:Instance'
-    this.state = { resourceTemplates: [getResourceTemplate(defaultResourceTemplate)]}
+    //   another child of the Editor component;  it will set state.resourceTemplateId
+    const defaultRtId = 'resourceTemplate:bf2:Monograph:Instance'
+    this.state = { resourceTemplateId: defaultRtId}
   }
 
   render() {
@@ -22,9 +21,9 @@ class Editor extends Component {
       <div id="editor">
         <Header triggerEditorMenu={this.props.triggerHandleOffsetMenu}/>
         <h1> Editor Page </h1>
-        <p>The selected resource template is <strong>{this.state.resourceTemplates[0].id}</strong></p>
+        <p>The selected resource template is <strong>{this.state.resourceTemplateId}</strong></p>
         <StartingPoints/>
-        <ResourceTemplate resourceTemplates = {this.state.resourceTemplates ? this.state.resourceTemplates : []} />
+        <ResourceTemplate resourceTemplateId = {this.state.resourceTemplateId} />
       </div>
     )
   }

--- a/src/components/editor/FormWrapper.jsx
+++ b/src/components/editor/FormWrapper.jsx
@@ -23,13 +23,13 @@ class FormWrapper extends Component{
                     )
                   }
                   else if (pt.type == 'resource'){
-                    return (<p> {pt.propertyLabel}: I am a resource type </p>)
+                    return (<p key={index}><b>{pt.propertyLabel}</b>: <i>resource</i> type</p>)
                   }
                   else if (pt.type == 'lookup'){
-                    return (<p> {pt.propertyLabel}: I am a lookup type! </p>)
+                    return (<p key={index}><b>{pt.propertyLabel}</b>: <i>lookup</i> type</p>)
                   }
                   else if (pt.type == 'target') {
-                    return (<p> {pt.propertyLabel}: I am a target type! </p>)
+                    return (<p key={index}><b>{pt.propertyLabel}</b>: <i>target</i> type</p>)
                   }
                 })}
               </div>

--- a/src/components/editor/ResourceTemplate.jsx
+++ b/src/components/editor/ResourceTemplate.jsx
@@ -2,6 +2,7 @@
 
 import React, { Component }  from 'react'
 import FormWrapper from './FormWrapper'
+const { getResourceTemplate } = require('../../sinopiaServerSpoof.js')
 
 class ResourceTemplate extends Component {
 
@@ -14,19 +15,20 @@ class ResourceTemplate extends Component {
       float: 'left',
       width:'75%'
     }
+    let resourceTemplate = getResourceTemplate(this.props.resourceTemplateId)
     return (
       <div className='ResourceTemplate' style={Object.assign(dashedBorder, float)}>
         <h3>Resource Template Container </h3>
         <p>Resource Template selected:</p>
         <ul>
-          <li>resourceLabel: <strong>{this.props.resourceTemplates[0].resourceLabel}</strong></li>
-          <li>resourceURI: <strong>{this.props.resourceTemplates[0].resourceURI}</strong></li>
-          <li>id: <strong>{this.props.resourceTemplates[0].id}</strong></li>
-          <li>remark: <strong>{this.props.resourceTemplates[0].remark}</strong></li>
+          <li>resourceLabel: <strong>{resourceTemplate.resourceLabel}</strong></li>
+          <li>resourceURI: <strong>{resourceTemplate.resourceURI}</strong></li>
+          <li>id: <strong>{this.props.resourceTemplateId}</strong></li>
+          <li>remark: <strong>{resourceTemplate.remark}</strong></li>
         </ul>
         <div id="resourceTemplate">
           <h4>BEGINNING OF FORM</h4>
-          <FormWrapper propertyTemplates = {[this.props.resourceTemplates[0].propertyTemplates]} />
+          <FormWrapper propertyTemplates = {[resourceTemplate.propertyTemplates]} />
           <h4>END OF FORM</h4>
         </div>
       </div>

--- a/src/sinopiaServerSpoof.js
+++ b/src/sinopiaServerSpoof.js
@@ -1,4 +1,5 @@
 // data structures to support spoofing Sinopia Server calls to get resource templates, etc.
+// TODO: eventually, this will do an http request to the sinopiaServer via fetch or axios
 
 const monographInstanceRt = require('../static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/MonographInstance.json')
 const monographWorkRt = require('../static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/MonographWork.json')
@@ -27,6 +28,7 @@ const resourceTemplateIds = []
 loadResourceTemplates()
 module.exports.resourceTemplateIds = resourceTemplateIds
 module.exports.resourceTemplateId2Json = resourceTemplateId2Json
+module.exports.getResourceTemplate = getResourceTemplate
 
 function loadResourceTemplates() {
   if (resourceTemplateIds.length == 0) {
@@ -34,4 +36,23 @@ function loadResourceTemplates() {
       resourceTemplateIds.push(el.id)
     })
   }
+}
+
+function getResourceTemplate(rtId) {
+  var rTemplate = {propertyTemplates : [{}] }
+  if (rtId != null) {
+    if (resourceTemplateIds.includes(rtId)) {
+      // FIXME:  there's probably a better way to find the value in array than forEach
+      resourceTemplateId2Json.forEach( function(el) {
+        if (rtId == el.id) {
+          rTemplate = el.json
+        }
+      })
+    } else {
+      console.error(`ERROR: un-spoofed resourceTemplate: ${rtId}`)
+    }
+  } else {
+    console.error(`ERROR: asked for resourceTemplate with null id`)
+  }
+  return rTemplate
 }


### PR DESCRIPTION
It turns out that the work to render individual form elements and the work to create modals both can benefit from making `getResourceTemplate` an importable function.  This enables that.  To use:

```javascript
const { getResourceTemplate } = require('../../sinopiaServerSpoof.js')
...
// Use how you wish:
    this.state = { resourceTemplates: [getResourceTemplate('foo')]}
```