### PR TITLE
Adds the default literal value if it exists

### DIFF
--- a/src/components/editor/InputListLOC.jsx
+++ b/src/components/editor/InputListLOC.jsx
@@ -19,9 +19,8 @@ class InputListLOC extends Component {
     }
     this.hasPropertyRemark = this.hasPropertyRemark.bind(this)
 
-    let defaultValue
     try {
-      defaultValue = this.props.propertyTemplate.valueConstraint.defaults[0]
+      const defaultValue = this.props.propertyTemplate.valueConstraint.defaults[0]
       const defaults = [{
         id: defaultValue.defaultURI,
         uri: defaultValue.defaultURI,

--- a/src/components/editor/InputListLOC.jsx
+++ b/src/components/editor/InputListLOC.jsx
@@ -9,8 +9,7 @@ import RequiredSuperscript from './RequiredSuperscript'
 import { connect } from 'react-redux'
 import { changeSelections } from '../../actions/index'
 
-class
-InputListLOC extends Component {
+class InputListLOC extends Component {
   constructor(props) {
     super(props)
     this.state = {

--- a/src/components/editor/InputLiteral.jsx
+++ b/src/components/editor/InputLiteral.jsx
@@ -27,9 +27,8 @@ export class InputLiteral extends Component {
     }
     this.lastId = -1
 
-    let defaultValue
     try {
-      defaultValue = this.props.propertyTemplate.valueConstraint.defaults[0]
+     const defaultValue = this.props.propertyTemplate.valueConstraint.defaults[0]
       this.state.defaults = [{
         content: defaultValue.defaultLiteral,
         id: ++this.lastId,

--- a/src/components/editor/InputLiteral.jsx
+++ b/src/components/editor/InputLiteral.jsx
@@ -22,9 +22,33 @@ export class InputLiteral extends Component {
     this.notRepeatable = this.notRepeatable.bind(this)
     this.addUserInput = this.addUserInput.bind(this)
     this.state = {
-      content_add: ""
+      content_add: "",
+      defaults: []
     }
     this.lastId = -1
+
+    let defaultValue
+    try {
+      defaultValue = this.props.propertyTemplate.valueConstraint.defaults[0]
+      this.state.defaults = [{
+        content: defaultValue.defaultLiteral,
+        id: ++this.lastId,
+        bnode: this.props.blankNodeForLiteral,
+        propPredicate: this.props.propPredicate
+      }]
+      this.setPayLoad(this.state.defaults)
+    } catch (error) {
+      console.log(`defaults not defined in the property template: ${error}`)
+    }
+  }
+
+  setPayLoad(defaults) {
+    const payload = {
+      id: this.props.propertyTemplate.propertyURI,
+      items: defaults,
+      rtId: this.props.rtId
+    }
+    this.props.handleMyItemsChange(payload)
   }
 
   handleFocus(event) {

--- a/static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/Barcode.json
+++ b/static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/Barcode.json
@@ -12,7 +12,12 @@
         "valueTemplateRefs": [],
         "useValuesFrom": [],
         "valueDataType": {},
-        "defaults": []
+        "defaults": [
+          {
+            "defaultURI": "http://id.loc.gov/vocabulary/itemPart",
+            "defaultLiteral": "12345"
+          }
+        ]
       },
       "propertyURI": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value",
       "propertyLabel": "Barcode"


### PR DESCRIPTION
Fixes #196 

- Gets default Literal value from property template and sets the "defaults" state with that data, plus any rdf-related properties that get passed in (`bnode` and `propPredicate`)
- Adds a test for this new feature
- Minor formatting of `InputListLOC`
- adds a default literal to the Barcode resource template so we can see that this is working.