### PR TITLE
Support for repeatable=false for InputLiteral

### DIFF
--- a/__tests__/components/editor/InputLiteral.test.js
+++ b/__tests__/components/editor/InputLiteral.test.js
@@ -160,9 +160,11 @@ describe('When the user enters input into field', ()=>{
     expect(removeMockDataFn.mock.calls.length).toEqual(0);
     mock_wrapper.find('button#displayedItem').first().simulate('click', { target: { "dataset": {"item": 5 }}})
     expect(removeMockDataFn.mock.calls.length).toEqual(1);
+    mockFormDataFn.mock.calls = []
   })
 
   it('shows the <InputLang> modal when the <Button/> is clicked', () => {
+    mock_wrapper.setProps({formData: { id: "http://id.loc.gov/ontologies/bibframe/instanceOf", items: [{content: "test", id: 6}]} })
     mock_wrapper.find('Button').first().simulate('click')
     expect(mock_wrapper.find('ModalTitle').render().text()).toEqual('Languages')
   })
@@ -194,3 +196,37 @@ describe('when there is a default literal value in the property template', () =>
   })
 })
 
+describe('<InputLiteral /> when repeatable="false"', () => {
+  const nrProps = {
+    "propertyTemplate":
+      {
+        "propertyLabel": "Instance of",
+        "propertyURI": "http://id.loc.gov/ontologies/bibframe/instanceOf",
+        "type": "literal",
+        "mandatory": "",
+        "repeatable": "false"
+      }
+  }
+
+  const mockMyItemsChange = jest.fn()
+  const mockRemoveItem = jest.fn()
+
+  const nonrepeat_wrapper = shallow(
+    <InputLiteral {...nrProps}
+      id={11}
+      rtId={'resourceTemplate:bf2:Monograph:Instance'}
+      handleMyItemsChange={mockMyItemsChange}
+      handleRemoveItem={mockRemoveItem} />)
+
+  it('input has disabled attribute set to "true" when repeatable is "false" and an item is added', () => {
+    nonrepeat_wrapper.find('input').simulate("change", { target: { value: "fooby" }})
+    nonrepeat_wrapper.find('input').simulate('keypress', {key: 'Enter', preventDefault: () => {}})
+    nonrepeat_wrapper.setProps({formData: { id: "http://id.loc.gov/ontologies/bibframe/instanceOf", items: [{content: "fooby", id: 0}]} })
+    expect(nonrepeat_wrapper.find('input').props('disabled')).toBeTruthy()
+  })
+
+  it('input no longer disabled if item is removed when repeatable="false"', () => {
+    nonrepeat_wrapper.find('button#displayedItem').first().simulate('click', { target: { "dataset": {"item": 0 }}})
+    expect(nonrepeat_wrapper.find('input').props().disabled).toBeFalsy()
+  })
+})

--- a/src/components/editor/InputLiteral.jsx
+++ b/src/components/editor/InputLiteral.jsx
@@ -32,7 +32,8 @@ export class InputLiteral extends Component {
     this.state = {
       show: false,
       content_add: "",
-      defaults: []
+      defaults: [],
+      disabled: false
     }
     this.lastId = -1
 
@@ -76,9 +77,10 @@ export class InputLiteral extends Component {
     this.setState({ content_add: usr_input })
   }
 
-  notRepeatable(userInputArray,currentcontent){
-    if (this.props.formData == undefined){
+  notRepeatable(userInputArray, currentcontent){
+    if (this.props.formData == undefined || this.props.formData.items < 1){
       this.addUserInput(userInputArray, currentcontent)
+      this.setState({ disabled: true})
     }
   }
 
@@ -125,6 +127,12 @@ export class InputLiteral extends Component {
     {
       id: idToRemove, label: labelToRemove
     })
+    this.props.formData.items.forEach(item => {
+      if(item.id === idToRemove) {
+        this.props.formData.items.pop(item)
+      }
+    })
+    this.setState({disabled: false})
   }
 
   checkMandatoryRepeatable() {
@@ -232,6 +240,7 @@ export class InputLiteral extends Component {
             onChange={this.handleChange}
             onKeyPress={this.handleKeypress}
             value={this.state.content_add}
+            disabled={this.state.disabled}
             id={"typeLiteral" + this.props.id}
             onClick={this.handleFocus}
           />


### PR DESCRIPTION
For the `InputLiteral` component, if the `PropertyTemplate`'s *repeatable* property is set to false, then the InputLiteral doesn't allow a second item to be added but the problem is there is no visual indication and users can still type in a value but nothing is saved. This PR address one of the two components mention in ticket [#347 Indicate when a field is non-repeatable](https://github.com/LD4P/sinopia_editor/issues/347). 

Starting with a propertyTemplate with repeatable=false:
![screen shot 2019-02-12 at 9 38 37 am](https://user-images.githubusercontent.com/71847/52651765-008bf100-2eaa-11e9-84ef-a68e8df0e77c.png)

I can enter text in the input field but hitting enter doesn't do anything:
![screen shot 2019-02-12 at 9 39 39 am](https://user-images.githubusercontent.com/71847/52651866-34ffad00-2eaa-11e9-8619-4fbe76ed3c7c.png)

This PR set's the input field to the Bootstrap-styles *disabled* attribute after one item is saved following BFE design:
![screen shot 2019-02-12 at 9 42 49 am](https://user-images.githubusercontent.com/71847/52652047-99bb0780-2eaa-11e9-8e84-aeecd4464139.png)

This PR also fixes a bug where if the user clicks and removes the single item, the input field is no longer disabled and allows the user to add in a new value:
![screen shot 2019-02-12 at 9 44 41 am](https://user-images.githubusercontent.com/71847/52652184-dc7cdf80-2eaa-11e9-89f7-81dc94c72cf4.png)
