### PR TITLE
PropertyRemark Component 

### DIFF
--- a/__tests__/components/editor/InputListLOC.test.js
+++ b/__tests__/components/editor/InputListLOC.test.js
@@ -2,6 +2,7 @@
 import React from 'react'
 import { shallow } from 'enzyme'
 import InputList from '../../../src/components/editor/InputListLOC'
+import PropertyRemark from '../../../src/components/editor/PropertyRemark'
 
 const plProps = {
   "propertyTemplate":
@@ -34,7 +35,9 @@ describe('<InputList />', () => {
   const wrapper = shallow(<InputList.WrappedComponent {...plProps} handleSelectedChange={mockFormDataFn} />)
 
   it('contains a label with the value of propertyLabel', () => {
-    expect(wrapper.find('label').text()).toMatch('Frequency (RDA 2.14)')
+    const label = wrapper.find('label')
+    const propertyRemark = label.find('PropertyRemark')
+    expect(propertyRemark.html()).toMatch("Frequency (RDA 2.14)")
   })
 
   it('typeahead component should have a placeholder attribute with value propertyLabel', () => {
@@ -49,6 +52,13 @@ describe('<InputList />', () => {
     wrapper.instance().props.propertyTemplate.mandatory = "true"
     wrapper.instance().forceUpdate()
     expect(wrapper.find('label > RequiredSuperscript')).toBeTruthy()
+  })
+
+  it('displays a text label if remark from template is absent', () => {
+    wrapper.instance().props.propertyTemplate.remark = undefined
+    wrapper.instance().forceUpdate()
+    const label = wrapper.find('label').text()
+    expect(label.startsWith("Frequency (RDA 2.14)")).toBeTruthy()
   })
 
   it('sets the typeahead component multiple attribute according to the repeatable value from the template', () => {

--- a/__tests__/components/editor/InputLiteral.test.js
+++ b/__tests__/components/editor/InputLiteral.test.js
@@ -35,6 +35,12 @@ describe('<InputLiteral />', () => {
     wrapper.instance().forceUpdate()
     expect(wrapper.find('input').prop('required')).toBeFalsy()
   })
+  it('label contains a PropertyRemark when a remark is added', () => {
+    wrapper.instance().props.propertyTemplate.remark = "http://rda.test.org/1.1"
+    wrapper.instance().forceUpdate()
+    const propertyRemark = wrapper.find('label > PropertyRemark')
+    expect(propertyRemark).toBeTruthy()
+  })
 })
 
 describe('When the user enters input into field', ()=>{

--- a/__tests__/components/editor/InputLookupQA.test.js
+++ b/__tests__/components/editor/InputLookupQA.test.js
@@ -74,4 +74,11 @@ describe('<InputLookup />', () => {
 
     expect(mockFormDataFn.mock.calls.length).toBe(2)
   })
+
+  it('should have a PropertyRemark when a remark is present', () => {
+    wrapper.instance().props.propertyTemplate.remark = "http://rda.test.org/1.1"
+    wrapper.instance().forceUpdate()
+    const propertyRemark = wrapper.find('label > PropertyRemark')
+    expect(propertyRemark).toBeTruthy()
+  })
 })

--- a/__tests__/components/editor/PropertyRemark.test.js
+++ b/__tests__/components/editor/PropertyRemark.test.js
@@ -1,0 +1,23 @@
+// Copyright 2019 Stanford University see Apache2.txt for license
+import React from 'react'
+import { shallow } from 'enzyme'
+import PropertyRemark from '../../../src/components/editor/PropertyRemark'
+
+describe('<PropertyRemark />', () => {
+  const wrapper = shallow(<PropertyRemark remark="http://access.rdatoolkit.org/example"
+      label="Example RDA" />)
+
+  it('displays an HTML anchor tag', () => {
+    expect(wrapper.find('a')).toBeTruthy()
+  })
+
+  it('contains a href with the value of the remark', () => {
+    const anchor = wrapper.find('a')
+    expect(anchor.prop('href')).toEqual("http://access.rdatoolkit.org/example")
+  })
+
+  it('contains a span with the value of the label', () => {
+    const span = wrapper.find('a > span')
+    expect(span.text()).toEqual("Example RDA")
+  })
+})

--- a/__tests__/components/editor/PropertyRemark.test.js
+++ b/__tests__/components/editor/PropertyRemark.test.js
@@ -13,11 +13,17 @@ describe('<PropertyRemark />', () => {
 
   it('contains a href with the value of the remark', () => {
     const anchor = wrapper.find('a')
-    expect(anchor.prop('href')).toEqual("http://access.rdatoolkit.org/example")
+    expect(anchor.prop('href')).toEqual(new URL("http://access.rdatoolkit.org/example"))
   })
 
   it('contains a span with the value of the label', () => {
     const span = wrapper.find('a > span')
     expect(span.text()).toEqual("Example RDA")
+  })
+
+  it('displays just a string label if remark is not a valid URL', () => {
+    const no_link_wrapper = shallow(<PropertyRemark remark="A test remark"
+        label="Example RDA" />)
+    expect(no_link_wrapper.text()).toBe("Example RDA")
   })
 })

--- a/__tests__/components/editor/ResourceTemplateForm.test.js
+++ b/__tests__/components/editor/ResourceTemplateForm.test.js
@@ -149,11 +149,19 @@ describe('<ResourceTemplateForm />', () => {
     expect(rtProps.propertyTemplates[0].repeatable).toBe("false")
     expect(rtProps.propertyTemplates[0].editable).toBe("true")
   })
+
   it('does not override "mandatory", "repeatable", or "editable" that has already been specified', () => {
     wrapper.instance().defaultValues()
     wrapper.instance().forceUpdate()
     expect(rtProps.propertyTemplates[1].mandatory).toBe("do not override me!")
     expect(rtProps.propertyTemplates[1].repeatable).toBe("do not override me!")
     expect(rtProps.propertyTemplates[1].editable).toBe("do not override me!")
+  })
+
+  it('displays a PropertyRemark when a remark is present', () => {
+    wrapper.instance().props.propertyTemplates[2].remark = "https://www.youtube.com/watch?v=jWkMhCLkVOg"
+    wrapper.instance().forceUpdate()
+    const propertyRemark = wrapper.find('label > PropertyRemark')
+    expect(propertyRemark).toBeTruthy()
   })
 })

--- a/package.json
+++ b/package.json
@@ -13,7 +13,10 @@
   },
   "contributors": [
     "Kirk Hess <khes@loc.gov>",
-    "Jeremy Nelson"
+    "Jeremy Nelson",
+    "Joshua Greben",
+    "Naomi Dushay",
+    "Sarav Shah"
   ],
   "devDependencies": {
     "@babel/core": "^7.1.6",
@@ -71,7 +74,7 @@
     "dev-build": "webpack --progress --mode development",
     "dev-build-test": "npm run dev-build && npm run test",
     "dev-start": "webpack-dev-server --config ./webpack.config.js --mode development",
-    "eslint": "eslint --max-warnings 32 --color -c .eslintrc.js --ext js,jsx ./src",
+    "eslint": "eslint --max-warnings 28 --color -c .eslintrc.js --ext js,jsx ./src",
     "jest-cov": "jest --coverage --colors",
     "jest-ci": "jest --ci --runInBand --coverage --reporters=default --reporters=jest-junit --colors  && cat ./coverage/lcov.info | coveralls",
     "test": "jest --colors"

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "dev-build": "webpack --progress --mode development",
     "dev-build-test": "npm run dev-build && npm run test",
     "dev-start": "webpack-dev-server --config ./webpack.config.js --mode development",
-    "eslint": "eslint --max-warnings 28 --color -c .eslintrc.js --ext js,jsx ./src",
+    "eslint": "eslint --max-warnings 29 --color -c .eslintrc.js --ext js,jsx ./src",
     "jest-cov": "jest --coverage --colors",
     "jest-ci": "jest --ci --runInBand --coverage --reporters=default --reporters=jest-junit --colors  && cat ./coverage/lcov.info | coveralls",
     "test": "jest --colors"

--- a/src/components/CanvasMenu.jsx
+++ b/src/components/CanvasMenu.jsx
@@ -2,8 +2,7 @@
 
 import React, { Component } from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faTimes } from '@fortawesome/free-solid-svg-icons'
-import { faArrowAltCircleRight } from '@fortawesome/free-solid-svg-icons'
+import { faTimes, faArrowAltCircleRight  } from '@fortawesome/free-solid-svg-icons'
 import PropTypes from 'prop-types'
 
 class CanvasMenu extends Component {

--- a/src/components/editor/InputListLOC.jsx
+++ b/src/components/editor/InputListLOC.jsx
@@ -83,7 +83,8 @@ class
     var opts = []
     return (
       <div>
-        <label htmlFor="targetComponent">
+        <label htmlFor="targetComponent"
+               title={this.props.propertyTemplate.remark}>
         {this.hasPropertyRemark(this.props.propertyTemplate)}
         {this.mandatorySuperscript()}
         <Typeahead

--- a/src/components/editor/InputListLOC.jsx
+++ b/src/components/editor/InputListLOC.jsx
@@ -3,6 +3,7 @@
 import React, { Component } from 'react';
 import { Typeahead } from 'react-bootstrap-typeahead'
 import PropTypes from 'prop-types'
+import PropertyRemark from './PropertyRemark'
 import RequiredSuperscript from './RequiredSuperscript'
 
 import { connect } from 'react-redux'
@@ -17,6 +18,8 @@ class
       options: [],
       defaults: []
     }
+    this.hasPropertyRemark = this.hasPropertyRemark.bind(this)
+
     let defaultValue
     try {
       defaultValue = this.props.propertyTemplate.valueConstraint.defaults[0]
@@ -39,6 +42,14 @@ class
       rtId: this.props.rtId
     }
     this.props.handleSelectedChange(payload)
+  }
+
+  hasPropertyRemark(propertyTemplate) {
+    if(propertyTemplate.remark) {
+      return <PropertyRemark remark={propertyTemplate.remark}
+          label={propertyTemplate.propertyLabel} />;
+    }
+    return propertyTemplate.propertyLabel;
   }
 
   mandatorySuperscript() {
@@ -72,7 +83,8 @@ class
     var opts = []
     return (
       <div>
-        <label htmlFor="targetComponent">{this.props.propertyTemplate.propertyLabel}
+        <label htmlFor="targetComponent">
+        {this.hasPropertyRemark(this.props.propertyTemplate)}
         {this.mandatorySuperscript()}
         <Typeahead
           onFocus={() => {

--- a/src/components/editor/InputLiteral.jsx
+++ b/src/components/editor/InputLiteral.jsx
@@ -1,9 +1,10 @@
-// Copyright 2018 Stanford University see Apache2.txt for license
+// Copyright 2018, 2019 Stanford University see Apache2.txt for license
 
 import React, {Component} from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { setItems, removeItem } from '../../actions/index'
+import PropertyRemark from './PropertyRemark'
 import RequiredSuperscript from './RequiredSuperscript'
 
 // Redux recommends exporting the unconnected component for unit tests.
@@ -16,6 +17,7 @@ export class InputLiteral extends Component {
     this.handleClick = this.handleClick.bind(this)
     this.handleFocus = this.handleFocus.bind(this)
     this.checkMandatoryRepeatable = this.checkMandatoryRepeatable.bind(this)
+    this.hasPropertyRemark = this.hasPropertyRemark.bind(this)
     this.mandatorySuperscript = this.mandatorySuperscript.bind(this)
     this.notRepeatable = this.notRepeatable.bind(this)
     this.addUserInput = this.addUserInput.bind(this)
@@ -101,6 +103,14 @@ export class InputLiteral extends Component {
      }
   }
 
+  hasPropertyRemark() {
+    if(this.props.propertyTemplate.remark) {
+      return <PropertyRemark remark={this.props.propertyTemplate.remark}
+          label={this.props.propertyTemplate.propertyLabel} />;
+    }
+    return this.props.propertyTemplate.propertyLabel;
+  }
+
   mandatorySuperscript() {
     if (this.props.propertyTemplate.mandatory === "true") {
       return <RequiredSuperscript />
@@ -136,7 +146,7 @@ export class InputLiteral extends Component {
     return (
       <div className="form-group">
         <label htmlFor={"typeLiteral" + this.props.id}>
-          {this.props.propertyTemplate.propertyLabel}
+          {this.hasPropertyRemark()}
           {this.mandatorySuperscript()}
           <input
             required={this.checkMandatoryRepeatable()}
@@ -163,6 +173,7 @@ InputLiteral.propTypes = {
     propertyURI: PropTypes.string.isRequired,
     mandatory: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
     repeatable: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+    remark: PropTypes.string,
     valueConstraint: PropTypes.shape({
       defaults: PropTypes.array
     })

--- a/src/components/editor/InputLiteral.jsx
+++ b/src/components/editor/InputLiteral.jsx
@@ -145,7 +145,8 @@ export class InputLiteral extends Component {
   render() {
     return (
       <div className="form-group">
-        <label htmlFor={"typeLiteral" + this.props.id}>
+        <label htmlFor={"typeLiteral" + this.props.id}
+               title={this.props.propertyTemplate.remark}>
           {this.hasPropertyRemark()}
           {this.mandatorySuperscript()}
           <input

--- a/src/components/editor/InputLookupQA.jsx
+++ b/src/components/editor/InputLookupQA.jsx
@@ -59,7 +59,8 @@ class InputLookupQA extends Component {
 
     return (
       <div>
-        <label htmlFor="lookupComponent">
+        <label htmlFor="lookupComponent"
+               title={this.props.propertyTemplate.remark}>
         {this.hasPropertyRemark()}
         {this.mandatorySuperscript()}
         <AsyncTypeahead id="lookupComponent"

--- a/src/components/editor/InputLookupQA.jsx
+++ b/src/components/editor/InputLookupQA.jsx
@@ -3,6 +3,7 @@ import React, { Component } from 'react'
 import { asyncContainer, Typeahead } from 'react-bootstrap-typeahead'
 import PropTypes from 'prop-types'
 import Swagger from 'swagger-client'
+import PropertyRemark from './PropertyRemark'
 import RequiredSuperscript from './RequiredSuperscript'
 import { connect } from 'react-redux'
 import { changeSelections } from '../../actions/index'
@@ -12,10 +13,19 @@ const AsyncTypeahead = asyncContainer(Typeahead)
 class InputLookupQA extends Component {
   constructor(props) {
     super(props)
+    this.hasPropertyRemark = this.hasPropertyRemark.bind(this)
     this.mandatorySuperscript = this.mandatorySuperscript.bind(this)
     this.state = {
       isLoading: false
     }
+  }
+
+  hasPropertyRemark() {
+    if(this.props.propertyTemplate.remark) {
+      return <PropertyRemark remark={this.props.propertyTemplate.remark}
+          label={this.props.propertyTemplate.propertyLabel} />;
+    }
+    return this.props.propertyTemplate.propertyLabel;
   }
 
   mandatorySuperscript() {
@@ -49,7 +59,8 @@ class InputLookupQA extends Component {
 
     return (
       <div>
-        <label htmlFor="lookupComponent">{this.props.propertyTemplate.propertyLabel}
+        <label htmlFor="lookupComponent">
+        {this.hasPropertyRemark()}
         {this.mandatorySuperscript()}
         <AsyncTypeahead id="lookupComponent"
           onSearch={query => {

--- a/src/components/editor/PropertyRemark.jsx
+++ b/src/components/editor/PropertyRemark.jsx
@@ -8,11 +8,18 @@ export class PropertyRemark extends Component {
     super(props)
   }
 
-  render() {
-    return (<a href={this.props.remark} className="prop-remark">
-           <span className="prop-remark">{this.props.label}</span>
-        </a>)
+  render () {
+    try {
+      const url = new URL(this.props.remark)
+      return <a href={url} className="prop-remark" alt={this.props.remark}>
+              <span className="prop-remark">{this.props.label}</span>
+             </a>
+
+    } catch (_) {
+      return this.props.label
+    }
   }
+
 }
 
 PropertyRemark.propTypes = {

--- a/src/components/editor/PropertyRemark.jsx
+++ b/src/components/editor/PropertyRemark.jsx
@@ -1,0 +1,22 @@
+// Copyright 2019 Stanford University see Apache2.txt for license
+import React, {Component} from 'react'
+import PropTypes from 'prop-types'
+
+export class PropertyRemark extends Component {
+
+  constructor(props) {
+    super(props)
+  }
+
+  render() {
+    return (<a href={this.props.remark} className="prop-remark">
+           <span className="prop-remark">{this.props.label}</span>
+        </a>)
+  }
+}
+
+PropertyRemark.propTypes = {
+  label: PropTypes.string.isRequired,
+  remark: PropTypes.string.isRequired
+}
+export default PropertyRemark;

--- a/src/components/editor/ResourceTemplateForm.jsx
+++ b/src/components/editor/ResourceTemplateForm.jsx
@@ -145,7 +145,7 @@ class ResourceTemplateForm extends Component {
                     return (
                       <ButtonToolbar key={index}>
                         <div>
-                          <b>{this.hasPropertyRemark(pt)}{this.mandatorySuperscript(pt.mandatory)}</b>
+                          <label title={pt.remark}>{this.hasPropertyRemark(pt)}{this.mandatorySuperscript(pt.mandatory)}</label>
                         </div>
                         {this.resourceTemplateButtons(pt.valueConstraint.valueTemplateRefs)}
                       </ButtonToolbar>

--- a/src/components/editor/ResourceTemplateForm.jsx
+++ b/src/components/editor/ResourceTemplateForm.jsx
@@ -8,6 +8,7 @@ import ButtonToolbar from 'react-bootstrap/lib/ButtonToolbar'
 import InputLiteral from './InputLiteral'
 import InputListLOC from './InputListLOC'
 import InputLookupQA from './InputLookupQA'
+import PropertyRemark from './PropertyRemark'
 import RequiredSuperscript from './RequiredSuperscript'
 import ModalToggle from './ModalToggle'
 import lookupConfig from '../../../static/spoofedFilesFromServer/fromSinopiaServer/lookupConfig.json'
@@ -21,6 +22,7 @@ class ResourceTemplateForm extends Component {
     this.resourceTemplateButtons = this.resourceTemplateButtons.bind(this)
     this.defaultValues = this.defaultValues.bind(this)
     this.previewRDF = this.previewRDF.bind(this)
+    this.hasPropertyRemark = this.hasPropertyRemark.bind(this)
     this.mandatorySuperscript = this.mandatorySuperscript.bind(this)
     this.defaultValues()
   }
@@ -61,6 +63,17 @@ class ResourceTemplateForm extends Component {
     if (JSON.parse(propMandatory)) {
       return <RequiredSuperscript />
     }
+  }
+
+  hasPropertyRemark = (prop) => {
+    let output;
+    if(prop.remark) {
+      output = <PropertyRemark remark={prop.remark}
+                label={prop.propertyLabel} />
+    } else {
+      output = prop.propertyLabel
+    }
+    return output
   }
 
   defaultValues = () => {
@@ -132,7 +145,7 @@ class ResourceTemplateForm extends Component {
                     return (
                       <ButtonToolbar key={index}>
                         <div>
-                          <b>{pt.propertyLabel} {this.mandatorySuperscript(pt.mandatory)}</b>
+                          <b>{this.hasPropertyRemark(pt)}{this.mandatorySuperscript(pt.mandatory)}</b>
                         </div>
                         {this.resourceTemplateButtons(pt.valueConstraint.valueTemplateRefs)}
                       </ButtonToolbar>

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -91,6 +91,16 @@ h2.editor-subtitle {
   margin-bottom: 5px;
 }
 
+a.prop-remark {
+  text-decoration: none;
+}
+
+span.prop-remark {
+  border-width: thin;
+  border-bottom-style: dashed !important;
+  color: #2F2424;
+}
+
 a.editor-subtitle {
   text-decoration: none;
   font-family: "Copperplate Gothic Light";

--- a/static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/MonographInstance.json
+++ b/static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/MonographInstance.json
@@ -85,7 +85,7 @@
     },
     {
       "propertyLabel": "Notes about the Instance",
-      "remark": "http://access.rdatoolkit.org/2.17.html",
+      "remark": "This is a great note",
       "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
       "mandatory": "false",
       "repeatable": "true",

--- a/static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/MonographInstance.json
+++ b/static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/MonographInstance.json
@@ -178,7 +178,8 @@
         "defaults": []
       },
       "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
-      "propertyLabel": "LOC Names: locnames_ld4l_cache/person"
+      "propertyLabel": "LOC Names: locnames_ld4l_cache/person",
+      "remark": "http://id.loc.gov/authorities/names.html"
     },
     {
       "propertyURI": "http://id.loc.gov/ontologies/bibframe/frequency",


### PR DESCRIPTION
In the BFE, if a `PropertyTemplate` has a **remark** property, then the label becomes a hyperlink to an external explanatory website, mostly used to associate RDA properties to documentation on the http://access.rdatoolkit.org website. More details in Issue [#315 PropertyLabel needs to be hyperlink to URL in PropertyRemark](https://github.com/LD4P/sinopia_editor/issues/315)

This PR adds a new React component `PropertyRemark` that is has two HTML elements, an anchor tag and a span tag that links to the URL in the remark property. In the styling, I decided to NOT follow BFE example and made the hyperlink less obvious by not changing the color of the link but I did add an underline to visually cue the user that a hyperlink exists for the label. 

## Examples
For the `InputLiteral` component:
![screen shot 2019-01-31 at 4 10 52 pm](https://user-images.githubusercontent.com/71847/52091777-d3b71000-2572-11e9-8bca-f5864a879a79.png)

For the `InputListLOC` component:
![screen shot 2019-01-31 at 4 11 53 pm](https://user-images.githubusercontent.com/71847/52091831-f8ab8300-2572-11e9-930b-749ce6f9abb0.png)

For the `InputLookupQA` component:
![screen shot 2019-01-31 at 4 16 11 pm](https://user-images.githubusercontent.com/71847/52092029-a0c14c00-2573-11e9-8a5e-a13e09a4ed1f.png)

In the `ResourceTemplateForm`, properties of **resource** type:
![screen shot 2019-01-31 at 4 18 10 pm](https://user-images.githubusercontent.com/71847/52092126-d5cd9e80-2573-11e9-907e-b44246740c51.png)


Fixes #315