### PR TITLE
Editor.jsx: update heading to be closer to what we eventually want

### DIFF
--- a/src/components/editor/Editor.jsx
+++ b/src/components/editor/Editor.jsx
@@ -26,8 +26,7 @@ class Editor extends Component {
     return(
       <div id="editor">
         <Header triggerEditorMenu={this.props.triggerHandleOffsetMenu}/>
-        <h1> Editor Page </h1>
-        <p>The selected resource template is <strong>{this.state.resourceTemplateId}</strong></p>
+        <h1>[Clone|Edit] title.of.resource</h1>
         <StartingPoints setResourceTemplateCallback={this.setResourceTemplates}/>
         <ResourceTemplate
           resourceTemplateId = {this.state.resourceTemplateId}


### PR DESCRIPTION
- Gets rid of hardcoded statement about which resource template was open (it never changed no matter what was opened)
- Make the top h1 of the page closer to what Astrid designed:

![image](https://user-images.githubusercontent.com/96775/51053560-d6839e00-158e-11e9-9d83-fadf3be5fe86.png)


# Before

![image](https://user-images.githubusercontent.com/96775/51053450-8573aa00-158e-11e9-8385-85e4b36e7652.png)

# After

![image](https://user-images.githubusercontent.com/96775/51053472-9a503d80-158e-11e9-9769-895c2a6fdb4b.png)
