### PR TITLE
Updating from Library of Congress Verso Profiles 

### DIFF
--- a/__tests__/versoSpoof.test.js
+++ b/__tests__/versoSpoof.test.js
@@ -8,7 +8,6 @@ describe('spoofed verso', () => {
       expect(versoSpoof.profiles).toHaveLength(30)
     })
     it('profile has id', () => {
-      console.log(`ID of 0 is : ${versoSpoof.profiles[0]['id']}`)
       expect(versoSpoof.profiles[0]['id']).toBe('bf2:AdminMetadata')
     })
     it('profile has name', () => {

--- a/__tests__/versoSpoof.test.js
+++ b/__tests__/versoSpoof.test.js
@@ -8,7 +8,8 @@ describe('spoofed verso', () => {
       expect(versoSpoof.profiles).toHaveLength(30)
     })
     it('profile has id', () => {
-      expect(versoSpoof.profiles[0]['id']).toBe('profile:bf2:AdminMetadata')
+      console.log(`ID of 0 is : ${versoSpoof.profiles[0]['id']}`)
+      expect(versoSpoof.profiles[0]['id']).toBe('bf2:AdminMetadata')
     })
     it('profile has name', () => {
       expect(versoSpoof.profiles[0]['name']).toBe('Metadata for BIBFRAME Resources')

--- a/static/spoofedFilesFromServer/from_verso/README.md
+++ b/static/spoofedFilesFromServer/from_verso/README.md
@@ -3,7 +3,7 @@ This directory and sub-directories contain JSON Profiles
 from the Library of Congress [Verso][VERSO] middleware source code repository.
 
 ### 2018-11-27
-Updated and removed profiles from master branch in [Verso][VERSO]. Current
+Updated profiles from master branch in [Verso][VERSO]. Current
 listing of profiles from SHA commit ecb3c1e55fe8c0109207d49e44bbc4a087246280.
 
   BIBFRAME 2.0 Admin Metadata.json

--- a/static/spoofedFilesFromServer/from_verso/README.md
+++ b/static/spoofedFilesFromServer/from_verso/README.md
@@ -2,6 +2,41 @@
 This directory and sub-directories contain JSON Profiles
 from the Library of Congress [Verso][VERSO] middleware source code repository.
 
+### 2018-11-27
+Updated and removed profiles from master branch in [Verso][VERSO]. Current
+listing of profiles from SHA commit ecb3c1e55fe8c0109207d49e44bbc4a087246280.
+
+  BIBFRAME 2.0 Admin Metadata.json
+  BIBFRAME 2.0 Agents Contribution.json
+  BIBFRAME 2.0 Agents Primary Contribution.json
+  BIBFRAME 2.0 Agents.json
+  BIBFRAME 2.0 Cartographic.json
+  BIBFRAME 2.0 DDC.json
+  BIBFRAME 2.0 Extra menus.json
+  BIBFRAME 2.0 Form.json
+  BIBFRAME 2.0 Identifiers.json
+  BIBFRAME 2.0 Item.json
+  BIBFRAME 2.0 LCC.json
+  BIBFRAME 2.0 Language.json
+  BIBFRAME 2.0 Monograph.json
+  BIBFRAME 2.0 Moving Image-35mm Feature Film.json
+  BIBFRAME 2.0 Moving Image-BluRay DVD.json
+  BIBFRAME 2.0 Notated Music.json
+  BIBFRAME 2.0 Note.json
+  BIBFRAME 2.0 Place.json
+  BIBFRAME 2.0 Publication, Distribution, Manufacturer Activity.json
+  BIBFRAME 2.0 RWO.json
+  BIBFRAME 2.0 Rare Materials.json
+  BIBFRAME 2.0 Related Works and Expressions.json
+  BIBFRAME 2.0 Serial.json
+  BIBFRAME 2.0 Series Information.json
+  BIBFRAME 2.0 Sound Recording-Analog.json
+  BIBFRAME 2.0 Sound Recording-Audio CD-R.json
+  BIBFRAME 2.0 Sound Recording-Audio CD.json
+  BIBFRAME 2.0 Title Information.json
+  BIBFRAME 2.0 Topic.json
+  PMO Medium of Performance.json
+
 ### 2018-10-30
 Initial import of profiles in [Verso][VERSO]. Here is the listing of
 profiles from the SHA commit 67786e709e2aa207f6605e6a484b69d01acb9a60.

--- a/static/spoofedFilesFromServer/from_verso/data/profiles/BIBFRAME 2.0 Admin Metadata.json
+++ b/static/spoofedFilesFromServer/from_verso/data/profiles/BIBFRAME 2.0 Admin Metadata.json
@@ -214,6 +214,276 @@
                         "propertyURI": "http://id.loc.gov/ontologies/bflc/profile",
                         "propertyLabel": "Profile",
                         "remark": "The profile code for the resource"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:Local"
+                            ],
+                            "useValuesFrom": [],
+                            "defaults": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
+                        "propertyLabel": "Identifier",
+                        "remark": "Local Identifier"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:AdminMetadata:GenerationProcess"
+                            ],
+                            "useValuesFrom": [],
+                            "defaults": [],
+                            "valueDataType": {},
+                            "validatePattern": ""
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/generationProcess",
+                        "propertyLabel": "Generation Process"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:AdminMetadata:Status"
+                            ],
+                            "useValuesFrom": [],
+                            "defaults": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/status",
+                        "propertyLabel": "Status",
+                        "remark": ""
+                    }
+                ],
+                "id": "profile:bf2:AdminMetadata:BFDB",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/AdminMetadata",
+                "resourceLabel": "BF DB Admin Metadata"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "remark": "http://id.loc.gov/ontologies/bflc/catalogerId"
+                            },
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/catalogerId",
+                        "propertyLabel": "Your cataloger ID (Windows ID)"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "false",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeLabelHint": "Date or date and time on which the original metadata first created."
+                            },
+                            "editable": "false",
+                            "defaults": []
+                        },
+                        "propertyLabel": "Creation date",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/creationDate"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "false",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeLabelHint": "Date or date and time on which the metadata was modified."
+                            },
+                            "editable": "false",
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/changeDate",
+                        "propertyLabel": "Change date"
+                    },
+                    {
+                        "mandatory": "true",
+                        "repeatable": "false",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/organizations"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Agent"
+                            },
+                            "editable": "false",
+                            "repeatable": "false",
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/organizations/dlc",
+                                    "defaultLiteral": "DLC"
+                                }
+                            ]
+                        },
+                        "propertyLabel": "Assigning agency",
+                        "remark": "",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/source"
+                    },
+                    {
+                        "mandatory": "true",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/marcauthen"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/DescriptionAuthentication"
+                            },
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/marcauthen/pcc",
+                                    "defaultLiteral": "pcc"
+                                }
+                            ]
+                        },
+                        "propertyLabel": "Description authentication",
+                        "remark": "",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/descriptionAuthentication"
+                    },
+                    {
+                        "mandatory": "true",
+                        "repeatable": "false",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/descriptionConventions"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/DescriptionConventions"
+                            },
+                            "editable": "false",
+                            "repeatable": "false",
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/descriptionConventions/rda",
+                                    "defaultLiteral": "rda"
+                                }
+                            ]
+                        },
+                        "propertyLabel": "Description conventions",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/descriptionConventions",
+                        "remark": ""
+                    },
+                    {
+                        "mandatory": "true",
+                        "repeatable": "false",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/languages"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Language",
+                                "dataTypeLabel": ""
+                            },
+                            "editable": "false",
+                            "repeatable": "false",
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/languages/eng",
+                                    "defaultLiteral": "English"
+                                }
+                            ]
+                        },
+                        "propertyLabel": "Description language",
+                        "remark": "",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/descriptionLanguage"
+                    },
+                    {
+                        "mandatory": "true",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Agent"
+                            },
+                            "editable": "false",
+                            "repeatable": "true",
+                            "defaults": [
+                                {
+                                    "defaultURI": "http://id.loc.gov/vocabulary/organizations/dlc",
+                                    "defaultLiteral": "DLC"
+                                }
+                            ]
+                        },
+                        "propertyLabel": "Description modifier",
+                        "remark": "",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/descriptionModifier"
+                    },
+                    {
+                        "mandatory": "true",
+                        "repeatable": "false",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/vocabulary/menclvl"
+                            ],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bflc/EncodingLevel"
+                            },
+                            "defaults": []
+                        },
+                        "propertyLabel": "Encoding level",
+                        "remark": "",
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/encodingLevel"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "false",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "valueDataType": {},
+                            "editable": "false",
+                            "defaults": []
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/profile",
+                        "propertyLabel": "Profile",
+                        "remark": "The profile code for the resource"
                     }
                 ],
                 "id": "profile:bf2:AdminMetadata",
@@ -415,12 +685,58 @@
                 "id": "profile:bf2:AdminMetadata2:Source",
                 "resourceLabel": "Source/Agent",
                 "resourceURI": "http://id.loc.gov/ontologies/bibframe/Agent"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "defaults": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Label",
+                        "remark": ""
+                    }
+                ],
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/GenerationProcess",
+                "id": "profile:bf2:AdminMetadata:GenerationProcess",
+                "resourceLabel": "Generation Process"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "defaults": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/code",
+                        "propertyLabel": "Code"
+                    }
+                ],
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Status",
+                "resourceLabel": "Status",
+                "remark": "",
+                "id": "profile:bf2:AdminMetadata:Status"
             }
         ],
-        "id": "profile:bf2:AdminMetadata",
+        "id": "bf2:AdminMetadata",
         "title": "BIBFRAME 2.0 Admin Metadata",
         "description": "Metadata for BIBFRAME Resources",
-        "date": "2017-05-20",
-        "contact": "NDMSO"
+        "date": "2018-10-24",
+        "author": "NDMSO",
+        "adherence": "BIBFRAME 2.0",
+        "source": ""
     }
 }

--- a/static/spoofedFilesFromServer/from_verso/data/profiles/BIBFRAME 2.0 Agents Contribution.json
+++ b/static/spoofedFilesFromServer/from_verso/data/profiles/BIBFRAME 2.0 Agents Contribution.json
@@ -87,10 +87,10 @@
                 ]
             }
         ],
-        "id": "profile:bf2:AgentsContribution",
+        "id": "bf2:AgentsContribution",
         "title": "BIBFRAME 2.0 Agents Contribution",
         "date": "2017-05-13",
         "description": "Creators and Contributors",
-        "contact": "NDMSO"
+        "author": "NDMSO"
     }
 }

--- a/static/spoofedFilesFromServer/from_verso/data/profiles/BIBFRAME 2.0 Agents Primary Contribution.json
+++ b/static/spoofedFilesFromServer/from_verso/data/profiles/BIBFRAME 2.0 Agents Primary Contribution.json
@@ -27,7 +27,7 @@
                     },
                     {
                         "mandatory": "false",
-                        "repeatable": "false",
+                        "repeatable": "true",
                         "type": "resource",
                         "resourceTemplates": [],
                         "valueConstraint": {
@@ -36,9 +36,9 @@
                             ],
                             "useValuesFrom": [],
                             "valueDataType": {},
-                            "repeatable": "false",
+                            "repeatable": "true",
                             "defaults": [],
-                            "editable": "true"
+                            "editable": "false"
                         },
                         "propertyURI": "http://id.loc.gov/ontologies/bibframe/role",
                         "propertyLabel": "Relationship Designator (RDA Appendix I)",
@@ -94,7 +94,7 @@
                 "resourceURI": "http://id.loc.gov/ontologies/bflc/PrimaryContribution"
             }
         ],
-        "contact": "NDMSO",
+        "author": "NDMSO",
         "id": "profile:bflc:PrimaryContribution",
         "title": "BIBFRAME 2.0 Agents Primary Contribution",
         "description": "Primary Contribution",

--- a/static/spoofedFilesFromServer/from_verso/data/profiles/BIBFRAME 2.0 Agents.json
+++ b/static/spoofedFilesFromServer/from_verso/data/profiles/BIBFRAME 2.0 Agents.json
@@ -18,7 +18,8 @@
                                 "dataTypeURI": ""
                             },
                             "valueLanguage": "",
-                            "defaults": []
+                            "defaults": [],
+                            "editable": "true"
                         },
                         "propertyURI": "http://www.loc.gov/mads/rdf/v1#PersonalName",
                         "type": "lookup",
@@ -37,7 +38,8 @@
                             "valueDataType": {
                                 "dataTypeURI": "http://www.loc.gov/mads/rdf/v1#PersonalName"
                             },
-                            "defaults": []
+                            "defaults": [],
+                            "editable": "true"
                         },
                         "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
                         "propertyLabel": "Preferred Name for Person (RDA 9.2.2) CORE ELEMENT",
@@ -71,7 +73,7 @@
                             "valueDataType": {},
                             "defaults": []
                         },
-                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#identifiesRWO",
+                        "propertyURI": "http://www.loc.gov/mads/rdf/v1#isIdentifiedByAuthority",
                         "propertyLabel": "Other Identifying Attributes (RDA 9.6-9.11)",
                         "remark": "http://access.rdatoolkit.org/rdachp9_rda9-5161.html"
                     },
@@ -178,9 +180,7 @@
                         "remark": "http://access.rdatoolkit.org/rdachp8_rda8-479.html",
                         "propertyURI": "http://www.loc.gov/mads/rdf/v1#hasSource"
                     }
-                ],
-                "contact": "",
-                "remark": ""
+                ]
             },
             {
                 "resourceURI": "http://www.loc.gov/mads/rdf/v1#FamilyName",
@@ -198,7 +198,8 @@
                                 "dataTypeURI": ""
                             },
                             "repeatable": "true",
-                            "defaults": []
+                            "defaults": [],
+                            "editable": "true"
                         },
                         "propertyURI": "http://www.loc.gov/mads/rdf/v1#FamilyName",
                         "type": "lookup",
@@ -441,7 +442,8 @@
                                 "dataTypeURI": ""
                             },
                             "repeatable": "true",
-                            "defaults": []
+                            "defaults": [],
+                            "editable": "true"
                         },
                         "propertyURI": "http://www.loc.gov/mads/rdf/v1#CorporateName",
                         "type": "lookup",
@@ -700,7 +702,8 @@
                                 "dataTypeURI": ""
                             },
                             "repeatable": "true",
-                            "defaults": []
+                            "defaults": [],
+                            "editable": "true"
                         },
                         "propertyURI": "http://www.loc.gov/mads/rdf/v1#ConferenceName",
                         "type": "lookup",
@@ -962,7 +965,8 @@
                                 "dataTypeURI": ""
                             },
                             "repeatable": "true",
-                            "defaults": []
+                            "defaults": [],
+                            "editable": "true"
                         }
                     },
                     {
@@ -1063,8 +1067,7 @@
                         "propertyURI": "http://www.loc.gov/mads/rdf/v1#hasSource",
                         "remark": "http://access.rdatoolkit.org/rdachp8_rda8-479.html"
                     }
-                ],
-                "contact": ""
+                ]
             },
             {
                 "propertyTemplates": [
@@ -1674,6 +1677,7 @@
         "id": "profile:bf2:Agents:Attributes",
         "title": "BIBFRAME 2.0 Agents",
         "date": "2017-05-22",
-        "description": "Agents are people, organizations, jurisdictions, etc., associated with a Work or Instance through roles such as author, editor, artist, photographer, composer, illustrator, etc."
+        "description": "Agents are people, organizations, jurisdictions, etc., associated with a Work or Instance through roles such as author, editor, artist, photographer, composer, illustrator, etc.",
+        "author": "NDMSO"
     }
 }

--- a/static/spoofedFilesFromServer/from_verso/data/profiles/BIBFRAME 2.0 Cartographic.json
+++ b/static/spoofedFilesFromServer/from_verso/data/profiles/BIBFRAME 2.0 Cartographic.json
@@ -35,7 +35,7 @@
                                 "dataTypeURI": "http://id.loc.gov/ontologies/bflc/PrimaryContribution"
                             },
                             "defaults": [],
-                            "editable": "true"
+                            "editable": "false"
                         },
                         "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
                         "propertyLabel": "Creator of Work (RDA 19.2)",
@@ -69,7 +69,8 @@
                             ],
                             "useValuesFrom": [],
                             "valueDataType": {},
-                            "defaults": []
+                            "defaults": [],
+                            "editable": "false"
                         },
                         "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm",
                         "propertyLabel": "Form of Work"
@@ -85,7 +86,8 @@
                             ],
                             "useValuesFrom": [],
                             "valueDataType": {},
-                            "defaults": []
+                            "defaults": [],
+                            "editable": "false"
                         },
                         "propertyURI": "http://id.loc.gov/ontologies/bibframe/geographicCoverage",
                         "propertyLabel": "(Geographic) Coverage of the Content"
@@ -112,14 +114,14 @@
                         "resourceTemplates": [],
                         "valueConstraint": {
                             "valueTemplateRefs": [
-                                "profile:bf2:Cartographic:Coordinates"
+                                "profile:bf2:Cartographic:Attributes"
                             ],
                             "useValuesFrom": [],
                             "valueDataType": {},
                             "defaults": []
                         },
                         "propertyURI": "http://id.loc.gov/ontologies/bibframe/cartographicAttributes",
-                        "propertyLabel": "Coordinates of Cartographic Content",
+                        "propertyLabel": "Cartographic Attributes",
                         "remark": ""
                     },
                     {
@@ -153,7 +155,7 @@
                             "useValuesFrom": [],
                             "valueDataType": {},
                             "defaults": [],
-                            "editable": "true"
+                            "editable": "false"
                         },
                         "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
                         "propertyLabel": "Contribution (RDA 19.3 and 20.2)",
@@ -355,23 +357,6 @@
                         },
                         "propertyURI": "http://id.loc.gov/ontologies/bibframe/scale",
                         "propertyLabel": "Scale information"
-                    },
-                    {
-                        "mandatory": "false",
-                        "repeatable": "true",
-                        "type": "resource",
-                        "resourceTemplates": [],
-                        "valueConstraint": {
-                            "valueTemplateRefs": [
-                                "profile:bf2:Cartographic:Projection"
-                            ],
-                            "useValuesFrom": [],
-                            "valueDataType": {},
-                            "defaults": []
-                        },
-                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/cartographicAttributes",
-                        "propertyLabel": "Projection of Cartographic Content",
-                        "remark": ""
                     },
                     {
                         "mandatory": "false",
@@ -800,7 +785,7 @@
                             "defaults": []
                         },
                         "propertyLabel": "Geographic Classification (MARC 052)",
-                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/classification"
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/geographicCoverage"
                     },
                     {
                         "mandatory": "false",
@@ -813,7 +798,8 @@
                             ],
                             "useValuesFrom": [],
                             "valueDataType": {},
-                            "defaults": []
+                            "defaults": [],
+                            "editable": "false"
                         },
                         "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
                         "propertyLabel": "Contributors (RDA 21.1)",
@@ -1030,26 +1016,40 @@
                 "propertyTemplates": [
                     {
                         "mandatory": "false",
-                        "repeatable": "false",
+                        "repeatable": "true",
                         "type": "literal",
                         "resourceTemplates": [],
                         "valueConstraint": {
                             "valueTemplateRefs": [],
                             "useValuesFrom": [],
-                            "valueDataType": {
-                                "dataTypeURI": ""
-                            },
-                            "repeatable": "false",
-                            "defaults": []
+                            "defaults": [],
+                            "valueDataType": {}
                         },
                         "propertyURI": "http://id.loc.gov/ontologies/bibframe/coordinates",
                         "propertyLabel": "Coordinates (RDA 7.4)",
                         "remark": "http://access.rdatoolkit.org/7.4.html"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "defaults": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Projection"
+                            }
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/projection",
+                        "propertyLabel": "Projection (RDA 7.26)",
+                        "remark": "http://access.rdatoolkit.org/7.26.html"
                     }
                 ],
-                "id": "profile:bf2:Cartographic:Coordinates",
                 "resourceURI": "http://id.loc.gov/ontologies/bibframe/Cartographic",
-                "resourceLabel": "Cartographic Coordinates"
+                "id": "profile:bf2:Cartographic:Attributes",
+                "resourceLabel": "Cartographic Attributes"
             },
             {
                 "propertyTemplates": [
@@ -1106,30 +1106,6 @@
                         "valueConstraint": {
                             "valueTemplateRefs": [],
                             "useValuesFrom": [],
-                            "defaults": [],
-                            "valueDataType": {
-                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Projection"
-                            }
-                        },
-                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/projection",
-                        "propertyLabel": "Projection (RDA 7.26)",
-                        "remark": "http://access.rdatoolkit.org/7.26.html"
-                    }
-                ],
-                "id": "profile:bf2:Cartographic:Projection",
-                "resourceLabel": "Cartographic Projection",
-                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Cartographic"
-            },
-            {
-                "propertyTemplates": [
-                    {
-                        "mandatory": "false",
-                        "repeatable": "true",
-                        "type": "literal",
-                        "resourceTemplates": [],
-                        "valueConstraint": {
-                            "valueTemplateRefs": [],
-                            "useValuesFrom": [],
                             "valueDataType": {
                                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Scale"
                             },
@@ -1174,12 +1150,12 @@
                             "repeatable": "false",
                             "defaults": []
                         },
-                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyURI": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value",
                         "propertyLabel": "Geographic Classification"
                     }
                 ],
                 "id": "profile:bf2:Cartographic:Class",
-                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Classification",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Place",
                 "resourceLabel": "Geographic Classification"
             },
             {
@@ -1767,7 +1743,7 @@
                 "resourceURI": "http://id.loc.gov/ontologies/bibframe/Work"
             }
         ],
-        "contact": "NDMSO",
+        "author": "NDMSO",
         "date": "2017-05-18",
         "description": "Work, Expression, Instance for Cartographic",
         "id": "profile:bf2:Cartographic",

--- a/static/spoofedFilesFromServer/from_verso/data/profiles/BIBFRAME 2.0 DDC.json
+++ b/static/spoofedFilesFromServer/from_verso/data/profiles/BIBFRAME 2.0 DDC.json
@@ -42,10 +42,10 @@
                 "resourceURI": "http://id.loc.gov/ontologies/bibframe/ClassificationDdc"
             }
         ],
-        "id": "profile:bf2:DDC",
+        "id": "bf2:DDC",
         "description": "Dewey Decimal Classification",
         "title": "BIBFRAME 2.0 DDC",
         "date": "2017-07-28",
-        "contact": "NDMSO"
+        "author": "NDMSO"
     }
 }

--- a/static/spoofedFilesFromServer/from_verso/data/profiles/BIBFRAME 2.0 Extra menus.json
+++ b/static/spoofedFilesFromServer/from_verso/data/profiles/BIBFRAME 2.0 Extra menus.json
@@ -53,7 +53,7 @@
                         "resourceTemplates": [],
                         "valueConstraint": {
                             "valueTemplateRefs": [
-                                "profile:bf2:Place"
+                                "profile:bf2:Capture:Place"
                             ],
                             "useValuesFrom": [],
                             "defaults": [],
@@ -98,6 +98,44 @@
                 "id": "profile:bf2:Capture",
                 "resourceURI": "http://id.loc.gov/ontologies/bibframe/Capture",
                 "resourceLabel": "Capture information"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "target",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/authorities/names",
+                                "http://id.loc.gov/authorities/subjects"
+                            ],
+                            "defaults": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
+                        "propertyLabel": "Search LCNAF/LCSH"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "defaults": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+                        "propertyLabel": "Record Place (if it does not appear above)"
+                    }
+                ],
+                "id": "profile:bf2:Capture:Place",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Place",
+                "resourceLabel": "Place of capture"
             },
             {
                 "propertyTemplates": [
@@ -866,7 +904,7 @@
         "id": "profile:bf2:Xtras",
         "title": "BIBFRAME 2.0 Extra menus",
         "date": "2018-09-26",
-        "contact": "NDMSO",
+        "author": "NDMSO",
         "description": "Extra submenus for format profiles"
     }
 }

--- a/static/spoofedFilesFromServer/from_verso/data/profiles/BIBFRAME 2.0 Form.json
+++ b/static/spoofedFilesFromServer/from_verso/data/profiles/BIBFRAME 2.0 Form.json
@@ -16,17 +16,17 @@
                             "valueDataType": {
                                 "dataTypeURI": ""
                             },
-                            "repeatable": "false"
+                            "repeatable": "false",
+                            "defaults": []
                         },
                         "propertyLabel": "Search LCGFT (RDA 6.3)",
-                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/GenreForm",
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm",
                         "remark": "http://access.rdatoolkit.org/6.3.html"
                     }
                 ],
                 "id": "profile:bf2:Form",
                 "resourceURI": "http://id.loc.gov/ontologies/bibframe/GenreForm",
-                "resourceLabel": "Form/Genre",
-                "contact": "NDMSO"
+                "resourceLabel": "Form/Genre"
             },
             {
                 "propertyTemplates": [
@@ -46,7 +46,8 @@
                                 "remark": ""
                             },
                             "repeatable": "false",
-                            "remark": ""
+                            "remark": "",
+                            "defaults": []
                         },
                         "propertyLabel": "(Geographic) Coverage of the Content (RDA 7.3)",
                         "remark": "http://access.rdatoolkit.org/7.3.html",
@@ -62,7 +63,8 @@
                                 "profile:bf2:Note"
                             ],
                             "useValuesFrom": [],
-                            "valueDataType": {}
+                            "valueDataType": {},
+                            "defaults": []
                         },
                         "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
                         "propertyLabel": "Note about Geographic coverage"
@@ -84,7 +86,8 @@
                             "useValuesFrom": [
                                 "http://id.loc.gov/authorities/genreForms"
                             ],
-                            "valueDataType": {}
+                            "valueDataType": {},
+                            "defaults": []
                         },
                         "propertyLabel": "Search LCGFT",
                         "propertyURI": "http://id.loc.gov/ontologies/bflc/target"
@@ -95,10 +98,10 @@
                 "resourceLabel": "Form/Genre Test"
             }
         ],
-        "id": "profile:bf2:Form",
+        "id": "bf2:Form",
         "title": "BIBFRAME 2.0 Form",
         "description": "Form of Work",
         "date": "2017-05-13",
-        "contact": "NDMSO"
+        "author": "NDMSO"
     }
 }

--- a/static/spoofedFilesFromServer/from_verso/data/profiles/BIBFRAME 2.0 Identifiers.json
+++ b/static/spoofedFilesFromServer/from_verso/data/profiles/BIBFRAME 2.0 Identifiers.json
@@ -268,6 +268,73 @@
                 "propertyTemplates": [
                     {
                         "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "defaults": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value",
+                        "propertyLabel": "Audio Issue Number"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Identifiers:Source"
+                            ],
+                            "useValuesFrom": [],
+                            "defaults": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/source",
+                        "propertyLabel": "Source of Number"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "literal",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [],
+                            "defaults": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/qualifier",
+                        "propertyLabel": "Qualifier"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Note"
+                            ],
+                            "useValuesFrom": [],
+                            "defaults": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                        "propertyLabel": "Note on Audio Issue Number"
+                    }
+                ],
+                "id": "profile:bf2:Identifiers:AudioIssue",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/AudioIssueNumber",
+                "resourceLabel": "Audio Issue Number"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
                         "repeatable": "false",
                         "type": "literal",
                         "resourceTemplates": [],
@@ -636,7 +703,7 @@
                         "propertyLabel": "Note on ISRC"
                     }
                 ],
-                "id": "profile:bf2:TestProfile:ISRC",
+                "id": "profile:bf2:Identifiers:ISRC",
                 "resourceURI": "http://id.loc.gov/ontologies/bibframe/Isrc",
                 "resourceLabel": "ISRC"
             },
@@ -1463,10 +1530,10 @@
                 "resourceLabel": "Accession or copy number"
             }
         ],
-        "id": "profile:bf2:Identifiers",
+        "id": "bf2:Identifiers",
         "title": "BIBFRAME 2.0 Identifiers",
         "description": "Identifiers for BIBFRAME Resources",
         "date": "2017-08-16",
-        "contact": "NDMSO"
+        "author": "NDMSO"
     }
 }

--- a/static/spoofedFilesFromServer/from_verso/data/profiles/BIBFRAME 2.0 Item.json
+++ b/static/spoofedFilesFromServer/from_verso/data/profiles/BIBFRAME 2.0 Item.json
@@ -264,11 +264,11 @@
                 "resourceLabel": "Chronology"
             }
         ],
-        "id": "profile:bf2:Item",
+        "id": "bf2:Item",
         "title": "BIBFRAME 2.0 Item",
         "description": "Item for all formats (testing)",
         "date": "2017-08-08",
-        "contact": "NDMSO",
+        "author": "NDMSO",
         "remark": ""
     }
 }

--- a/static/spoofedFilesFromServer/from_verso/data/profiles/BIBFRAME 2.0 LCC.json
+++ b/static/spoofedFilesFromServer/from_verso/data/profiles/BIBFRAME 2.0 LCC.json
@@ -22,10 +22,10 @@
                 "resourceURI": "http://id.loc.gov/ontologies/bibframe/ClassificationLcc"
             }
         ],
-        "id": "profile:bf2:LCC",
+        "id": "bf2:LCC",
         "title": "BIBFRAME 2.0 LCC",
         "description": "LC Classification/Call Number",
         "date": "2017-05-13",
-        "contact": "NDMSO"
+        "author": "NDMSO"
     }
 }

--- a/static/spoofedFilesFromServer/from_verso/data/profiles/BIBFRAME 2.0 Language.json
+++ b/static/spoofedFilesFromServer/from_verso/data/profiles/BIBFRAME 2.0 Language.json
@@ -74,7 +74,7 @@
                 "resourceLabel": "Language of Content"
             }
         ],
-        "id": "profile:bf2:Language",
+        "id": "bf2:Language",
         "title": "BIBFRAME 2.0 Language",
         "date": "2017-05-13",
         "description": "Language"

--- a/static/spoofedFilesFromServer/from_verso/data/profiles/BIBFRAME 2.0 Monograph.json
+++ b/static/spoofedFilesFromServer/from_verso/data/profiles/BIBFRAME 2.0 Monograph.json
@@ -35,7 +35,7 @@
                                 "dataTypeURI": "http://id.loc.gov/ontologies/bflc/PrimaryContribution"
                             },
                             "defaults": [],
-                            "editable": "true",
+                            "editable": "false",
                             "repeatable": "true"
                         },
                         "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
@@ -70,8 +70,14 @@
                                 "profile:bf2:Form"
                             ],
                             "useValuesFrom": [],
-                            "valueDataType": {},
-                            "defaults": []
+                            "valueDataType": {
+                                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/GenreForm",
+                                "dataTypeLabel": "Series enumeration",
+                                "remark": ""
+                            },
+                            "defaults": [],
+                            "editable": "false",
+                            "repeatable": "true"
                         },
                         "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm",
                         "propertyLabel": "Form of Work"
@@ -119,7 +125,8 @@
                             ],
                             "useValuesFrom": [],
                             "valueDataType": {},
-                            "defaults": []
+                            "defaults": [],
+                            "editable": "false"
                         },
                         "propertyURI": "http://id.loc.gov/ontologies/bibframe/geographicCoverage",
                         "propertyLabel": "(Geographic) Coverage of the Content"
@@ -169,7 +176,7 @@
                                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Contribution"
                             },
                             "defaults": [],
-                            "editable": "true",
+                            "editable": "false",
                             "repeatable": "true"
                         },
                         "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
@@ -1794,7 +1801,7 @@
                 "resourceLabel": "BIBFRAME Work (RDA Expression Elements)"
             }
         ],
-        "contact": "NDMSO",
+        "author": "NDMSO",
         "date": "2017-05-26",
         "description": "Work, Expression, Instance for Monographs",
         "id": "profile:bf2:Monograph",

--- a/static/spoofedFilesFromServer/from_verso/data/profiles/BIBFRAME 2.0 Moving Image-35mm Feature Film.json
+++ b/static/spoofedFilesFromServer/from_verso/data/profiles/BIBFRAME 2.0 Moving Image-35mm Feature Film.json
@@ -114,7 +114,8 @@
                             ],
                             "useValuesFrom": [],
                             "valueDataType": {},
-                            "defaults": []
+                            "defaults": [],
+                            "editable": "true"
                         },
                         "propertyURI": "http://id.loc.gov/ontologies/bibframe/geographicCoverage",
                         "propertyLabel": "(Geographic) Coverage of the Content"
@@ -260,7 +261,8 @@
                             ],
                             "useValuesFrom": [],
                             "valueDataType": {},
-                            "defaults": []
+                            "defaults": [],
+                            "editable": "false"
                         },
                         "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
                         "propertyLabel": "Creator of Work (RDA 19.2)",
@@ -277,7 +279,8 @@
                             ],
                             "useValuesFrom": [],
                             "valueDataType": {},
-                            "defaults": []
+                            "defaults": [],
+                            "editable": "false"
                         },
                         "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
                         "propertyLabel": "Contribution (RDA 19.3 and 20.2)",
@@ -913,7 +916,8 @@
                             ],
                             "useValuesFrom": [],
                             "valueDataType": {},
-                            "defaults": []
+                            "defaults": [],
+                            "editable": "false"
                         },
                         "propertyLabel": "Persons, Families, Corporate Bodies Associated with the Manifestation (RDA 21.1.2)",
                         "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
@@ -1953,7 +1957,7 @@
                 "resourceLabel": "BIBFRAME Work (RDA Expression Elements)"
             }
         ],
-        "contact": "NDMSO",
+        "author": "NDMSO",
         "date": "2017-05-20",
         "description": "Work, Expression, Instance for 35mmFeatureFilm",
         "id": "profile:bf2:35mmFeatureFilm",

--- a/static/spoofedFilesFromServer/from_verso/data/profiles/BIBFRAME 2.0 Moving Image-BluRay DVD.json
+++ b/static/spoofedFilesFromServer/from_verso/data/profiles/BIBFRAME 2.0 Moving Image-BluRay DVD.json
@@ -50,7 +50,8 @@
                             ],
                             "useValuesFrom": [],
                             "valueDataType": {},
-                            "defaults": []
+                            "defaults": [],
+                            "editable": "false"
                         },
                         "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm",
                         "propertyLabel": "Form of Work"
@@ -133,7 +134,8 @@
                             ],
                             "useValuesFrom": [],
                             "valueDataType": {},
-                            "defaults": []
+                            "defaults": [],
+                            "editable": "false"
                         },
                         "propertyURI": "http://id.loc.gov/ontologies/bibframe/geographicCoverage",
                         "propertyLabel": "(Geographic) Coverage of the Content"
@@ -198,7 +200,8 @@
                             "valueDataType": {
                                 "dataTypeURI": "http://id.loc.gov/ontologies/bflc/PrimaryContribution"
                             },
-                            "defaults": []
+                            "defaults": [],
+                            "editable": "false"
                         },
                         "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
                         "propertyLabel": "Creator of Work (RDA 19.2)",
@@ -215,7 +218,8 @@
                             ],
                             "useValuesFrom": [],
                             "valueDataType": {},
-                            "defaults": []
+                            "defaults": [],
+                            "editable": "false"
                         },
                         "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
                         "propertyLabel": "Contribution (RDA 19.3 and 20.2)",
@@ -526,22 +530,6 @@
                         "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasExpression",
                         "propertyLabel": "Related Expressions",
                         "remark": ""
-                    },
-                    {
-                        "mandatory": "false",
-                        "repeatable": "true",
-                        "type": "resource",
-                        "resourceTemplates": [],
-                        "valueConstraint": {
-                            "valueTemplateRefs": [
-                                "profile:bf2:RelatedInstance"
-                            ],
-                            "useValuesFrom": [],
-                            "valueDataType": {},
-                            "defaults": []
-                        },
-                        "propertyURI": "http://id.loc.gov/ontologies/bflc/relationship",
-                        "propertyLabel": "Related Instances"
                     },
                     {
                         "mandatory": "false",
@@ -993,7 +981,8 @@
                             ],
                             "useValuesFrom": [],
                             "valueDataType": {},
-                            "defaults": []
+                            "defaults": [],
+                            "editable": "false"
                         },
                         "propertyLabel": "LCGFT Accessibility Term (Video recordings for ... )",
                         "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm"
@@ -1109,7 +1098,8 @@
                             ],
                             "useValuesFrom": [],
                             "valueDataType": {},
-                            "defaults": []
+                            "defaults": [],
+                            "editable": "false"
                         },
                         "propertyLabel": "Persons, Families, Corporate Bodies Associated with the Manifestation (RDA 21.1.2)",
                         "remark": "http://access.rdatoolkit.org/rdachp21_rda21-74.html",
@@ -2356,7 +2346,7 @@
                 "resourceLabel": "BIBFRAME Work (RDA Expression Elements)"
             }
         ],
-        "contact": "NDMSO",
+        "author": "NDMSO",
         "date": "2017-05-20",
         "description": "Work, Expression, Instance for BluRay DVD",
         "id": "profile:bf2:MIBluRayDVD",

--- a/static/spoofedFilesFromServer/from_verso/data/profiles/BIBFRAME 2.0 Notated Music.json
+++ b/static/spoofedFilesFromServer/from_verso/data/profiles/BIBFRAME 2.0 Notated Music.json
@@ -35,7 +35,7 @@
                                 "dataTypeURI": "http://id.loc.gov/ontologies/bflc/PrimaryContribution"
                             },
                             "defaults": [],
-                            "editable": "true",
+                            "editable": "false",
                             "repeatable": "true"
                         },
                         "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
@@ -86,7 +86,8 @@
                             ],
                             "useValuesFrom": [],
                             "valueDataType": {},
-                            "defaults": []
+                            "defaults": [],
+                            "editable": "false"
                         },
                         "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm",
                         "propertyLabel": "Form of Work"
@@ -178,14 +179,14 @@
                         "resourceTemplates": [],
                         "valueConstraint": {
                             "valueTemplateRefs": [
-                                "profile:bf2:PMOMedPerf:DecMed"
+                                "profile:bf2:PMOMedPerf:Doubling"
                             ],
                             "useValuesFrom": [],
                             "valueDataType": {},
                             "defaults": []
                         },
                         "propertyLabel": "Doubling Declared Medium",
-                        "propertyURI": "http://performedmusicontology.org/ontology/hasDoublingMediumOfPerformance"
+                        "propertyURI": "http://performedmusicontology.org/ontology/hasMdeiumPart"
                     },
                     {
                         "mandatory": "false",
@@ -278,7 +279,7 @@
                             "useValuesFrom": [],
                             "valueDataType": {},
                             "defaults": [],
-                            "editable": "true",
+                            "editable": "false",
                             "repeatable": "true"
                         },
                         "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
@@ -908,7 +909,7 @@
                             "useValuesFrom": [],
                             "valueDataType": {},
                             "defaults": [],
-                            "editable": "true"
+                            "editable": "false"
                         },
                         "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
                         "propertyLabel": "Contributor (RDA 20.2)",
@@ -2935,7 +2936,7 @@
                 "resourceLabel": "Medium of Performance: Individual Facets"
             }
         ],
-        "contact": "NDMSO",
+        "author": "NDMSO",
         "date": "2018-02-13",
         "description": "Work, Expression, Instance for Notated Music",
         "id": "profile:bf2:NotatedMusic",

--- a/static/spoofedFilesFromServer/from_verso/data/profiles/BIBFRAME 2.0 Note.json
+++ b/static/spoofedFilesFromServer/from_verso/data/profiles/BIBFRAME 2.0 Note.json
@@ -190,10 +190,10 @@
                 "resourceLabel": "System Requirement"
             }
         ],
-        "id": "profile:bf2:Note",
+        "id": "bf2:Note",
         "title": "BIBFRAME 2.0 Note",
         "description": "Notes (and more) for BIBFRAME resources",
         "date": "2017-08-21",
-        "contact": "NDMSO"
+        "author": "NDMSO"
     }
 }

--- a/static/spoofedFilesFromServer/from_verso/data/profiles/BIBFRAME 2.0 Place.json
+++ b/static/spoofedFilesFromServer/from_verso/data/profiles/BIBFRAME 2.0 Place.json
@@ -47,12 +47,13 @@
                 "id": "profile:bf2:Place",
                 "resourceURI": "http://id.loc.gov/ontologies/bibframe/Place",
                 "resourceLabel": "Place Associated with a Work",
-                "contact": ""
+                "author": "NDMSO"
             }
         ],
-        "id": "profile:bf2:Place",
+        "id": "bf2:Place",
         "title": "BIBFRAME 2.0 Place",
         "date": "2017-05-13",
-        "description": "Place Associated with a Resource"
+        "description": "Place Associated with a Resource",
+        "author": "NDMSO"
     }
 }

--- a/static/spoofedFilesFromServer/from_verso/data/profiles/BIBFRAME 2.0 Publication, Distribution, Manufacturer Activity.json
+++ b/static/spoofedFilesFromServer/from_verso/data/profiles/BIBFRAME 2.0 Publication, Distribution, Manufacturer Activity.json
@@ -74,7 +74,7 @@
                     }
                 ],
                 "id": "profile:bf2:PublicationInformation",
-                "contact": "",
+                "author": "NDMSO",
                 "resourceURI": "http://id.loc.gov/ontologies/bibframe/Publication",
                 "resourceLabel": "Publication Activity"
             },
@@ -421,6 +421,6 @@
         "title": "BIBFRAME 2.0 Publication, Distribution, Manufacturer Activity",
         "description": "Publication, Distribution, Manufacture Activity",
         "date": "2017-06-02",
-        "contact": "NDMSO"
+        "author": "NDMSO"
     }
 }

--- a/static/spoofedFilesFromServer/from_verso/data/profiles/BIBFRAME 2.0 RWO.json
+++ b/static/spoofedFilesFromServer/from_verso/data/profiles/BIBFRAME 2.0 RWO.json
@@ -920,13 +920,13 @@
                 "id": "profile:bf2:Agent:RWO",
                 "resourceURI": "http://www.loc.gov/mads/rdf/v1#RWO",
                 "resourceLabel": "Other Identifying Attributes",
-                "contact": "NDMSO"
+                "author": "NDMSO"
             }
         ],
         "title": "BIBFRAME 2.0 RWO",
         "id": "profile:bf2:Agents:RWO",
         "description": "A madsrdf:RWO is an abstract entity and identifies a Real World Object (RWO) identified by the label of a madsrdf:Authority or madsrdf:DeprecatedAuthority",
-        "contact": "NDMSO",
+        "author": "NDMSO",
         "date": "2017-05-17"
     }
 }

--- a/static/spoofedFilesFromServer/from_verso/data/profiles/BIBFRAME 2.0 Rare Materials.json
+++ b/static/spoofedFilesFromServer/from_verso/data/profiles/BIBFRAME 2.0 Rare Materials.json
@@ -34,7 +34,8 @@
                             "valueDataType": {
                                 "dataTypeURI": "http://id.loc.gov/ontologies/bflc/PrimaryContribution"
                             },
-                            "defaults": []
+                            "defaults": [],
+                            "editable": "false"
                         },
                         "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
                         "propertyLabel": "Creator of Work (RDA 19.2)",
@@ -107,7 +108,8 @@
                             ],
                             "useValuesFrom": [],
                             "valueDataType": {},
-                            "defaults": []
+                            "defaults": [],
+                            "editable": "true"
                         },
                         "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm",
                         "propertyLabel": "Form of Work"
@@ -426,7 +428,8 @@
                             ],
                             "useValuesFrom": [],
                             "valueDataType": {},
-                            "defaults": []
+                            "defaults": [],
+                            "editable": "false"
                         },
                         "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
                         "propertyLabel": "Contributors"
@@ -1550,6 +1553,6 @@
         "title": "BIBFRAME 2.0 Rare Materials",
         "description": "Work, Expression, Instance for Rare Materials",
         "date": "2017-08-30",
-        "contact": "NDMSO"
+        "author": "NDMSO"
     }
 }

--- a/static/spoofedFilesFromServer/from_verso/data/profiles/BIBFRAME 2.0 Serial.json
+++ b/static/spoofedFilesFromServer/from_verso/data/profiles/BIBFRAME 2.0 Serial.json
@@ -69,7 +69,8 @@
                             ],
                             "useValuesFrom": [],
                             "valueDataType": {},
-                            "defaults": []
+                            "defaults": [],
+                            "editable": "false"
                         },
                         "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm",
                         "propertyLabel": "Form of Work (RDA 6.3)",
@@ -1073,7 +1074,7 @@
                 "id": "profile:bf2:Serial:Title",
                 "resourceURI": "http://id.loc.gov/ontologies/bibframe/Title",
                 "resourceLabel": "Title",
-                "contact": "NDMSO"
+                "author": "NDMSO"
             },
             {
                 "propertyTemplates": [
@@ -2155,7 +2156,7 @@
                 "resourceLabel": "BIBFRAME Work (RDA Expression Elements)"
             }
         ],
-        "contact": "NDMSO",
+        "author": "NDMSO",
         "date": "2017-05-20",
         "description": "Work, Expression, Instance for Serials",
         "id": "profile:bf2:Serial",

--- a/static/spoofedFilesFromServer/from_verso/data/profiles/BIBFRAME 2.0 Series Information.json
+++ b/static/spoofedFilesFromServer/from_verso/data/profiles/BIBFRAME 2.0 Series Information.json
@@ -86,10 +86,10 @@
                 "remark": "http://access.rdatoolkit.org/rdachp2_rda2-7632.html"
             }
         ],
-        "id": "profile:bf2:SeriesInformation",
+        "id": "bf2:SeriesInformation",
         "title": "BIBFRAME 2.0 Series Information",
         "date": "2017-06-07",
-        "contact": "NDMSO",
+        "author": "NDMSO",
         "description": "Instance, Series Information"
     }
 }

--- a/static/spoofedFilesFromServer/from_verso/data/profiles/BIBFRAME 2.0 Sound Recording-Analog.json
+++ b/static/spoofedFilesFromServer/from_verso/data/profiles/BIBFRAME 2.0 Sound Recording-Analog.json
@@ -34,7 +34,8 @@
                             "valueDataType": {
                                 "dataTypeURI": "http://id.loc.gov/ontologies/bflc/PrimaryContribution"
                             },
-                            "defaults": []
+                            "defaults": [],
+                            "editable": "false"
                         },
                         "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
                         "propertyLabel": "Creator of Work (RDA 19.2)",
@@ -69,7 +70,8 @@
                             ],
                             "useValuesFrom": [],
                             "valueDataType": {},
-                            "defaults": []
+                            "defaults": [],
+                            "editable": "false"
                         },
                         "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm",
                         "propertyLabel": "Form of Work"
@@ -261,7 +263,8 @@
                             ],
                             "useValuesFrom": [],
                             "valueDataType": {},
-                            "defaults": []
+                            "defaults": [],
+                            "editable": "false"
                         },
                         "propertyURI": "http://id.loc.gov/ontologies/bibframe/geographicCoverage",
                         "propertyLabel": "(Geographic) Coverage of the Content"
@@ -311,7 +314,8 @@
                             ],
                             "useValuesFrom": [],
                             "valueDataType": {},
-                            "defaults": []
+                            "defaults": [],
+                            "editable": "false"
                         },
                         "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
                         "propertyLabel": "Contribution (RDA 19.3 and 20.2)",
@@ -728,10 +732,11 @@
                                 "profile:bf2:Identifiers:PubNumber",
                                 "profile:bf2:Identifiers:EAN",
                                 "profile:bf2:Identifiers:UPC",
-                                "profile:bf2:TestProfile:ISRC",
+                                "profile:bf2:Identifiers:ISRC",
                                 "profile:bf2:Identifiers:Copyright",
                                 "profile:bf2:Identifiers:Other",
-                                "profile:bf2:Identifiers:Local"
+                                "profile:bf2:Identifiers:Local",
+                                "profile:bf2:Identifiers:AudioIssue"
                             ],
                             "useValuesFrom": [],
                             "valueDataType": {},
@@ -1943,7 +1948,7 @@
                 "resourceLabel": "BIBFRAME Work (RDA Expression Elements)"
             }
         ],
-        "contact": "NDMSO",
+        "author": "NDMSO",
         "date": "2017-10-25",
         "description": "Work, Expression, Instance for Analog Recordings",
         "id": "profile:bf2:Analog",

--- a/static/spoofedFilesFromServer/from_verso/data/profiles/BIBFRAME 2.0 Sound Recording-Audio CD-R.json
+++ b/static/spoofedFilesFromServer/from_verso/data/profiles/BIBFRAME 2.0 Sound Recording-Audio CD-R.json
@@ -34,7 +34,8 @@
                             "valueDataType": {
                                 "dataTypeURI": "http://id.loc.gov/ontologies/bflc/PrimaryContribution"
                             },
-                            "defaults": []
+                            "defaults": [],
+                            "editable": "false"
                         },
                         "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
                         "propertyLabel": "Creator of Work (RDA 19.2)",
@@ -69,7 +70,8 @@
                             ],
                             "useValuesFrom": [],
                             "valueDataType": {},
-                            "defaults": []
+                            "defaults": [],
+                            "editable": "false"
                         },
                         "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm",
                         "propertyLabel": "Form of Work"
@@ -261,7 +263,8 @@
                             ],
                             "useValuesFrom": [],
                             "valueDataType": {},
-                            "defaults": []
+                            "defaults": [],
+                            "editable": "false"
                         },
                         "propertyURI": "http://id.loc.gov/ontologies/bibframe/geographicCoverage",
                         "propertyLabel": "(Geographic) Coverage of the Content"
@@ -313,7 +316,8 @@
                             ],
                             "useValuesFrom": [],
                             "valueDataType": {},
-                            "defaults": []
+                            "defaults": [],
+                            "editable": "false"
                         },
                         "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
                         "propertyLabel": "Contribution (RDA 19.3 and 20.2)",
@@ -716,10 +720,11 @@
                                 "profile:bf2:Identifiers:PubNumber",
                                 "profile:bf2:Identifiers:EAN",
                                 "profile:bf2:Identifiers:UPC",
-                                "profile:bf2:TestProfile:ISRC",
+                                "profile:bf2:Identifiers:ISRC",
                                 "profile:bf2:Identifiers:Copyright",
                                 "profile:bf2:Identifiers:Other",
-                                "profile:bf2:Identifiers:Local"
+                                "profile:bf2:Identifiers:Local",
+                                "profile:bf2:Identifiers:AudioIssue"
                             ],
                             "useValuesFrom": [],
                             "valueDataType": {},
@@ -1909,7 +1914,7 @@
                 "resourceLabel": "BIBFRAME Work (RDA Expression Elements)"
             }
         ],
-        "contact": "NDMSO",
+        "author": "NDMSO",
         "date": "2017-09-06",
         "description": "Work, Expression, Instance for Audio CD-R",
         "id": "profile:bf2:SoundCDR",

--- a/static/spoofedFilesFromServer/from_verso/data/profiles/BIBFRAME 2.0 Sound Recording-Audio CD.json
+++ b/static/spoofedFilesFromServer/from_verso/data/profiles/BIBFRAME 2.0 Sound Recording-Audio CD.json
@@ -34,7 +34,8 @@
                             "valueDataType": {
                                 "dataTypeURI": "http://id.loc.gov/ontologies/bflc/PrimaryContribution"
                             },
-                            "defaults": []
+                            "defaults": [],
+                            "editable": "false"
                         },
                         "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
                         "propertyLabel": "Creator of Work (RDA 19.2)",
@@ -69,7 +70,8 @@
                             ],
                             "useValuesFrom": [],
                             "valueDataType": {},
-                            "defaults": []
+                            "defaults": [],
+                            "editable": "false"
                         },
                         "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm",
                         "propertyLabel": "Form of Work"
@@ -261,7 +263,8 @@
                             ],
                             "useValuesFrom": [],
                             "valueDataType": {},
-                            "defaults": []
+                            "defaults": [],
+                            "editable": "false"
                         },
                         "propertyURI": "http://id.loc.gov/ontologies/bibframe/geographicCoverage",
                         "propertyLabel": "(Geographic) Coverage of the Content"
@@ -311,7 +314,8 @@
                             ],
                             "useValuesFrom": [],
                             "valueDataType": {},
-                            "defaults": []
+                            "defaults": [],
+                            "editable": "false"
                         },
                         "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
                         "propertyLabel": "Contribution (RDA 19.3 and 20.2)",
@@ -712,9 +716,10 @@
                                 "profile:bf2:Identifiers:PubNumber",
                                 "profile:bf2:Identifiers:EAN",
                                 "profile:bf2:Identifiers:UPC",
-                                "profile:bf2:TestProfile:ISRC",
+                                "profile:bf2:Identifiers:ISRC",
                                 "profile:bf2:Identifiers:Other",
-                                "profile:bf2:Identifiers:Local"
+                                "profile:bf2:Identifiers:Local",
+                                "profile:bf2:Identifiers:AudioIssue"
                             ],
                             "useValuesFrom": [],
                             "valueDataType": {},
@@ -1594,7 +1599,7 @@
                 "remark": "Graphic, non-realized representations of musical works intended to be perceived visually."
             }
         ],
-        "contact": "NDMSO",
+        "author": "NDMSO",
         "date": "2017-05-19",
         "description": "Work, Expression, Instance for Audio CD",
         "id": "profile:bf2:SoundRecording",

--- a/static/spoofedFilesFromServer/from_verso/data/profiles/BIBFRAME 2.0 Title Information.json
+++ b/static/spoofedFilesFromServer/from_verso/data/profiles/BIBFRAME 2.0 Title Information.json
@@ -413,119 +413,6 @@
                             "valueDataType": {},
                             "defaults": []
                         },
-                        "propertyLabel": "Parallel Title Proper (RDA 2.3.3)",
-                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/ParallelTitle",
-                        "remark": "http://access.rdatoolkit.org/rdachp2_rda2-3695.html"
-                    },
-                    {
-                        "mandatory": "false",
-                        "repeatable": "true",
-                        "type": "literal",
-                        "resourceTemplates": [],
-                        "valueConstraint": {
-                            "valueTemplateRefs": [],
-                            "useValuesFrom": [],
-                            "valueDataType": {},
-                            "defaults": []
-                        },
-                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/subtitle",
-                        "propertyLabel": "Parallel Other Title Information (RDA 2.3.5)",
-                        "remark": "http://access.rdatoolkit.org/rdachp2_rda2-3939.html"
-                    },
-                    {
-                        "mandatory": "false",
-                        "repeatable": "true",
-                        "type": "literal",
-                        "resourceTemplates": [],
-                        "valueConstraint": {
-                            "valueTemplateRefs": [],
-                            "useValuesFrom": [],
-                            "valueDataType": {},
-                            "defaults": []
-                        },
-                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/KeyTitle",
-                        "propertyLabel": "Key title"
-                    },
-                    {
-                        "mandatory": "false",
-                        "repeatable": "true",
-                        "type": "literal",
-                        "resourceTemplates": [],
-                        "valueConstraint": {
-                            "valueTemplateRefs": [],
-                            "useValuesFrom": [],
-                            "valueDataType": {},
-                            "defaults": []
-                        },
-                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/AbbreviatedTitle",
-                        "propertyLabel": "Abbreviated title"
-                    },
-                    {
-                        "mandatory": "false",
-                        "repeatable": "true",
-                        "type": "literal",
-                        "resourceTemplates": [],
-                        "valueConstraint": {
-                            "valueTemplateRefs": [],
-                            "useValuesFrom": [],
-                            "valueDataType": {},
-                            "defaults": []
-                        },
-                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/CollectiveTitle",
-                        "propertyLabel": "Collective title"
-                    },
-                    {
-                        "mandatory": "false",
-                        "repeatable": "true",
-                        "type": "literal",
-                        "resourceTemplates": [],
-                        "valueConstraint": {
-                            "valueTemplateRefs": [],
-                            "useValuesFrom": [],
-                            "valueDataType": {},
-                            "defaults": []
-                        },
-                        "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
-                        "remark": "http://access.rdatoolkit.org/rdachp2_rda2-4013.html",
-                        "propertyLabel": "Variant Title (RDA 2.3.6)"
-                    },
-                    {
-                        "mandatory": "false",
-                        "repeatable": "true",
-                        "type": "resource",
-                        "resourceTemplates": [],
-                        "valueConstraint": {
-                            "valueTemplateRefs": [
-                                "profile:bf2:Title:Note"
-                            ],
-                            "useValuesFrom": [],
-                            "valueDataType": {},
-                            "defaults": []
-                        },
-                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-                        "propertyLabel": "Note on title",
-                        "remark": "http://access.rdatoolkit.org/2.17.2.html"
-                    }
-                ],
-                "contact": "Title variation",
-                "resourceLabel": "Instance Title Variation",
-                "resourceURI": "http://id.loc.gov/ontologies/bibframe/VariantTitle",
-                "id": "profile:bf2:VariantTitle",
-                "remark": "Title associated with the resource that is different from the Work or Instance title."
-            },
-            {
-                "propertyTemplates": [
-                    {
-                        "mandatory": "false",
-                        "repeatable": "true",
-                        "type": "literal",
-                        "resourceTemplates": [],
-                        "valueConstraint": {
-                            "valueTemplateRefs": [],
-                            "useValuesFrom": [],
-                            "valueDataType": {},
-                            "defaults": []
-                        },
                         "propertyURI": "http://id.loc.gov/ontologies/bflc/title00MarcKey",
                         "propertyLabel": "LC Extension: title00MarcKey"
                     },
@@ -677,8 +564,8 @@
         ],
         "title": "BIBFRAME 2.0 Title Information",
         "date": "2017-05-26",
-        "contact": "NDMSO",
-        "id": "profile:bf2:Title",
+        "author": "NDMSO",
+        "id": "bf2:Title",
         "remark": "",
         "description": "Title information relating to a resource: work title, preferred title, instance title, transcribed title, translated title, variant form of title, etc."
     }

--- a/static/spoofedFilesFromServer/from_verso/data/profiles/BIBFRAME 2.0 Topic.json
+++ b/static/spoofedFilesFromServer/from_verso/data/profiles/BIBFRAME 2.0 Topic.json
@@ -322,10 +322,10 @@
                 "resourceLabel": "Subject of Work"
             }
         ],
-        "id": "profile:bf2:Topic",
+        "id": "bf2:Topic",
         "title": "BIBFRAME 2.0 Topic",
         "description": "Subject of Work",
         "date": "2017-05-13",
-        "contact": "NDMSO"
+        "author": "NDMSO"
     }
 }

--- a/static/spoofedFilesFromServer/from_verso/data/profiles/PMO Medium of Performance.json
+++ b/static/spoofedFilesFromServer/from_verso/data/profiles/PMO Medium of Performance.json
@@ -333,56 +333,6 @@
                     {
                         "mandatory": "false",
                         "repeatable": "true",
-                        "type": "literal",
-                        "resourceTemplates": [],
-                        "valueConstraint": {
-                            "valueTemplateRefs": [],
-                            "useValuesFrom": [],
-                            "valueDataType": {},
-                            "defaults": []
-                        },
-                        "propertyURI": "http://performedmusicontology.org/ontology/hasDistinctPartCount",
-                        "propertyLabel": "has Distinct Part Count"
-                    },
-                    {
-                        "mandatory": "false",
-                        "repeatable": "true",
-                        "type": "literal",
-                        "resourceTemplates": [],
-                        "valueConstraint": {
-                            "valueTemplateRefs": [],
-                            "useValuesFrom": [],
-                            "valueDataType": {},
-                            "defaults": []
-                        },
-                        "propertyURI": "http://performedmusicontology.org/ontology/hasRequiredPerformerCount",
-                        "propertyLabel": "has Required Part Count"
-                    },
-                    {
-                        "mandatory": "false",
-                        "repeatable": "true",
-                        "type": "literal",
-                        "resourceTemplates": [],
-                        "valueConstraint": {
-                            "valueTemplateRefs": [],
-                            "useValuesFrom": [],
-                            "valueDataType": {},
-                            "defaults": []
-                        },
-                        "propertyURI": "http://performedmusicontology.org/ontology/hasEnsembleCount",
-                        "propertyLabel": "has Ensemble Count"
-                    }
-                ],
-                "id": "profile:bf2:PMOMedPerf:DecMedTotals",
-                "resourceURI": "http://performedmusicontology.org/ontology/DeclaredMedium",
-                "resourceLabel": "Medium of Performance: Totaling Counts for the Entire Work",
-                "remark": ""
-            },
-            {
-                "propertyTemplates": [
-                    {
-                        "mandatory": "false",
-                        "repeatable": "true",
                         "type": "resource",
                         "resourceTemplates": [],
                         "valueConstraint": {
@@ -419,14 +369,14 @@
                         "resourceTemplates": [],
                         "valueConstraint": {
                             "valueTemplateRefs": [
-                                "profile:bf2:PMOMedPerf:MedPart2"
+                                "profile:bf2:PMOMedPerf:Doubling"
                             ],
                             "useValuesFrom": [],
                             "valueDataType": {},
                             "defaults": []
                         },
                         "propertyLabel": "OR has Doubling Medium Part",
-                        "propertyURI": "http://performedmusicontology.org/ontology/hasDoublingMediumOfPerformance"
+                        "propertyURI": "http://performedmusicontology.org/ontology/hasMediumPart"
                     },
                     {
                         "mandatory": "false",
@@ -474,12 +424,132 @@
                 "id": "profile:bf2:PMOMedPerf:DecMedTest",
                 "resourceURI": "http://performedmusicontology.org/ontology/DeclaredMedium",
                 "resourceLabel": "Declared Medium Test"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agent:Person"
+                            ],
+                            "useValuesFrom": [],
+                            "defaults": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/agent",
+                        "propertyLabel": "Agent"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:Agent:Role"
+                            ],
+                            "useValuesFrom": [],
+                            "defaults": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://id.loc.gov/ontologies/bibframe/role",
+                        "propertyLabel": "Role"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [],
+                            "useValuesFrom": [
+                                "http://id.loc.gov/authorities/performanceMediums"
+                            ],
+                            "defaults": [],
+                            "valueDataType": {
+                                "dataTypeURI": "http://performedmusicontology.org/ontology/IndividualMediumOfPerformance"
+                            }
+                        },
+                        "propertyURI": "http://performedmusicontology.org/ontology/hasMediumOfPerformance",
+                        "propertyLabel": "Medium of Performance"
+                    }
+                ],
+                "id": "profile:bf2:PMOAgentPerf",
+                "resourceURI": "http://id.loc.gov/ontologies/bibframe/Contribution",
+                "resourceLabel": "Agent, Role, Medium of Performance"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:PMOMedPerf:MedPart2"
+                            ],
+                            "useValuesFrom": [],
+                            "defaults": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://performedmusicontology.org/ontology/hasMediumPart",
+                        "propertyLabel": "Declared Medium of Performance"
+                    },
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:PMOMedPerf:Doubling"
+                            ],
+                            "useValuesFrom": [],
+                            "defaults": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://performedmusicontology.org/ontology/hasMediumPart",
+                        "propertyLabel": "Doubling Medium of Performance"
+                    }
+                ],
+                "id": "profile:bf2:PMODecDoubling",
+                "resourceURI": "http://performedmusicontology.org/ontology/DeclaredMedium",
+                "resourceLabel": "Declared + Doubling"
+            },
+            {
+                "propertyTemplates": [
+                    {
+                        "mandatory": "false",
+                        "repeatable": "true",
+                        "type": "resource",
+                        "resourceTemplates": [],
+                        "valueConstraint": {
+                            "valueTemplateRefs": [
+                                "profile:bf2:PMOMedPerf:MedPerfI1",
+                                "profile:bf2:PMOMedPerf:MedPerfI2"
+                            ],
+                            "useValuesFrom": [],
+                            "defaults": [],
+                            "valueDataType": {}
+                        },
+                        "propertyURI": "http://performedmusicontology.org/ontology/hasDoublingMediumOfPerformance",
+                        "propertyLabel": "Doubling Medium of Performance"
+                    }
+                ],
+                "id": "profile:bf2:PMOMedPerf:Doubling",
+                "resourceURI": "http://performedmusicontology.org/ontology/MediumPart",
+                "resourceLabel": "Doubling Medium of Performance"
             }
         ],
         "id": "profile:bf2:PMOMedPerf",
         "title": "PMO Medium of Performance",
         "description": "PMO Medium of Performance",
         "date": "2018-05-24",
-        "contact": "NDMSO"
+        "author": "NDMSO"
     }
 }


### PR DESCRIPTION
All `resourceTemplates` in Profiles updated from the current [Verso](https://github.com/lcnetdev/verso) Master Branch. Includes updated README.md.

Fixes #201