### PR TITLE
Update Proptype id

### DIFF
--- a/src/components/editor/InputLiteral.jsx
+++ b/src/components/editor/InputLiteral.jsx
@@ -147,7 +147,7 @@ export class InputLiteral extends Component {
 }
 
 InputLiteral.propTypes = {
-  id: PropTypes.string.isRequired,
+  id: PropTypes.number.isRequired,
   propertyTemplate: PropTypes.shape({
     propertyLabel: PropTypes.string.isRequired,
     propertyURI: PropTypes.string.isRequired,


### PR DESCRIPTION
fixes :
checkPropTypes.js:19 Warning: Failed prop type: Invalid prop `id` of type `number` supplied to `InputLiteral`, expected `string`.