### PR TITLE
Adds a Profile button with DropZone to the StartingPoints section

### DIFF
--- a/__tests__/components/editor/StartingPoints.test.js
+++ b/__tests__/components/editor/StartingPoints.test.js
@@ -1,14 +1,73 @@
 // Copyright 2018 Stanford University see Apache2.txt for license
 
 import React from 'react'
-import { shallow } from 'enzyme'
+import { shallow, mount } from 'enzyme'
 import StartingPoints from '../../../src/components/editor/StartingPoints'
+import DropZone from '../../../src/components/editor/StartingPoints'
+
+const jsdom = require("jsdom");
+
+setUpDomEnvironment();
 
 describe('<StartingPoints />', () => {
-  const wrapper = shallow(<StartingPoints />)
+  let wrapper = shallow(<StartingPoints />)
 
   it('Has a div with headings', () => {
     expect(wrapper.find('div > h3').text()).toEqual('Create Resource')
-    expect(wrapper.find('div > h4').text()).toEqual('Starting points:')
   })
 })
+
+describe('<DropZone />', () => {
+  let wrapper = mount(<DropZone />)
+
+  it('shows the dropzone div when button is clicked', () => {
+    wrapper.find('button.btn').simulate('click')
+    expect(wrapper.find('DropZone > section > p').text()).toEqual('Drop profile files here or click to select a file:')
+  })
+
+  it('hides the dropzone div when button is clicked again', () => {
+    wrapper.find('button.btn').simulate('click')
+    expect(wrapper.find('DropZone > section > p').exists()).toBeFalsy()
+  })
+
+  it('hides the dropzone div when the file dialog is canceled', () => {
+    wrapper.find('button.btn').simulate('click')
+    expect(wrapper.state('showDropZone')).toBeTruthy()
+    wrapper.instance().updateShowDropZone(false)
+    expect(wrapper.state('showDropZone')).toBeFalsy()
+  })
+
+  it('sets the state to include the selected file', () => {
+    wrapper.find('button.btn').simulate('click')
+    wrapper.find('input[type="file"]').simulate('drop')
+    expect(wrapper.state('files')).toBeDefined()
+  })
+
+  describe('cleanup', () => {
+    it('unmounts the wrapper', () => {
+      expect(wrapper.debug().length).toBeGreaterThanOrEqual(1)
+      wrapper.unmount();
+      expect(wrapper.debug().length).toBe(0)
+    })
+  })
+})
+
+
+function setUpDomEnvironment() {
+  const { JSDOM } = jsdom;
+  const dom = new JSDOM('<!doctype html><html><body></body></html>', {url: 'http://localhost/'});
+  const { window } = dom;
+
+  global.window = window;
+  global.document = window.document;
+  global.navigator = {
+    userAgent: 'node.js',
+  };
+  copyProps(window, global);
+}
+function copyProps(src, target) {
+  const props = Object.getOwnPropertyNames(src)
+    .filter(prop => typeof target[prop] === 'undefined')
+    .map(prop => Object.getOwnPropertyDescriptor(src, prop));
+  Object.defineProperties(target, props);
+}

--- a/__tests__/integration/StartingPoints.test.js
+++ b/__tests__/integration/StartingPoints.test.js
@@ -1,0 +1,25 @@
+// Copyright 2018 Stanford University see Apache2.txt for license
+import expect from 'expect-puppeteer'
+
+describe('Starting Points menu', () => {
+  // beforeAll(async () => {
+  //   await page.goto('http://127.0.0.1:8080/editor')
+  // })
+
+  it('has a starting points div with header and button', async() => {
+    // await expect_value_in_sel_textContent('div.StartingPoints > h3', 'Create Resource')
+    // await page.waitForSelector('div.StartingPoints > button')
+    //   .then(
+    //     await expect(page).toClick('button', { text: 'Import Profile'})
+    //   ).catch(e => {console.warn(e)})
+    //
+    // await expect(page).toClick('button', { text: 'Import profile' })
+    // await expect(page).toMatchElement('input[type="file"]')
+  })
+})
+//
+// async function expect_value_in_sel_textContent(sel, value) {
+//   await page.waitForSelector(sel)
+//   const sel_text = await page.$eval(sel, e => e.textContent)
+//   expect(sel_text).toBe(value)
+// }

--- a/jest-puppeteer.config.js
+++ b/jest-puppeteer.config.js
@@ -6,7 +6,7 @@ module.exports = {
     'args' : [ '--disable-web-security' ],
   },
   server: {
-    command: 'node server.js',
-    port: 8000,
+    command: 'npm run dev-start',
+    port: 8080,
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1965,6 +1965,14 @@
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
     },
+    "attr-accept": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-1.1.3.tgz",
+      "integrity": "sha512-iT40nudw8zmCweivz6j58g+RT33I4KbaIvRUhjNmDwO2WmsQUxFEZZYZ5w3vXe5x5MX9D7mfvA/XaLOZYFR9EQ==",
+      "requires": {
+        "core-js": "^2.5.0"
+      }
+    },
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -11128,6 +11136,15 @@
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
         "scheduler": "^0.11.2"
+      }
+    },
+    "react-dropzone": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-7.0.1.tgz",
+      "integrity": "sha512-J4rbzhFZPVW7k7K9CVb0OcwSOJGLWa0y+0rvtB4rBLVkvq0agH/o3kPJ0DCkd6ZVzL2K1NFqIOvtQkwQKpmJBA==",
+      "requires": {
+        "attr-accept": "^1.1.3",
+        "prop-types": "^15.6.2"
       }
     },
     "react-hot-loader": {

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "react-bootstrap": "^0.32.4",
     "react-bootstrap-typeahead": "^3.2.4",
     "react-dom": "^16.6.3",
+    "react-dropzone": "^7.0.1",
     "react-offcanvas": "^0.3.1",
     "react-router-dom": "^4.3.1",
     "x2js": "^3.2.3"

--- a/src/components/editor/StartingPoints.jsx
+++ b/src/components/editor/StartingPoints.jsx
@@ -1,8 +1,35 @@
 // Copyright 2018 Stanford University see Apache2.txt for license
 
 import React, { Component }  from 'react'
+import Dropzone from 'react-dropzone'
+import PropTypes from 'prop-types'
 
 class StartingPoints extends Component {
+  constructor() {
+    super()
+    this.handleClick = this.handleClick.bind(this)
+    this.onDrop = this.onDrop.bind(this)
+    this.state = {
+      files: [],
+      showDropZone: false
+    }
+  }
+
+  handleClick() {
+    let val = this.state.showDropZone
+    this.setState({ showDropZone: !val })
+  }
+
+  onDrop(files) {
+    this.setState({
+      files
+    })
+  }
+
+  updateShowDropZone = (val) => {
+    this.setState({ showDropZone: val })
+  }
+
   render() {
     let startingPoints = {
       border: '1px dotted',
@@ -10,16 +37,44 @@ class StartingPoints extends Component {
       padding: '20px'
     }
     return (
-      <div className="StartingPoints" style={startingPoints}>
-        <h3>Create Resource</h3>
-        <h4>Starting points:</h4>
-        <ul>
-          <li>Resource template 1</li>
-          <li>Resource template 2</li>
-        </ul>
-      </div>
+      <section>
+        <div className="StartingPoints" style={startingPoints}>
+          <h3>Create Resource</h3>
+          <button className="btn btn-primary btn-small" onClick={this.handleClick} >Import Profile</button>
+          { this.state.showDropZone ? <DropZone showDropZoneCB={this.updateShowDropZone} onDropCB={this.onDrop} filesCB={this.state.files}/> : null }
+        </div>
+      </section>
     )
   }
+}
+
+class DropZone extends Component {
+  render() {
+    return (
+      <section>
+        <p>Drop profile files here or click to select a file:</p>
+        <div>
+          <Dropzone
+            onFileDialogCancel={() => this.props.showDropZoneCB(false)}
+            onDrop={this.props.onDropCB.bind(this)}
+          >
+          </Dropzone>
+          <aside>
+            <h4>Dropped files:</h4>
+            <ul>
+              { this.props.filesCB.map(f => <li key={f.name}>{f.name} - {f.size} bytes</li>) }
+            </ul>
+          </aside>
+        </div>
+      </section>
+    )
+  }
+}
+
+DropZone.propTypes = {
+  onDropCB: PropTypes.func,
+  showDropZoneCB: PropTypes.func,
+  filesCB: PropTypes.array
 }
 
 export default StartingPoints;


### PR DESCRIPTION
- Profile button toggles a div with a DropZone component
- DropZone opens a file dialog onClick, or you can drag and drop a file.
- cancelling the file dialog will toggle-close the DropZone component
- selected file names display at the bottom of the DropZone component section.
- removes the old Starting points text.
- Adds an integration test stub that does not work yet (jest with expect-puppeteer is still not playing nicely with enzyme and the configuration probably needs some more love ¯\_(ツ)_/¯ )