### PR TITLE
Enable cors mode to be able to fetch list from LOC

### DIFF
--- a/src/components/editor/InputListLOC.jsx
+++ b/src/components/editor/InputListLOC.jsx
@@ -90,7 +90,7 @@ class
         <Typeahead
           onFocus={() => {
             this.setState({isLoading: true})
-            fetch(`${lookupUri}.json`)
+            fetch(`${lookupUri}.json`, { mode: 'cors' })
               .then(resp => resp.json())
               .then(json => {
                 for(var i in json){


### PR DESCRIPTION
Lets see if this fixes the errors on the sinopia deployment:

`Fetch API cannot load http://id.loc.gov/vocabulary/xyz.json due to access control checks.`