### PR TITLE
Displays a FontAwesome Asterisk when a Property is Mandatory

### DIFF
--- a/__tests__/components/editor/InputListLOC.test.js
+++ b/__tests__/components/editor/InputListLOC.test.js
@@ -45,10 +45,10 @@ describe('<InputList />', () => {
     expect(wrapper.find('#targetComponent').props().required).toBe(false)
   })
 
-  it('displays FontAwesome Asterisk if mandatory from template is true', () => {
+  it('displays RequiredSuperscript if mandatory from template is true', () => {
     wrapper.instance().props.propertyTemplate.mandatory = "true"
     wrapper.instance().forceUpdate()
-    expect(wrapper.find('label > sup').text()).toBe("<FontAwesomeIcon />")
+    expect(wrapper.find('label > RequiredSuperscript')).toBeTruthy()
   })
 
   it('sets the typeahead component multiple attribute according to the repeatable value from the template', () => {

--- a/__tests__/components/editor/InputListLOC.test.js
+++ b/__tests__/components/editor/InputListLOC.test.js
@@ -45,6 +45,12 @@ describe('<InputList />', () => {
     expect(wrapper.find('#targetComponent').props().required).toBe(false)
   })
 
+  it('displays FontAwesome Asterisk if mandatory from template is true', () => {
+    wrapper.instance().props.propertyTemplate.mandatory = "true"
+    wrapper.instance().forceUpdate()
+    expect(wrapper.find('label > sup').text()).toBe("<FontAwesomeIcon />")
+  })
+
   it('sets the typeahead component multiple attribute according to the repeatable value from the template', () => {
     expect(wrapper.find('#targetComponent').props().multiple).toBe(true)
   })

--- a/__tests__/components/editor/InputLiteral.test.js
+++ b/__tests__/components/editor/InputLiteral.test.js
@@ -5,7 +5,7 @@ import { shallow } from 'enzyme'
 import { InputLiteral } from '../../../src/components/editor/InputLiteral'
 
 const plProps = {
-  "propertyTemplate": 
+  "propertyTemplate":
     {
       "propertyLabel": "Instance of",
       "propertyURI": "http://id.loc.gov/ontologies/bibframe/instanceOf",
@@ -17,7 +17,7 @@ const plProps = {
 
 describe('<InputLiteral />', () => {
   const wrapper = shallow(<InputLiteral {...plProps} id={10}/>)
-  
+
   it('contains a label with "Instance of"', () => {
     expect(wrapper.find('label').text()).toBe('Instance of')
   })
@@ -26,12 +26,13 @@ describe('<InputLiteral />', () => {
   })
  it('contains required="true" attribute on input tag when mandatory is true', () => {
     wrapper.instance().props.propertyTemplate.mandatory = "true"
-    wrapper.instance().forceUpdate() /** update plProps with mandatory: "true" **/  
+    wrapper.instance().forceUpdate() /** update plProps with mandatory: "true" **/
     expect(wrapper.find('input').prop('required')).toBeTruthy()
+    expect(wrapper.find('label > sup').text()).toBe("<FontAwesomeIcon />")
   })
   it('contains required="false" attribute on input tag when mandatory is false', () => {
     wrapper.instance().props.propertyTemplate.mandatory = "false"
-    wrapper.instance().forceUpdate()    
+    wrapper.instance().forceUpdate()
     expect(wrapper.find('input').prop('required')).toBeFalsy()
   })
 })
@@ -80,7 +81,7 @@ describe('When the user enters input into field', ()=>{
     expect(mockFormDataFn.mock.calls[1][0]).toEqual(
       {id: "http://id.loc.gov/ontologies/bibframe/instanceOf", items:[{content: 'bar', id: 2}]}
     )
-    mockFormDataFn.mock.calls = [] // reset the redux store to empty    
+    mockFormDataFn.mock.calls = [] // reset the redux store to empty
   })
   it('property template contains repeatable "false", only allowed to add one item to redux', () => {
     mock_wrapper.instance().props.propertyTemplate.repeatable = "false"
@@ -88,11 +89,11 @@ describe('When the user enters input into field', ()=>{
 
     mock_wrapper.find('input').simulate("change", { target: { value: "fooby" }})
     mock_wrapper.find('input').simulate('keypress', {key: 'Enter', preventDefault: () => {}})
-    
+
     mock_wrapper.setProps({formData: { id: "http://id.loc.gov/ontologies/bibframe/instanceOf", items: [{content: "fooby", id: 0}]} })
-  
+
     mock_wrapper.find('input').simulate("change", { target: { value: "bar" }})
-    mock_wrapper.find('input').simulate('keypress', {key: 'Enter', preventDefault: () => {}})    
+    mock_wrapper.find('input').simulate('keypress', {key: 'Enter', preventDefault: () => {}})
 
     expect(mockFormDataFn.mock.calls[0][0]).toEqual(
       {id: "http://id.loc.gov/ontologies/bibframe/instanceOf", items:[{content: 'fooby', id: 3}]}
@@ -100,7 +101,7 @@ describe('When the user enters input into field', ()=>{
     expect(mockFormDataFn.mock.calls[1][0]).toEqual(
       {id: "http://id.loc.gov/ontologies/bibframe/instanceOf", items:[]}
     )
-    mockFormDataFn.mock.calls = [] // reset the redux store to empty    
+    mockFormDataFn.mock.calls = [] // reset the redux store to empty
 
     mock_wrapper.setProps({formData: undefined }) // reset props for next test
   })
@@ -123,7 +124,7 @@ describe('When the user enters input into field', ()=>{
     mock_wrapper.setProps({formData: { id: "http://id.loc.gov/ontologies/bibframe/instanceOf", items: [{content: "foo", id: 4}]} })
     expect(mock_wrapper.find('div#userInput').text()).toEqual('fooX') // contains X as a button to delete the input
     mock_wrapper.setProps({formData: undefined }) // reset props for next test
-    mockFormDataFn.mock.calls = [] // reset the redux store to empty    
+    mockFormDataFn.mock.calls = [] // reset the redux store to empty
   })
 
   it('should call the removeMockDataFn when X is clicked', () => {
@@ -133,5 +134,3 @@ describe('When the user enters input into field', ()=>{
     expect(removeMockDataFn.mock.calls.length).toEqual(1);
   })
 })
-
-  

--- a/__tests__/components/editor/InputLiteral.test.js
+++ b/__tests__/components/editor/InputLiteral.test.js
@@ -28,7 +28,7 @@ describe('<InputLiteral />', () => {
     wrapper.instance().props.propertyTemplate.mandatory = "true"
     wrapper.instance().forceUpdate() /** update plProps with mandatory: "true" **/
     expect(wrapper.find('input').prop('required')).toBeTruthy()
-    expect(wrapper.find('label > sup').text()).toBe("<FontAwesomeIcon />")
+    expect(wrapper.find('label > RequiredSuperscript')).toBeTruthy()
   })
   it('contains required="false" attribute on input tag when mandatory is false', () => {
     wrapper.instance().props.propertyTemplate.mandatory = "false"

--- a/__tests__/components/editor/InputLookupQA.test.js
+++ b/__tests__/components/editor/InputLookupQA.test.js
@@ -38,6 +38,12 @@ describe('<InputLookup />', () => {
     expect(wrapper.find('#lookupComponent').props().required).toBeFalsy()
   })
 
+  it('displays FontAwesome Asterisk if mandatory from template is true', () => {
+    wrapper.instance().props.propertyTemplate.mandatory = "true"
+    wrapper.instance().forceUpdate()
+    expect(wrapper.find('label > sup').text()).toBe("<FontAwesomeIcon />")
+  })
+
   it('sets the typeahead component multiple attribute according to the repeatable property from the template', () => {
     expect(wrapper.find('#lookupComponent').props().multiple).toBeTruthy()
   })

--- a/__tests__/components/editor/InputLookupQA.test.js
+++ b/__tests__/components/editor/InputLookupQA.test.js
@@ -38,10 +38,10 @@ describe('<InputLookup />', () => {
     expect(wrapper.find('#lookupComponent').props().required).toBeFalsy()
   })
 
-  it('displays FontAwesome Asterisk if mandatory from template is true', () => {
+  it('displays RequiredSuperscript if mandatory from template is true', () => {
     wrapper.instance().props.propertyTemplate.mandatory = "true"
     wrapper.instance().forceUpdate()
-    expect(wrapper.find('label > sup').text()).toBe("<FontAwesomeIcon />")
+    expect(wrapper.find('label > RequiredSuperscript')).toBeTruthy()
   })
 
   it('sets the typeahead component multiple attribute according to the repeatable property from the template', () => {

--- a/__tests__/components/editor/RequiredSuperscript.test.js
+++ b/__tests__/components/editor/RequiredSuperscript.test.js
@@ -1,0 +1,15 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import RequiredSuperscript from '../../../src/components/editor/RequiredSuperscript'
+
+describe("<RequiredSuperscript />", () => {
+  const wrapper = shallow(<RequiredSuperscript />)
+
+  it('displays a HTML <sup>', () => {
+    expect(wrapper.find("sup")).toBeTruthy()
+  })
+
+  it('uses FontAwesome Asterisk', () => {
+    expect(wrapper.find('sup > FontAwesomeIcon[className="asterick text-danger"]')).toBeTruthy()
+  })
+})

--- a/__tests__/components/editor/ResourceTemplateForm.test.js
+++ b/__tests__/components/editor/ResourceTemplateForm.test.js
@@ -41,7 +41,8 @@ const rtProps = {
         "valueTemplateRefs": [
           "resourceTemplate:bf2:Note"
         ]
-      }
+      },
+      "mandatory": "true"
     },
     {
       "propertyLabel": "YAM (yet another modal)",
@@ -103,6 +104,11 @@ describe('<ResourceTemplateForm />', () => {
         expect(node.prop('buttonLabel')).toEqual('Note')
         expect(node.prop('rtId')).toEqual('resourceTemplate:bf2:Note')
         expect(node.prop('propertyTemplates')).toBeInstanceOf(Array)
+      })
+    })
+    it('displays a FontAwesome Asterisk for a mandatory property', () => {
+      wrapper.find('div.ResourceTemplateForm ButtonToolbar > div > b > sup').forEach((node) => {
+        expect(node.text()).toBe("<FontAwesomeIcon />")
       })
     })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5411,7 +5411,8 @@
     "expect-puppeteer": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/expect-puppeteer/-/expect-puppeteer-3.5.1.tgz",
-      "integrity": "sha512-SB5JeJCXWSRcUK39fBJlCA6qnVt3BG1/M9vYZ+XYq8gY9jab9Jm4BztsrAwDTWca1L+O/7dRYrG2BPziRtjh+Q=="
+      "integrity": "sha512-SB5JeJCXWSRcUK39fBJlCA6qnVt3BG1/M9vYZ+XYq8gY9jab9Jm4BztsrAwDTWca1L+O/7dRYrG2BPziRtjh+Q==",
+      "dev": true
     },
     "express": {
       "version": "4.16.4",
@@ -5997,7 +5998,7 @@
     },
     "finalhandler": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
       "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
       "requires": {
         "debug": "2.6.9",

--- a/src/components/editor/InputListLOC.jsx
+++ b/src/components/editor/InputListLOC.jsx
@@ -3,8 +3,8 @@
 import React, { Component } from 'react';
 import { Typeahead } from 'react-bootstrap-typeahead'
 import PropTypes from 'prop-types'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faAsterisk } from '@fortawesome/free-solid-svg-icons'
+import RequiredSuperscript from './RequiredSuperscript'
+
 import { connect } from 'react-redux'
 import { changeSelections } from '../../actions/index'
 
@@ -43,7 +43,7 @@ class
 
   mandatorySuperscript() {
     if (JSON.parse(this.props.propertyTemplate.mandatory)) {
-      return <sup><FontAwesomeIcon className="asterick text-danger" icon={faAsterisk} /></sup>
+      return <RequiredSuperscript />
     }
   }
 

--- a/src/components/editor/InputListLOC.jsx
+++ b/src/components/editor/InputListLOC.jsx
@@ -3,6 +3,8 @@
 import React, { Component } from 'react';
 import { Typeahead } from 'react-bootstrap-typeahead'
 import PropTypes from 'prop-types'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faAsterisk } from '@fortawesome/free-solid-svg-icons'
 import { connect } from 'react-redux'
 import { changeSelections } from '../../actions/index'
 
@@ -39,6 +41,12 @@ class
     this.props.handleSelectedChange(payload)
   }
 
+  mandatorySuperscript() {
+    if (JSON.parse(this.props.propertyTemplate.mandatory)) {
+      return <sup><FontAwesomeIcon className="asterick text-danger" icon={faAsterisk} /></sup>
+    }
+  }
+
   render() {
     let lookupUri, isMandatory, isRepeatable
     try {
@@ -65,6 +73,7 @@ class
     return (
       <div>
         <label htmlFor="targetComponent">{this.props.propertyTemplate.propertyLabel}
+        {this.mandatorySuperscript()}
         <Typeahead
           onFocus={() => {
             this.setState({isLoading: true})

--- a/src/components/editor/InputLiteral.jsx
+++ b/src/components/editor/InputLiteral.jsx
@@ -3,11 +3,8 @@
 import React, {Component} from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faAsterisk } from '@fortawesome/free-solid-svg-icons'
 import { setItems, removeItem } from '../../actions/index'
-
-
+import RequiredSuperscript from './RequiredSuperscript'
 
 // Redux recommends exporting the unconnected component for unit tests.
 export class InputLiteral extends Component {
@@ -106,7 +103,7 @@ export class InputLiteral extends Component {
 
   mandatorySuperscript() {
     if (this.props.propertyTemplate.mandatory === "true") {
-      return <sup><FontAwesomeIcon className="asterick text-danger" icon={faAsterisk} /></sup>
+      return <RequiredSuperscript />
     }
   }
 

--- a/src/components/editor/InputLiteral.jsx
+++ b/src/components/editor/InputLiteral.jsx
@@ -3,6 +3,8 @@
 import React, {Component} from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faAsterisk } from '@fortawesome/free-solid-svg-icons'
 import { setItems, removeItem } from '../../actions/index'
 
 
@@ -17,6 +19,7 @@ export class InputLiteral extends Component {
     this.handleClick = this.handleClick.bind(this)
     this.handleFocus = this.handleFocus.bind(this)
     this.checkMandatoryRepeatable = this.checkMandatoryRepeatable.bind(this)
+    this.mandatorySuperscript = this.mandatorySuperscript.bind(this)
     this.notRepeatable = this.notRepeatable.bind(this)
     this.addUserInput = this.addUserInput.bind(this)
     this.state = {
@@ -101,6 +104,12 @@ export class InputLiteral extends Component {
      }
   }
 
+  mandatorySuperscript() {
+    if (this.props.propertyTemplate.mandatory === "true") {
+      return <sup><FontAwesomeIcon className="asterick text-danger" icon={faAsterisk} /></sup>
+    }
+  }
+
   makeAddedList() {
     let formInfo = this.props.formData
       if (formInfo == undefined) return
@@ -131,6 +140,7 @@ export class InputLiteral extends Component {
       <div className="form-group">
         <label htmlFor={"typeLiteral" + this.props.id}>
           {this.props.propertyTemplate.propertyLabel}
+          {this.mandatorySuperscript()}
           <input
             required={this.checkMandatoryRepeatable()}
             className="form-control"

--- a/src/components/editor/InputLookupQA.jsx
+++ b/src/components/editor/InputLookupQA.jsx
@@ -3,8 +3,7 @@ import React, { Component } from 'react'
 import { asyncContainer, Typeahead } from 'react-bootstrap-typeahead'
 import PropTypes from 'prop-types'
 import Swagger from 'swagger-client'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faAsterisk } from '@fortawesome/free-solid-svg-icons'
+import RequiredSuperscript from './RequiredSuperscript'
 import { connect } from 'react-redux'
 import { changeSelections } from '../../actions/index'
 
@@ -21,7 +20,7 @@ class InputLookupQA extends Component {
 
   mandatorySuperscript() {
     if (JSON.parse(this.props.propertyTemplate.mandatory)) {
-      return <sup><FontAwesomeIcon className="asterick text-danger" icon={faAsterisk} /></sup>
+      return <RequiredSuperscript />
     }
   }
 

--- a/src/components/editor/InputLookupQA.jsx
+++ b/src/components/editor/InputLookupQA.jsx
@@ -3,6 +3,8 @@ import React, { Component } from 'react'
 import { asyncContainer, Typeahead } from 'react-bootstrap-typeahead'
 import PropTypes from 'prop-types'
 import Swagger from 'swagger-client'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faAsterisk } from '@fortawesome/free-solid-svg-icons'
 import { connect } from 'react-redux'
 import { changeSelections } from '../../actions/index'
 
@@ -11,8 +13,15 @@ const AsyncTypeahead = asyncContainer(Typeahead)
 class InputLookupQA extends Component {
   constructor(props) {
     super(props)
+    this.mandatorySuperscript = this.mandatorySuperscript.bind(this)
     this.state = {
       isLoading: false
+    }
+  }
+
+  mandatorySuperscript() {
+    if (JSON.parse(this.props.propertyTemplate.mandatory)) {
+      return <sup><FontAwesomeIcon className="asterick text-danger" icon={faAsterisk} /></sup>
     }
   }
 
@@ -42,6 +51,7 @@ class InputLookupQA extends Component {
     return (
       <div>
         <label htmlFor="lookupComponent">{this.props.propertyTemplate.propertyLabel}
+        {this.mandatorySuperscript()}
         <AsyncTypeahead id="lookupComponent"
           onSearch={query => {
             this.setState({isLoading: true});

--- a/src/components/editor/RequiredSuperscript.jsx
+++ b/src/components/editor/RequiredSuperscript.jsx
@@ -1,0 +1,20 @@
+import React, {Component} from 'react'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faAsterisk } from '@fortawesome/free-solid-svg-icons'
+
+export class RequiredSuperscript extends Component {
+
+  constructor(props) {
+    super(props)
+  }
+
+  render() {
+    return (<sup>
+              <FontAwesomeIcon className="asterick text-danger"
+                               icon={faAsterisk} />
+           </sup>)
+  }
+}
+
+
+export default RequiredSuperscript;

--- a/src/components/editor/ResourceTemplateForm.jsx
+++ b/src/components/editor/ResourceTemplateForm.jsx
@@ -5,11 +5,10 @@ import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
 import ButtonGroup from 'react-bootstrap/lib/ButtonGroup'
 import ButtonToolbar from 'react-bootstrap/lib/ButtonToolbar'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faAsterisk } from '@fortawesome/free-solid-svg-icons'
 import InputLiteral from './InputLiteral'
 import InputListLOC from './InputListLOC'
 import InputLookupQA from './InputLookupQA'
+import RequiredSuperscript from './RequiredSuperscript'
 import ModalToggle from './ModalToggle'
 import lookupConfig from '../../../static/spoofedFilesFromServer/fromSinopiaServer/lookupConfig.json'
 import { getRDF } from '../../actions/index'
@@ -60,7 +59,7 @@ class ResourceTemplateForm extends Component {
 
   mandatorySuperscript = (propMandatory) => {
     if (JSON.parse(propMandatory)) {
-      return <sup><FontAwesomeIcon className="asterick text-danger" icon={faAsterisk} /></sup>
+      return <RequiredSuperscript />
     }
   }
 

--- a/src/components/editor/ResourceTemplateForm.jsx
+++ b/src/components/editor/ResourceTemplateForm.jsx
@@ -5,6 +5,8 @@ import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
 import ButtonGroup from 'react-bootstrap/lib/ButtonGroup'
 import ButtonToolbar from 'react-bootstrap/lib/ButtonToolbar'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faAsterisk } from '@fortawesome/free-solid-svg-icons'
 import InputLiteral from './InputLiteral'
 import InputListLOC from './InputListLOC'
 import InputLookupQA from './InputLookupQA'
@@ -20,6 +22,7 @@ class ResourceTemplateForm extends Component {
     this.resourceTemplateButtons = this.resourceTemplateButtons.bind(this)
     this.defaultValues = this.defaultValues.bind(this)
     this.previewRDF = this.previewRDF.bind(this)
+    this.mandatorySuperscript = this.mandatorySuperscript.bind(this)
     this.defaultValues()
   }
 
@@ -53,6 +56,12 @@ class ResourceTemplateForm extends Component {
       buttons.push(<ButtonGroup key={`${rtId}-${i}`}>{this.rtModalButton(rtId)}</ButtonGroup>)
     })
     return buttons
+  }
+
+  mandatorySuperscript = (propMandatory) => {
+    if (JSON.parse(propMandatory)) {
+      return <sup><FontAwesomeIcon className="asterick text-danger" icon={faAsterisk} /></sup>
+    }
   }
 
   defaultValues = () => {
@@ -124,7 +133,7 @@ class ResourceTemplateForm extends Component {
                     return (
                       <ButtonToolbar key={index}>
                         <div>
-                          <b>{pt.propertyLabel}</b>
+                          <b>{pt.propertyLabel} {this.mandatorySuperscript(pt.mandatory)}</b>
                         </div>
                         {this.resourceTemplateButtons(pt.valueConstraint.valueTemplateRefs)}
                       </ButtonToolbar>

--- a/static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/MonographInstance.json
+++ b/static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/MonographInstance.json
@@ -17,7 +17,7 @@
         "valueDataType": {},
         "defaults": []
       },
-      "mandatory": "false",
+      "mandatory": "true",
       "repeatable": "true"
     },
     {
@@ -46,7 +46,7 @@
       "propertyLabel": "Statement of Responsibility Relating to Title Proper (RDA 2.4.2)",
       "remark": "http://access.rdatoolkit.org/2.4.2.html",
       "propertyURI": "http://id.loc.gov/ontologies/bibframe/responsibilityStatement",
-      "mandatory": "false",
+      "mandatory": "true",
       "repeatable": "true",
       "type": "literal",
       "resourceTemplates": [],
@@ -61,7 +61,7 @@
       "propertyURI": "http://id.loc.gov/ontologies/bibframe/issuance",
       "propertyLabel": "Mode of Issuance (RDA 2.13)",
       "remark": "http://access.rdatoolkit.org/2.13.html",
-      "mandatory": "false",
+      "mandatory": "true",
       "repeatable": "true",
       "type": "resource",
       "resourceTemplates": [],
@@ -163,7 +163,7 @@
       "remark": "http://access.rdatoolkit.org/3.3.html"
     },
     {
-      "mandatory": "false",
+      "mandatory": "true",
       "repeatable": "true",
       "type": "lookup",
       "resourceTemplates": [],


### PR DESCRIPTION
In a ResourceTemplate, for all `literals`, `lookups`, and `resource` properties, if *mandatory* is set to "true", then displays a red asterisk (using FontAwesome) to indicate the component is required.

Changed for the following Components:
- InputLiteral, 
- InputLookupQA,
- InputListLOC
- ButtonToolbar in ResourceTemplateForm.

 In the spoofed `MonographInstance` Resource Template, the *Instance Of*'s mandatory property is set to **true**:
<img width="890" alt="screen shot 2019-01-23 at 4 59 51 pm" src="https://user-images.githubusercontent.com/71847/51645378-3126dd80-1f31-11e9-8786-834b5c8a38ab.png">

Which generates the following label with a red asterisk:
![screen shot 2019-01-23 at 5 07 31 pm](https://user-images.githubusercontent.com/71847/51645432-68958a00-1f31-11e9-9116-6afff95eb8bd.png)

This is work required to complete Issue #303. @astridu may want to look at adjust as needed for the final user interface.