### PR TITLE
BFF does JSON schema validation of resource template on import

### DIFF
--- a/__tests__/components/editor/StartingPoints.test.js
+++ b/__tests__/components/editor/StartingPoints.test.js
@@ -5,15 +5,23 @@ import { shallow, mount } from 'enzyme'
 import StartingPoints from '../../../src/components/editor/StartingPoints'
 import DropZone from '../../../src/components/editor/StartingPoints'
 
-const jsdom = require("jsdom");
+const jsdom = require("jsdom")
+require('isomorphic-fetch')
 
-setUpDomEnvironment();
+setUpDomEnvironment()
 
 describe('<StartingPoints />', () => {
   let wrapper = shallow(<StartingPoints />)
 
   it('Has a div with headings', () => {
     expect(wrapper.find('div > h3').text()).toEqual('Create Resource')
+  })
+
+  it('fetches JSON schemas once (for validation of resourceTemplate)', () => {
+    const instance = wrapper.instance()
+    jest.spyOn(instance, 'fetchSchemaObjectsPromise')
+    instance.componentDidMount()
+    expect(instance.fetchSchemaObjectsPromise).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1392,10 +1392,9 @@
       }
     },
     "ajv": {
-      "version": "6.5.4",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.4.tgz",
-      "integrity": "sha512-4Wyjt8+t6YszqaXnLDfMmG/8AlO5Zbcsy3ATHncCzjW/NoPzAId8AK6749Ybjmdt+kUY1gP60fCu46oDxPv/mg==",
-      "dev": true,
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.2.tgz",
+      "integrity": "sha512-FBHEW6Jf5TB9MGBgUUA9XHkTbjXYfAUjY43ACMfmdMRHniyoMHjHjzD50OK8LGDWQwp4rWEsIq5kEqq7rvIM1g==",
       "requires": {
         "fast-deep-equal": "^2.0.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -5514,8 +5513,7 @@
     "fast-deep-equal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-      "dev": true
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
     },
     "fast-glob": {
       "version": "2.2.3",
@@ -5854,8 +5852,7 @@
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-      "dev": true
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -5989,7 +5986,7 @@
     },
     "finalhandler": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
       "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
       "requires": {
         "debug": "2.6.9",
@@ -9211,8 +9208,7 @@
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -10998,8 +10994,7 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "puppeteer": {
       "version": "1.10.0",
@@ -13993,7 +13988,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
-      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.8",
     "@fortawesome/free-solid-svg-icons": "^5.5.0",
     "@fortawesome/react-fontawesome": "^0.1.3",
+    "ajv": "^6.6.2",
     "babel-core": "^7.0.0-bridge.0",
     "event-stream": "3.3.4",
     "express": "^4.16.4",

--- a/src/components/editor/StartingPoints.jsx
+++ b/src/components/editor/StartingPoints.jsx
@@ -3,6 +3,8 @@
 import React, { Component }  from 'react'
 import Dropzone from 'react-dropzone'
 import PropTypes from 'prop-types'
+const Ajv = require('ajv') // JSON schema validation
+const util = require('util') // for JSON schema validation errors
 
 class StartingPoints extends Component {
   constructor() {
@@ -15,16 +17,35 @@ class StartingPoints extends Component {
     }
   }
 
+  componentDidMount() {
+    this.fetchSchemaObjectsPromise()
+      .then(schemaObjs => {
+        this.ajv = new Ajv({
+          schemas: schemaObjs,
+          allErrors: true,
+          verbose: true
+        })
+      })
+      .catch(err => {console.error(`componentDidMount: error getting json schemas ${err}`)})
+  }
+
   handleClick() {
     let val = this.state.showDropZone
     this.setState({ showDropZone: !val })
   }
 
   onDropFile(files) {
-    //supplies the json loaded from the profile file
+    // supplies the json loaded from the resource template
     const handleFileRead = () => {
       const content = fileReader.result
-      this.props.setResourceTemplateCallback(content)
+      const valid = this.validateTemplate(JSON.parse(content))
+      if (valid) {
+        this.props.setResourceTemplateCallback(content)
+      }
+      else {
+        // TODO: don't continue on with display of ResourceTemplate component (#295)
+        console.error("ERROR: unable to use template as it isn't valid - we shouldn't display form")
+      }
     }
 
     let fileReader = new window.FileReader()
@@ -39,6 +60,59 @@ class StartingPoints extends Component {
 
   updateShowDropZone = (val) => {
     this.setState({ showDropZone: val })
+  }
+
+  validateTemplate = (template) => {
+    // TODO: get schema $id from template being validated (#294)
+    const valid = this.ajv.validate('https://ld4p.github.io/sinopia/schemas/0.0.1/profile.json', template)
+    // TODO:  indicate template validity to user (#295)
+    console.debug(`resource template is valid? ${valid}`)
+    if (!valid) {
+      // TODO:  indicate template errors to user (#295)
+      console.error(`template isn't valid: ${util.inspect(this.ajv.errors)}`)
+    }
+    return valid
+  }
+
+  // return array of objects - one for each fetched json schema file
+  // TODO: cache the schemas in local storage (#292)
+  fetchSchemaObjectsPromise = () => {
+    // TODO: get schema url from template json ... once it is in the template json (#294)
+    // TODO: recurse to fetch schemas from any $ref urls found in schema?
+    const schemaUrls = [
+      'https://ld4p.github.io/sinopia/schemas/0.0.1/profile.json',
+      'https://ld4p.github.io/sinopia/schemas/0.0.1/resource-templates-array.json',
+      'https://ld4p.github.io/sinopia/schemas/0.0.1/resource-template.json',
+      'https://ld4p.github.io/sinopia/schemas/0.0.1/property-templates-array.json',
+      'https://ld4p.github.io/sinopia/schemas/0.0.1/property-template.json'
+    ]
+    const schemaFetchPromises = []
+    schemaUrls.forEach( (url) => {
+      schemaFetchPromises.push(this.fetchJsonPromise(url))
+    })
+
+    return Promise.all(schemaFetchPromises)
+  }
+
+  fetchJsonPromise = (uri) => {
+    return new Promise((resolve, reject) => {
+      fetch(uri)
+      .then(resp => {
+        if (resp.ok) {
+          resp.json()
+            .then(data => {
+              resolve(data)
+            })
+            .catch(err => { reject(new Error(`Error parsing json schema ${uri} - ${err}`))})
+        }
+        else {
+          reject(new Error(`HTTP error fetching schema: ${resp.status} - ${resp.statusText}`))
+        }
+      })
+      .catch((err) => {
+        reject(new Error(`Error fetching schema ${uri} - ${err}`))
+      })
+    })
   }
 
   render() {


### PR DESCRIPTION
Uses ajv for schema validation of resource template on import.   Results of validation are written to console;  nothing else is changed.

- Tests are incomplete as integration tests are required, and it was non-trivial to untangle that (see #301)  --> hence coverage drop.

Note that we also still need to:
- get schema url/$id from template being validated (#294)
- indicate template validity to user and adjust UX flow (#295)
- cache the schemas in local storage rather than doing a get each time (#292)

Closes #258  (????)