### PR TITLE
circleci: don't do static code analysis and don't store coverage or analysis artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,15 +45,6 @@ jobs:
           command: npm run jest-ci
           environment:
             JEST_JUNIT_OUTPUT: "test-results/jest/jest-results.xml"
-      - store_test_results:
-          path: test-results
-      - store_artifacts:
-          path: coverage
-          destination: jest-coverage
-      - run: npm run analysis
-      - store_artifacts:
-          path: static-analysis
-          destination: static-analysis
 
   register_image:
     <<: *defaults


### PR DESCRIPTION
No one looks at these on circleci;  the coverage is available via coveralls (and let's us fail builds on reduced coverage from there) and the static analysis can be generated locally (as can coverage, for that matter).