### PR TITLE
Editor uses hardcoded rtid of resourceTemplate:bf2:Monograph:Instance

### DIFF
--- a/src/components/editor/Editor.jsx
+++ b/src/components/editor/Editor.jsx
@@ -13,8 +13,7 @@ class Editor extends Component {
     // TODO: temporarily hardcoded here.
     //  Selecting a resource template will happen in the left-nav "Starting Points" menu,
     //   another child of the Editor component;  it will set state.resourceTemplateId
-    // const defaultRtId = 'resourceTemplate:bf2:Monograph:Instance'
-    const defaultRtId = 'resourceTemplate:bf2:Serial:Frequency'
+    const defaultRtId = 'resourceTemplate:bf2:Monograph:Instance'
     this.state = { resourceTemplateId: defaultRtId}
   }
 

--- a/static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/MonographInstance.json
+++ b/static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/MonographInstance.json
@@ -2,7 +2,7 @@
   "id": "resourceTemplate:bf2:Monograph:Instance",
   "resourceLabel": "BIBFRAME Instance",
   "resourceURI": "http://id.loc.gov/ontologies/bibframe/Instance",
-  "remark": "Can you believe we're doing this!?",
+  "remark": "This is altered greatly for testing purposes",
   "propertyTemplates": [
     {
       "propertyLabel": "Instance of",

--- a/static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/MonographInstance.json
+++ b/static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/MonographInstance.json
@@ -127,6 +127,25 @@
       "remark": "http://access.rdatoolkit.org/3.3.html"
     },
     {
+      "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
+      "propertyLabel": "Frequency (RDA 2.14)",
+      "remark": "http://access.rdatoolkit.org/2.14.html",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "target",
+      "resourceTemplates": [],
+      "valueConstraint": {
+        "valueTemplateRefs": [],
+        "useValuesFrom": [
+          "vocabulary:bf2:frequencies"
+        ],
+        "valueDataType": {
+          "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Frequency"
+        },
+        "defaults": []
+      }
+    },
+    {
       "propertyLabel": "WITH ALL VALUE CONSTRAINTS",
       "propertyURI": "http://id.loc.gov/ontologies/fake",
       "repeatable": "true",


### PR DESCRIPTION
for all of our code to play nicely together and be exercised in tests, we need the temporarily hardcoded resource template from Editor to remain Monograph:Instance.

@jgreben this was blocking both Sarav and me, so I just did it.

@jermnelson this was from a quick merge ... oops.