### PR TITLE
add ci script to package.json so we can run it all locally in one step

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
   "scripts": {
     "analysis": "es6-plato -d static-analysis -n -e .eslintrc.js src src/lib static/js/config.js",
     "build": "webpack -p --progress --mode production",
+    "ci": "npm i && npm run eslint && npm run dev-build && npm run jest-cov",
     "dev-build": "webpack --progress --mode development",
     "dev-build-test": "npm run dev-build && npm run test",
     "dev-start": "webpack-dev-server --config ./webpack.config.js --mode development",


### PR DESCRIPTION
Given that we should now be:
- looking at eslint warnings/errors for every build ("did these changes add any?")
- looking at warnings from running tests (see below)
- considering code coverage when adding code

I thought it would be helpful to make a single npm script to run with all the steps we do in circleci.

`npm run ci`

e.g.: a warning from running "npm test" 
```
      Warning: Each child in an array or iterator should have a unique "key" prop.
      
      Check the render method of `FormWrapper`. See https://fb.me/react-warning-keys for more information.
          in p (created by FormWrapper)
          in FormWrapper (created by ResourceTemplate)
          in div (created by ResourceTemplate)
          in div (created by ResourceTemplate)
          in ResourceTemplate (created by Editor)
          in div (created by Editor)
          in Editor (created by Route)
          in Route (created by App)
          in Switch (created by App)
          in div (created by App)
          in div
          in Unknown (created by App)
          in div
          in OffCanvasBody (created by App)
          in div
          in OffCanvas (created by App)
          in div (created by App)
          in App
          in Router (created by MemoryRouter)
          in MemoryRouter (created by WrapperComponent)
          in WrapperComponent
```