### PR TITLE
Generate RDF from ResourceTemplateForm

### DIFF
--- a/__tests__/actions/index.test.js
+++ b/__tests__/actions/index.test.js
@@ -15,3 +15,18 @@ describe('setItems actions', () => {
   })
 })
 
+describe('getRDF action', () => {
+  it('getRDF should create GENERATE_RDF action', () => {
+    const inputs = { literals: {id: "Instance of",
+                                items: [{ id: 0,
+                                          content: "A Work"}]},
+                     lookups: {id: "http://example.com/1234",
+                               uri: "http://example.com/1234",
+                               label: "An example"}
+    }
+    expect(actions.getRDF(inputs)).toEqual({
+      type: 'GENERATE_RDF',
+      payload: inputs
+    })
+  })
+})

--- a/__tests__/components/editor/ResourceTemplateForm.test.js
+++ b/__tests__/components/editor/ResourceTemplateForm.test.js
@@ -109,14 +109,18 @@ describe('<ResourceTemplateForm />', () => {
   })
 
   describe('a generate RDF button', () => {
-
+    const rtTest = { resourceURI: "http://id.loc.gov/ontologies/bibframe/Work" }
+    const rdf_wrapper = shallow(<ResourceTemplateForm.WrappedComponent
+      {...rtProps}
+      resourceTemplate = {rtTest}
+      handleGenerateRDF = {mockHandleGenerateRDF} />)
     it('renders a Preview RDF button', () =>{
-      expect(wrapper
+      expect(rdf_wrapper
         .find('div > button.btn-success').length)
         .toEqual(1)
     })
     it('displays a pop-up alert when clicked', () => {
-      wrapper.find('div > button.btn-success').simulate('click')
+      rdf_wrapper.find('div > button.btn-success').simulate('click')
       expect(mockHandleGenerateRDF.mock.calls.length).toBe(1)
     })
   })

--- a/__tests__/components/editor/ResourceTemplateForm.test.js
+++ b/__tests__/components/editor/ResourceTemplateForm.test.js
@@ -2,7 +2,7 @@
 
 import React from 'react'
 import ButtonToolbar from 'react-bootstrap/lib/ButtonToolbar'
-import { shallow } from 'enzyme'
+import { mount, shallow } from 'enzyme'
 import InputLiteral from '../../../src/components/editor/InputLiteral'
 import ModalToggle from '../../../src/components/editor/ModalToggle'
 import ResourceTemplateForm from '../../../src/components/editor/ResourceTemplateForm'
@@ -60,7 +60,10 @@ const rtProps = {
 }
 
 describe('<ResourceTemplateForm />', () => {
-  const wrapper = shallow(<ResourceTemplateForm {...rtProps} />)
+  const mockHandleGenerateRDF = jest.fn()
+  const wrapper = shallow(<ResourceTemplateForm.WrappedComponent
+    {...rtProps}
+    handleGenerateRDF = {mockHandleGenerateRDF} />)
 
   it('renders the ResourceTemplateForm text nodes', () => {
     wrapper.find('div.ResourceTemplateForm > p').forEach((node) => {
@@ -102,10 +105,24 @@ describe('<ResourceTemplateForm />', () => {
         expect(node.prop('propertyTemplates')).toBeInstanceOf(Array)
       })
     })
+
+  })
+
+  describe('a generate RDF button', () => {
+
+    it('renders a Preview RDF button', () =>{
+      expect(wrapper
+        .find('div > button.btn-success').length)
+        .toEqual(1)
+    })
+    it('displays a pop-up alert when clicked', () => {
+      wrapper.find('div > button.btn-success').simulate('click')
+      expect(mockHandleGenerateRDF.mock.calls.length).toBe(1)
+    })
   })
 
   it('renders error text when there are no propertyTemplates', () => {
-    const myWrap = shallow(<ResourceTemplateForm propertyTemplates={[]} />)
+    const myWrap = shallow(<ResourceTemplateForm.WrappedComponent propertyTemplates={[]} />)
     const errorEl = myWrap.find('h1')
     expect(errorEl).toHaveLength(1)
     expect(errorEl.text()).toEqual('There are no propertyTemplates - probably an error.')

--- a/__tests__/reducers/rdf.test.js
+++ b/__tests__/reducers/rdf.test.js
@@ -1,0 +1,9 @@
+import generateRDF from '../../src/reducers/rdf'
+
+describe('generateRDF reducer', () => {
+  it('should handle initial state', () => {
+    expect(
+      generateRDF(undefined, {})
+    ).toEqual({ "graph": null})
+  })
+})

--- a/__tests__/reducers/rdf.test.js
+++ b/__tests__/reducers/rdf.test.js
@@ -1,9 +1,93 @@
-import generateRDF from '../../src/reducers/rdf'
+import { generateRDF, addTriples } from '../../src/reducers/rdf'
+
+const N3 = require('n3')
+
+const { DataFactory } = N3
+const { blankNode, defaultGraph } = DataFactory
 
 describe('generateRDF reducer', () => {
   it('should handle initial state', () => {
     expect(
-      generateRDF(undefined, {})
-    ).toEqual({ "graph": null})
+      generateRDF(null, {})
+    ).toEqual( null )
   })
+
+  it('should generate a triple that has a blank-node subject with a BIBFRAME Instance Type', () => {
+    let action = { type: 'GENERATE_RDF',
+      payload: {
+        literals: { formData: []},
+        lookups: { formData: []},
+        type: 'http://id.loc.gov/ontologies/bibframe/Instance'
+      }
+    }
+    let graph = generateRDF(null, action)['graph']
+    graph.end((error, result) => {
+      expect( result ).toBe(`@prefix bf: <http://id.loc.gov/ontologies/bibframe/>.
+
+    _:n3-0 a bf:Instance.`)
+    })
+  })
+})
+
+describe('addTriples function', () => {
+
+  it('throws an error if missing parameters',
+    () => {
+    expect(
+      addTriples
+    ).toThrowError(TypeError)
+  })
+
+  it('does not add triple if resourceTemplate ID is null', () => {
+    const subject = blankNode()
+    const graph = N3.Store()
+    addTriples(subject, [], null, null, graph)
+    expect(graph.size).toBe(0)
+  })
+
+  it('adds triple with a literal for the object', () => {
+    const formData = [
+      { id: "http://id.loc.gov/ontologies/bibframe/responsibilityStatement",
+        rtId: "resourceTemplate:bf2:Monograph:Instance",
+        items: [{
+          id: 0,
+          content: "A test string"
+        }]}
+    ]
+    const subject = blankNode()
+    const graph = N3.Store()
+    addTriples(subject,
+      formData,
+      "resourceTemplate:bf2:Monograph:Instance",
+      'content',
+      graph)
+    const object = graph.getObjects(subject, null, null)[0]
+    expect(graph.size).toBe(1)
+    expect(object.id).toMatch("A test string")
+  })
+
+  it('adds a triple with a URI for the object', () => {
+    const monograph = "http://id.loc.gov/vocabulary/issuance/mono"
+    const formData = [
+      { id: "http://id.loc.gov/ontologies/bibframe/issuance",
+        rtId: "resourceTemplate:bf2:Monograph:Instance",
+        items: [{
+          id: monograph,
+          uri: monograph,
+          label: "single unit"
+        }]}
+    ]
+    const subject = blankNode()
+    const graph = N3.Store()
+    addTriples(subject,
+      formData,
+      "resourceTemplate:bf2:Monograph:Instance",
+      'uri',
+      graph)
+    const object = graph.getObjects(subject, null, null)[0]
+    expect(graph.size).toBe(1)
+    expect(object.id).toMatch(monograph)
+  })
+
+
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -9899,6 +9899,11 @@
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
     },
+    "n3": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/n3/-/n3-1.0.2.tgz",
+      "integrity": "sha512-zPdiX4N9fFFKoDi+DKawy1hRbStxNm1TVtyQh6IV+L1+m8GN6NBHSFy4Hw9sOanbezo28YfhS/ys/+INHT67iA=="
+    },
     "nan": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.0.tgz",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "express": "^4.16.4",
     "identity-obj-proxy": "^3.0.0",
     "merge": "^1.2.1",
+    "n3": "^1.0.2",
     "react": "^16.6.3",
     "react-bootstrap": "^0.32.4",
     "react-bootstrap-typeahead": "^3.2.4",

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -12,3 +12,8 @@ export const changeSelections = item => ({
   type: 'CHANGE_SELECTIONS',
   payload: item
 })
+
+export const getRDF = inputs => ({
+  type: 'GENERATE_RDF',
+  payload: inputs
+})

--- a/src/components/editor/InputListLOC.jsx
+++ b/src/components/editor/InputListLOC.jsx
@@ -33,7 +33,8 @@ class
   setPayLoad(items) {
     let payload = {
       id: this.props.propertyTemplate.propertyURI,
-      items: items
+      items: items,
+      rtId: this.props.rtId
     }
     this.props.handleSelectedChange(payload)
   }

--- a/src/components/editor/InputLiteral.jsx
+++ b/src/components/editor/InputLiteral.jsx
@@ -25,10 +25,12 @@ export class InputLiteral extends Component {
     this.lastId = -1
   }
 
+
   handleFocus(event) {
     document.getElementById(event.target.id).focus()
   }
-  
+
+
   handleChange(event) {
     const usr_input = event.target.value
     this.setState({ content_add: usr_input })
@@ -63,6 +65,7 @@ export class InputLiteral extends Component {
       }
       const user_input = {
         id: this.props.propertyTemplate.propertyURI,
+        rtId: this.props.rtId,
         items: userInputArray
       }
       this.props.handleMyItemsChange(user_input)
@@ -81,14 +84,14 @@ export class InputLiteral extends Component {
       id: idToRemove, label: labelToRemove
     })
   }
-  
+
   checkMandatoryRepeatable() {
      if (this.props.propertyTemplate.mandatory == "true") {
       if (this.props.formData == undefined) return true
       const inputLength = (this.props.formData.items).length
       if (inputLength > 0) {
         return false
-      } 
+      }
       else {
         return true
       }
@@ -105,7 +108,7 @@ export class InputLiteral extends Component {
         return <div
                 id="userInput"
                 key = {obj.id}
-                  > 
+                  >
                   {obj.content}
 
                   <button
@@ -119,7 +122,7 @@ export class InputLiteral extends Component {
                   </button>
                 </div>
       })
-    
+
     return elements
   }
 
@@ -140,14 +143,14 @@ export class InputLiteral extends Component {
           />
           {this.makeAddedList()}
         </label>
-        
+
       </div>
     )
   }
 }
 
 InputLiteral.propTypes = {
-  id: PropTypes.number.isRequired,
+  id: PropTypes.number,
   propertyTemplate: PropTypes.shape({
     propertyLabel: PropTypes.string.isRequired,
     propertyURI: PropTypes.string.isRequired,
@@ -162,7 +165,8 @@ InputLiteral.propTypes = {
     items: PropTypes.array
   }),
   handleMyItemsChange: PropTypes.func,
-  handleRemoveItem: PropTypes.func
+  handleRemoveItem: PropTypes.func,
+  rtId: PropTypes.string.isRequired
 }
 
 const mapStatetoProps = (state, props) => {
@@ -174,7 +178,7 @@ const mapStatetoProps = (state, props) => {
 const mapDispatchtoProps = dispatch => ({
   handleMyItemsChange(user_input){
     dispatch(setItems(user_input))
-  }, 
+  },
   handleRemoveItem(id){
     dispatch(removeItem(id))
   }

--- a/src/components/editor/InputLookupQA.jsx
+++ b/src/components/editor/InputLookupQA.jsx
@@ -64,8 +64,9 @@ class InputLookupQA extends Component {
           }}
           onChange={selected => {
             let payload = {
-                id: this.props.propertyTemplate.propertyLabel,
-                items: selected
+                id: this.props.propertyTemplate.propertyURI,
+                items: selected,
+                rtId: this.props.rtId
               }
               this.props.handleSelectedChange(payload)
             }

--- a/src/components/editor/ResourceTemplate.jsx
+++ b/src/components/editor/ResourceTemplate.jsx
@@ -22,11 +22,9 @@ class ResourceTemplate extends Component {
       if(rtd !== undefined) {
         json = JSON.parse(rtd)
         result = json['Profile']['resourceTemplates'] // from the profile editor
-        console.info(`Using resource templates from profile: ${json['Profile'].id}`)
       }
       else {
         result = [getResourceTemplate(this.props.resourceTemplateId)]
-        console.info(`Using resource template: ${this.props.resourceTemplateId}`)
       }
       return result
     }
@@ -51,6 +49,7 @@ class ResourceTemplate extends Component {
                   <ResourceTemplateForm
                     propertyTemplates = {rt.propertyTemplates}
                     resourceTemplate = {rt}
+                    rtId = {rt.id}
                   />
                 <h4>END ResourceTemplate</h4>
               </div>

--- a/src/components/editor/ResourceTemplateForm.jsx
+++ b/src/components/editor/ResourceTemplateForm.jsx
@@ -9,11 +9,8 @@ import InputLiteral from './InputLiteral'
 import InputListLOC from './InputListLOC'
 import InputLookupQA from './InputLookupQA'
 import ModalToggle from './ModalToggle'
-<<<<<<< HEAD
 import lookupConfig from '../../../static/spoofedFilesFromServer/fromSinopiaServer/lookupConfig.json'
-=======
 import { getRDF } from '../../actions/index'
->>>>>>> d4220fd... RDF reducer with generateRDF action, displays literals and URIs from
 const { getResourceTemplate } = require('../../sinopiaServerSpoof.js')
 
 class ResourceTemplateForm extends Component {
@@ -109,17 +106,17 @@ class ResourceTemplateForm extends Component {
 
                   if (listComponent === 'list'){
                     return (
-                      <InputListLOC propertyTemplate = {pt} lookupConfig = {lookupConfigItem} key = {index} />
+                      <InputListLOC propertyTemplate = {pt} lookupConfig = {lookupConfigItem} key = {index} rtId = {this.props.rtId} />
                     )
                   }
                   else if (listComponent ===  'lookup'){
                     return(
-                      <InputLookupQA propertyTemplate = {pt} lookupConfig = {lookupConfigItem} key = {index} />
+                      <InputLookupQA propertyTemplate = {pt} lookupConfig = {lookupConfigItem} key = {index} rtId = {this.props.rtId} />
                     )
                   }
                   else if(pt.type == 'literal'){
                     return(
-                      <InputLiteral propertyTemplate = {pt} key = {index} id = {index} {this.props.rtId} />
+                      <InputLiteral propertyTemplate = {pt} key = {index} id = {index} rtId = {this.props.rtId} />
                     )
                   }
                   else if (isResourceWithValueTemplateRefs) {

--- a/src/components/editor/ResourceTemplateForm.jsx
+++ b/src/components/editor/ResourceTemplateForm.jsx
@@ -1,6 +1,7 @@
 // Copyright 2018 Stanford University see Apache2.txt for license
 
 import React, {Component} from 'react'
+import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
 import ButtonGroup from 'react-bootstrap/lib/ButtonGroup'
 import ButtonToolbar from 'react-bootstrap/lib/ButtonToolbar'
@@ -8,7 +9,11 @@ import InputLiteral from './InputLiteral'
 import InputListLOC from './InputListLOC'
 import InputLookupQA from './InputLookupQA'
 import ModalToggle from './ModalToggle'
+<<<<<<< HEAD
 import lookupConfig from '../../../static/spoofedFilesFromServer/fromSinopiaServer/lookupConfig.json'
+=======
+import { getRDF } from '../../actions/index'
+>>>>>>> d4220fd... RDF reducer with generateRDF action, displays literals and URIs from
 const { getResourceTemplate } = require('../../sinopiaServerSpoof.js')
 
 class ResourceTemplateForm extends Component {
@@ -17,7 +22,16 @@ class ResourceTemplateForm extends Component {
     this.rtModalButton = this.rtModalButton.bind(this)
     this.resourceTemplateButtons = this.resourceTemplateButtons.bind(this)
     this.defaultValues = this.defaultValues.bind(this)
+    this.previewRDF = this.previewRDF.bind(this)
     this.defaultValues()
+  }
+
+  previewRDF = () => {
+    const inputs = {}
+    inputs['literals'] = this.props.literals
+    inputs['lookups'] = this.props.lookups
+    // TODO: Add Modal to inputs
+    this.props.handleGenerateRDF(inputs)
   }
 
   rtModalButton = (rtId) => {
@@ -122,6 +136,10 @@ class ResourceTemplateForm extends Component {
                 })}
               </div>
             <p>END ResourceTemplateForm</p>
+            <button
+              type="button"
+              className="btn btn-success btn-sm"
+              onClick={this.previewRDF}>Preview RDF</button>
           </div>
         </form>
       )
@@ -130,8 +148,24 @@ class ResourceTemplateForm extends Component {
 }
 
 ResourceTemplateForm.propTypes = {
-  propertyTemplates: PropTypes.arrayOf(PropTypes.object).isRequired,
-  lookupConfig: PropTypes.object
+  literals: PropTypes.array.isRequired,
+  lookups: PropTypes.array.isRequired,
+  handleGenerateRDF: PropTypes.func.isRequired,
+  propertyTemplates: PropTypes.arrayOf(PropTypes.object).isRequired
 }
 
-export default ResourceTemplateForm
+const mapStateToProps = (state) => {
+  return {
+    literals: state.literal,
+    lookups: state.lookups
+  }
+}
+
+const mapDispatchToProps = dispatch => (
+  {
+  handleGenerateRDF(inputs){
+    dispatch(getRDF(inputs))
+  }
+})
+
+export default connect(mapStateToProps, mapDispatchToProps)(ResourceTemplateForm)

--- a/src/components/editor/ResourceTemplateForm.jsx
+++ b/src/components/editor/ResourceTemplateForm.jsx
@@ -30,16 +30,19 @@ class ResourceTemplateForm extends Component {
     const inputs = {}
     inputs['literals'] = this.props.literals
     inputs['lookups'] = this.props.lookups
+    inputs['rtId'] = this.props.rtId
+    inputs['type'] = this.props.resourceTemplate.resourceURI
     // TODO: Add Modal to inputs
     this.props.handleGenerateRDF(inputs)
   }
 
-  rtModalButton = (rtId) => {
+  rtModalButton = (rtId, rtType) => {
     let resourceTemplate = getResourceTemplate(rtId)
     return (
       <ModalToggle
         key={rtId}
         rtId={rtId}
+        rtType={rtType}
         buttonLabel={resourceTemplate.resourceLabel}
         propertyTemplates ={resourceTemplate.propertyTemplates}
       />
@@ -116,7 +119,7 @@ class ResourceTemplateForm extends Component {
                   }
                   else if(pt.type == 'literal'){
                     return(
-                      <InputLiteral propertyTemplate = {pt} key = {index} id = {index} />
+                      <InputLiteral propertyTemplate = {pt} key = {index} id = {index} {this.props.rtId} />
                     )
                   }
                   else if (isResourceWithValueTemplateRefs) {
@@ -148,10 +151,12 @@ class ResourceTemplateForm extends Component {
 }
 
 ResourceTemplateForm.propTypes = {
-  literals: PropTypes.array.isRequired,
-  lookups: PropTypes.array.isRequired,
+  literals: PropTypes.oneOfType([PropTypes.array, PropTypes.object]).isRequired,
+  lookups: PropTypes.oneOfType([PropTypes.array, PropTypes.object]).isRequired,
   handleGenerateRDF: PropTypes.func.isRequired,
-  propertyTemplates: PropTypes.arrayOf(PropTypes.object).isRequired
+  propertyTemplates: PropTypes.arrayOf(PropTypes.object).isRequired,
+  resourceTemplate: PropTypes.object.isRequired,
+  rtId: PropTypes.string.isRequired
 }
 
 const mapStateToProps = (state) => {

--- a/src/components/editor/ResourceTemplateModal.jsx
+++ b/src/components/editor/ResourceTemplateModal.jsx
@@ -35,7 +35,8 @@ class ResourceTemplateModal extends Component {
           <Modal.Title>{rtId}</Modal.Title>
         </Modal.Header>
         <Modal.Body>
-          <ResourceTemplateForm propertyTemplates = {this.props.propertyTemplates} />
+          <ResourceTemplateForm propertyTemplates = {this.props.propertyTemplates}
+            rtType = {this.props.rtType} />
         </Modal.Body>
         <Modal.Footer>
           <Button onClick={this.handleClose}>Cancel</Button>

--- a/src/components/editor/ResourceTemplateModal.jsx
+++ b/src/components/editor/ResourceTemplateModal.jsx
@@ -35,8 +35,7 @@ class ResourceTemplateModal extends Component {
           <Modal.Title>{rtId}</Modal.Title>
         </Modal.Header>
         <Modal.Body>
-          <ResourceTemplateForm propertyTemplates = {this.props.propertyTemplates}
-            rtType = {this.props.rtType} />
+          <ResourceTemplateForm propertyTemplates = {this.props.propertyTemplates} />
         </Modal.Body>
         <Modal.Footer>
           <Button onClick={this.handleClose}>Cancel</Button>

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,7 +1,10 @@
 import { combineReducers } from 'redux'
 import literal from './literal'
 import lookups from './lookups'
+import generateRDF from './rdf'
 
 export default combineReducers({
-  literal, lookups
+  literal,
+  lookups,
+  generateRDF
 })

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,7 +1,7 @@
 import { combineReducers } from 'redux'
 import literal from './literal'
 import lookups from './lookups'
-import generateRDF from './rdf'
+import { generateRDF } from './rdf'
 
 export default combineReducers({
   literal,

--- a/src/reducers/rdf.js
+++ b/src/reducers/rdf.js
@@ -1,0 +1,48 @@
+const N3 = require('n3')
+
+const { DataFactory } = N3
+const { namedNode, literal, blankNode, quad } = DataFactory
+
+const DEFAULT_STATE = {
+  graph: null
+}
+
+const generateMyRDF = (state, action) => {
+  const writer = N3.Writer({
+    prefixes: { bf: 'http://id.loc.gov/ontologies/bibframe/'}
+  })
+  const subject = blankNode()
+  action.payload.literals.formData.forEach(field => {
+    field.items.forEach(item => {
+      if(item.hasOwnProperty('content')) {
+        writer.addQuad(
+          quad(subject, namedNode(field.id), literal(item.content))
+        )
+      }
+    })
+  })
+  action.payload.lookups.formData.forEach(field => {
+    field.items.forEach(item => {
+      if(item.hasOwnProperty('uri')) {
+        writer.addQuad(subject, namedNode(field.id), namedNode(item.uri))
+      }
+    })
+  })
+  // Temp solution displays RDF in Turtle, likely use a Modal Component
+  // to display graph in multiple formats.
+  writer.end((error, result) => {
+    alert(result)
+    return { ...state, graph: result }
+  })
+}
+
+const generateRDF = (state=DEFAULT_STATE, action) => {
+  switch(action.type) {
+    case 'GENERATE_RDF':
+      return generateMyRDF(state, action)
+    default:
+      return state
+  }
+}
+
+export default generateRDF


### PR DESCRIPTION
Starts support for generating a simple RDF graph for components and props in a `ResourceTemplateForm`.  

- New reducer generates RDF based on the based on the Redux stores for `InputList`, `InputLiteral`, and `InputLookup`. 
- Adds a new key, **rtId** for storing the `ResourceTemplate` id in `InputList`, `InputLiteral`, and `InputLookup`, this is used to scope the generation of triples to a single ResourceTemplate
- Uses [N3](https://github.com/rdfjs/N3.js) JS module for RDF manipulation. 
- New Preview RDF button displays a JS alert with the serialized graph in Turtle format. 
- All subjects are blank nodes
### New Preview RDF Button
<img width="744" alt="screen shot 2019-01-11 at 12 25 41 pm" src="https://user-images.githubusercontent.com/71847/51055096-0edda900-159c-11e9-8f23-efa7f12bc2c6.png">

### Alert with RDF Serialization in Turtle
<img width="557" alt="screen shot 2019-01-11 at 9 57 47 am" src="https://user-images.githubusercontent.com/71847/51055113-20bf4c00-159c-11e9-83a1-b15eba6dff7e.png">

## Know Issues and Future Work
- Only works for `ResourceTemplateForm`s that are **NOT** embedded in a modal; issue is ticketed in #281. 
- Once #281 is completed, will need to return the blank node or uri to the calling `ResourceTemplateForm` to complete the triple, ticketed in #282
- Should use the N3 Store instead of a N3 writer for adding triples to the graphs. Using `N3.Store` may make it easier to send RDF back to Trellis in the Sinopia Server. Ticket #280 
- Need to either mint a new URI from a Sinopia Server call or create a dummy URI for client-side RDF subjects for those `ResourceTemplateForm`s that need a URI for the subject. Ticket #283


