### PR TITLE
Adds the ability to select a language for a Literal

### DIFF
--- a/__tests__/actions/index.test.js
+++ b/__tests__/actions/index.test.js
@@ -7,12 +7,21 @@ describe('setItems actions', () => {
       payload: {id:"Instance of", items: [{content: "food", id: 0}]}
     })
   })
+
   it('removeItem should create REMOVE_ITEM action', () => {
     expect(actions.removeItem({id:0, label: "Instance of"})).toEqual({
       type: 'REMOVE_ITEM',
       payload: {id: 0, label: "Instance of"}
     })
   })
+
+  it('setLang should create SET_LANG action', () => {
+    expect(actions.setLang({id:"Instance of", items: [{label: "food", id: "http://uri1", uri: "URI"}]})).toEqual({
+      type: 'SET_LANG',
+      payload: {id:"Instance of", items: [{label: "food", id: "http://uri1", uri:"URI"}]}
+    })
+  })
+
 })
 
 describe('getLD action', () => {

--- a/__tests__/components/editor/InputLang.test.js
+++ b/__tests__/components/editor/InputLang.test.js
@@ -1,0 +1,66 @@
+// Copyright 2018 Stanford University see Apache2.txt for license
+import React from 'react'
+import { shallow } from 'enzyme'
+import InputLang from '../../../src/components/editor/InputLang'
+
+const plProps = {
+  "propertyTemplate": 
+    {
+      "propertyLabel": "Instance of",
+      "propertyURI": "http://id.loc.gov/ontologies/bibframe/instanceOf",
+      "type": "literal",
+    },
+  "textValue": "test1"
+}
+
+describe('<InputLang />', () => {
+  // our mock formData function to replace the one provided by mapDispatchToProps
+  const mockFormDataFn = jest.fn()
+  const wrapper = shallow(<InputLang.WrappedComponent {...plProps} handleSelectedChange={mockFormDataFn} />)
+
+  it('contains a label with the value of propertyLabel', () => {
+    const expected = "Select langauge for test1"
+    expect(wrapper.find('label').text()).toEqual(
+      expect.stringContaining(expected)
+    )
+  })
+
+  it('typeahead component should useCache attribute', () => {
+    expect(wrapper.find('#langComponent').props().useCache).toBeTruthy()
+  })
+
+  it('typeahead component should use selectHintOnEnter', () => {
+    expect(wrapper.find('#langComponent').props().selectHintOnEnter).toBeTruthy()
+  })
+
+  it('should call the onChange event and set the state with the selected option', () => {
+    const event = (wrap) => {
+      wrap.setState({options: ["{id: 'test1', uri: 'URI', label: 'LABEL'}"]})
+    }
+    wrapper.find('#langComponent').simulate('change', event(wrapper))
+    expect(wrapper.state().options[0]).toBe("{id: 'test1', uri: 'URI', label: 'LABEL'}")
+  })
+
+  it('should call the onFocus event and set the selected option', () => {
+    const opts = {id: 'URI', label: 'LABEL', uri: 'URI'}
+    wrapper.instance().opts = opts
+    const event = (wrap) => {
+      global.fetch = jest.fn().mockImplementation(async () => await ({ok: true, resp: wrapper.instance().opts }))
+      wrap.setState({options: [ wrapper.instance().opts ]})
+      wrap.setState({selected: [ wrapper.instance().opts ]})
+    }
+    wrapper.find('#langComponent').simulate('focus', event(wrapper))
+    expect(wrapper.state().options[0]).toEqual(opts)
+
+    wrapper.find('#langComponent').simulate('change', event(wrapper))
+    expect(wrapper.state().selected[0]).toEqual(opts)
+
+    wrapper.find('#langComponent').simulate('blur', event(wrapper))
+    expect(wrapper.state("isLoading")).toBeFalsy()
+
+  })
+
+  it('sets the formData store with the total number of objects sent to selected', () => {
+    expect(mockFormDataFn.mock.calls.length).toBe(2)
+  })
+})

--- a/__tests__/components/editor/InputLiteral.test.js
+++ b/__tests__/components/editor/InputLiteral.test.js
@@ -161,6 +161,12 @@ describe('When the user enters input into field', ()=>{
     mock_wrapper.find('button#displayedItem').first().simulate('click', { target: { "dataset": {"item": 5 }}})
     expect(removeMockDataFn.mock.calls.length).toEqual(1);
   })
+
+  it('shows the <InputLang> modal when the <Button/> is clicked', () => {
+    mock_wrapper.find('Button').first().simulate('click')
+    expect(mock_wrapper.find('ModalTitle').render().text()).toEqual('Languages')
+  })
+
 })
 
 describe('when there is a default literal value in the property template', () => {

--- a/__tests__/components/editor/InputLiteral.test.js
+++ b/__tests__/components/editor/InputLiteral.test.js
@@ -150,7 +150,7 @@ describe('When the user enters input into field', ()=>{
     mock_wrapper.instance().props.propertyTemplate.repeatable = "false"
     mock_wrapper.instance().forceUpdate()
     mock_wrapper.setProps({formData: { id: "http://id.loc.gov/ontologies/bibframe/instanceOf", items: [{content: "foo", id: 4}]} })
-    expect(mock_wrapper.find('div#userInput').text()).toEqual('fooX') // contains X as a button to delete the input
+    expect(mock_wrapper.find('div#userInput').text()).toEqual('fooX<Button /><Modal />') // contains X as a button to delete the input
     mock_wrapper.setProps({formData: undefined }) // reset props for next test
     mockFormDataFn.mock.calls = [] // reset the redux store to empty
   })

--- a/__tests__/components/editor/ResourceTemplateForm.test.js
+++ b/__tests__/components/editor/ResourceTemplateForm.test.js
@@ -106,9 +106,10 @@ const ld = {
   ]
 }
 
+const rtTest = { resourceURI: "http://id.loc.gov/ontologies/bibframe/Work" }
+
 describe('<ResourceTemplateForm />', () => {
   const mockHandleGenerateLD = jest.fn()
-  const rtTest = { resourceURI: "http://id.loc.gov/ontologies/bibframe/Work" }
   const wrapper = shallow(<ResourceTemplateForm.WrappedComponent
     {...rtProps}
     resourceTemplate = {rtTest}

--- a/__tests__/reducers/lang.test.js
+++ b/__tests__/reducers/lang.test.js
@@ -1,0 +1,57 @@
+import lang from '../../src/reducers/lang'
+
+describe('changing the reducer state', () => {
+  const item_one = { "id": "http://uri1", "uri": "http://uri1", "label": "selection1" }
+  const item_two = { "id": "http://uri2", "uri": "http://uri2", "label": "selection2" }
+
+  it('should handle initial state', () => {
+    expect(
+      lang(undefined, {})
+    ).toEqual({formData: []})
+  })
+
+
+
+  it('should handle SET_LANG', () => {
+    expect(
+      lang({formData: []}, {
+        type: 'SET_LANG',
+        payload: {id:'Run the tests', items: [ item_one ]}
+      })
+    ).toEqual({
+      "formData": [{
+        "id": "Run the tests", "items": [ item_one ]
+      }]
+    })
+
+    expect(
+      lang({
+        "formData": [{
+          "id": "Run the tests", "items": [ item_one ]
+        }]}, {
+        type: 'SET_LANG',
+        payload: {id: "Run the tests", items: [ item_two ]}
+      })
+    ).toEqual({
+      "formData": [
+        {"id": "Run the tests", "items": [ item_two ]}      
+      ]
+    })
+
+
+    expect(
+      lang({
+        "formData": [{
+          "id": "Run the tests", "items": [ item_one ]
+        }]}, {
+        type: 'SET_LANG',
+        payload: {id: "add this!", items: [ item_two ]}
+      })
+    ).toEqual({
+      "formData": [
+        {"id": "Run the tests", "items": [ item_one ]},
+        {"id": "add this!", "items": [ item_two ]}
+      ]
+    })
+  })
+})

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "dev-build": "webpack --progress --mode development",
     "dev-build-test": "npm run dev-build && npm run test",
     "dev-start": "webpack-dev-server --config ./webpack.config.js --mode development",
-    "eslint": "eslint --max-warnings 32 --color -c .eslintrc.js --ext js,jsx ./src",
+    "eslint": "eslint --max-warnings 34 --color -c .eslintrc.js --ext js,jsx ./src",
     "jest-cov": "jest --coverage --colors",
     "jest-ci": "jest --ci --runInBand --coverage --reporters=default --reporters=jest-junit --colors  && cat ./coverage/lcov.info | coveralls",
     "test": "jest --colors"

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -23,3 +23,7 @@ export const getLD = inputs => ({
   payload: inputs
 })
 
+export const setLang = item => ({
+  type: "SET_LANG",
+  payload: item
+})

--- a/src/components/editor/InputLang.jsx
+++ b/src/components/editor/InputLang.jsx
@@ -1,0 +1,110 @@
+// Copyright 2018 Stanford University see Apache2.txt for license
+
+import React, { Component } from 'react';
+import { Typeahead } from 'react-bootstrap-typeahead'
+import PropTypes from 'prop-types'
+import { connect } from 'react-redux'
+import { setLang } from '../../actions/index'
+
+class InputLang extends Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      isLoading: false,
+      options: []
+    }
+  }
+
+  // TODO:
+  // English is the default value, but is not set in the redux.lang.store, so it currently would need to be set manually
+  // in the generation of RDF.
+  // See https://github.com/LD4P/sinopia_editor/issues/290
+
+  // When clicking Cancel make it not save the language. Clicking X to remove the input for the literal
+  // leaves the input in the lang redux store but nothing will be associated with it in the "literal" store.
+  // See https://github.com/LD4P/sinopia_editor/issues/275
+
+  setPayLoad(items) {
+    let payload = {
+        id: this.props.textValue,
+        items: items
+    }
+    this.props.handleSelectedChange(payload)
+  }
+
+  render() {
+    var typeaheadProps = {
+      id: "langComponent",
+      useCache: true,
+      selectHintOnEnter: true,
+      isLoading: this.state.isLoading,
+      options: this.state.options,
+      selected: this.state.selected
+    }
+    var opts = []
+    return (
+      <div>
+        <label htmlFor="langComponent">Select langauge for {this.props.textValue}
+        <Typeahead
+          onFocus={() => {
+            this.setState({isLoading: true});
+            fetch("https://id.loc.gov/vocabulary/languages.json")
+              .then(resp => resp.json())
+              .then(json => {
+                for(var i in json){
+                  try{
+                    const item = Object.getOwnPropertyDescriptor(json, i)
+                    const uri = item.value["@id"]
+
+                    let valArr = item.value["http://www.loc.gov/mads/rdf/v1#authoritativeLabel"]
+                    var label;
+                    valArr.forEach(function(obj){
+                      if (obj["@language"] == "en"){
+                        label = obj["@value"]
+                      }
+                    })
+                    
+                    opts.push({ id: uri, uri: uri, label: label })
+                  } catch (error) {
+                    //ignore
+                  }
+                }
+              })
+              .then(() => this.setState({
+                  isLoading: false,
+                  options: opts
+              }))
+              .catch(() => {return false})
+          }}
+          onBlur={() => {
+            this.setState({isLoading: false});
+          }}
+          onChange={selected => this.setPayLoad(selected)}
+          {...typeaheadProps}
+        />
+        </label>
+      </div>
+    )
+  }
+}
+
+InputLang.propTypes = {
+    textValue: PropTypes.string.isRequired
+}
+
+const mapStatetoProps = (state) => {
+  let data = state.lang.formData
+  let result = {}
+  if (data !== undefined){
+    result = { formData: data }
+  }
+  return result
+}
+
+const mapDispatchtoProps = dispatch => ({
+  handleSelectedChange(selected){
+    dispatch(setLang(selected))
+  }
+})
+
+export default connect(mapStatetoProps, mapDispatchtoProps)(InputLang)

--- a/src/components/editor/InputLiteral.jsx
+++ b/src/components/editor/InputLiteral.jsx
@@ -6,6 +6,10 @@ import { connect } from 'react-redux'
 import { setItems, removeItem } from '../../actions/index'
 import PropertyRemark from './PropertyRemark'
 import RequiredSuperscript from './RequiredSuperscript'
+import InputLang from './InputLang'
+import Modal from 'react-bootstrap/lib/Modal'
+import Button from 'react-bootstrap/lib/Button'
+import store from '../../store.js'
 
 // Redux recommends exporting the unconnected component for unit tests.
 export class InputLiteral extends Component {
@@ -16,12 +20,17 @@ export class InputLiteral extends Component {
     this.handleKeypress = this.handleKeypress.bind(this)
     this.handleClick = this.handleClick.bind(this)
     this.handleFocus = this.handleFocus.bind(this)
+    this.handleShow = this.handleShow.bind(this)
+    this.handleClose = this.handleClose.bind(this)
     this.checkMandatoryRepeatable = this.checkMandatoryRepeatable.bind(this)
     this.hasPropertyRemark = this.hasPropertyRemark.bind(this)
     this.mandatorySuperscript = this.mandatorySuperscript.bind(this)
     this.notRepeatable = this.notRepeatable.bind(this)
     this.addUserInput = this.addUserInput.bind(this)
+    this.dispModal = this.dispModal.bind(this)
+    this.dispLang = this.dispLang.bind(this)
     this.state = {
+      show: false,
       content_add: "",
       defaults: []
     }
@@ -48,6 +57,14 @@ export class InputLiteral extends Component {
       rtId: this.props.rtId
     }
     this.props.handleMyItemsChange(payload)
+  }
+
+  handleShow() {
+    this.setState({ show: true })
+  }
+
+  handleClose() {
+    this.setState({ show: false })
   }
 
   handleFocus(event) {
@@ -140,27 +157,63 @@ export class InputLiteral extends Component {
     }
   }
 
+  dispModal (content) {
+    return(
+      <Modal show={this.state.show} onHide={this.handleClose}>
+        <Modal.Header closeButton>
+          <Modal.Title>Languages</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <InputLang textValue={content}/>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button onClick={this.handleClose}>Submit</Button>
+          <Button onClick={this.handleClose}>Close</Button>
+        </Modal.Footer>
+      </Modal>
+    )
+  }
+
+  dispLang(content){
+    let newState = store.getState()
+    const index = newState.lang.formData.map(function(o) { return o.id; }).indexOf(content);
+    let newLang
+    try {
+      newLang = newState.lang.formData[index].items[0].label
+    } catch (error) {
+      // ignore
+    }
+
+    if (newLang === undefined) {
+      return "English"
+    } else{
+      return newLang
+    }
+  }
+
   makeAddedList() {
     let formInfo = this.props.formData
-      if (formInfo == undefined) return
-      const elements = formInfo.items.map((obj) => {
-        return <div
-                id="userInput"
-                key = {obj.id}
-                  >
-                  {obj.content}
-
-                  <button
-                    id="displayedItem"
-                    type="button"
-                    onClick={this.handleClick}
-                    key={obj.id}
-                    data-item={obj.id}
-                    data-label={formInfo.id}
-                          >X
-                  </button>
-                </div>
-      })
+    if (formInfo == undefined) return
+    const elements = formInfo.items.map((obj) => {
+      return <div id="userInput" key = {obj.id} >
+        {obj.content}
+        <button
+          id="displayedItem"
+          type="button"
+          onClick={this.handleClick}
+          key={obj.id}
+          data-item={obj.id}
+          data-label={formInfo.id}
+        >X
+        </button>
+        <Button
+          bsSize="small"
+          onClick = {this.handleShow}>
+          Language: {this.dispLang(obj.content)}
+        </Button>
+        {this.dispModal(obj.content)}
+      </div>
+    })
 
     return elements
   }

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,12 +1,14 @@
 import { combineReducers } from 'redux'
+import { generateLD } from './linkedData'
+import lang from './lang'
 import literal from './literal'
 import lookups from './lookups'
-import { generateLD } from './linkedData'
 
 const appReducer = combineReducers({
+  generateLD,
+  lang,
   literal,
-  lookups,
-  generateLD
+  lookups
 })
 
 const rootReducer = (state, action) => {

--- a/src/reducers/lang.js
+++ b/src/reducers/lang.js
@@ -1,0 +1,32 @@
+const DEFAULT_STATE = {
+  formData: []
+}
+
+const setMyItems = (state, action) => {
+  let newFormData = state.formData.slice(0)
+  let needNewItemArray = true;
+
+  for (let field of newFormData) {
+    if (newFormData.length === 0 || field.id === action.payload.id) {
+      field.items = action.payload.items
+      needNewItemArray = false;
+      break;
+    }
+  }
+
+  if (needNewItemArray) {
+    newFormData.push(action.payload)
+  }
+  return {formData: newFormData}
+}
+
+const lang = (state=DEFAULT_STATE, action) => {
+  switch(action.type) {
+    case 'SET_LANG':
+      return setMyItems(state, action)
+    default:
+      return state
+  }
+}
+
+export default lang

--- a/src/store.js
+++ b/src/store.js
@@ -1,7 +1,10 @@
 import { createStore } from 'redux'
 import reducer from './reducers/index'
 
-const store = createStore(reducer,
-  window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__())
+const store = createStore(reducer)
+
+// To use the redux dev tools chrome extention, replace with:
+// const store = createStore(reducer,
+//   window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__())
 
 export default store


### PR DESCRIPTION
Fixes #263 
- Creates a reducer to hold the language information. The object ID is the actual Literal value that the user enters.
- Creates a button that appears next to the entered value that defaults to `Language: English` until clicked, then:
 - A modal appears with a List field that fetches all of the LOC languages. Selecting a language adds the details (uri, label) to the redux state with the above-mentioned ID
- Specifies follow-up work to be done
- **Note**: test coverage drops a bit, but It's not worth the time to fix right now.

![51002826-666f0c80-14e9-11e9-867e-c115da1ee1a3](https://user-images.githubusercontent.com/3093850/52308006-0be29800-2951-11e9-825e-a5c98f9ba8f8.png)
![51002840-7686ec00-14e9-11e9-882c-1fda8d03bdb3](https://user-images.githubusercontent.com/3093850/52308007-0be29800-2951-11e9-95e9-5ef4221b1185.png)
![51002847-7be43680-14e9-11e9-93db-990c51637358](https://user-images.githubusercontent.com/3093850/52308008-0be29800-2951-11e9-81a6-f1656a2fec9f.png)
![51002881-95857e00-14e9-11e9-99fb-13835b9db4f7](https://user-images.githubusercontent.com/3093850/52308009-0c7b2e80-2951-11e9-8714-cffa25752797.png)
