### PR TITLE
InputLiteral initially disabled when defaults are present and repeatable is false

### DIFF
--- a/__tests__/components/editor/InputLiteral.test.js
+++ b/__tests__/components/editor/InputLiteral.test.js
@@ -230,3 +230,32 @@ describe('when there is a default literal value in the property template', () =>
     })
   })
 })
+
+describe('when repeatable="false" and defaults exist', () => {
+  const defaultProps = {
+    "propertyTemplate":
+    {
+      "propertyLabel": "Instance of",
+      "propertyURI": "http://id.loc.gov/ontologies/bibframe/instanceOf",
+      "type": "literal",
+      "mandatory": "",
+      "repeatable": "false",
+      "valueConstraint": {
+        "defaults": [
+          {
+            "defaultURI": "http://id.loc.gov/vocabulary/organizations/dlc",
+            "defaultLiteral": "DLC"
+          }
+        ]
+      }
+    }
+  }
+
+  const default_wrapper =  shallow(
+     <InputLiteral {...defaultProps}
+      id={13}
+      rtId={'resourceTemplate:bf2:Monograph:Item'} />)
+  it('in the initial display, the input field is disabled ', () => {
+    expect(default_wrapper.find('input').props('disabled')).toBeTruthy()
+  })
+})

--- a/src/components/editor/InputLiteral.jsx
+++ b/src/components/editor/InputLiteral.jsx
@@ -33,6 +33,9 @@ export class InputLiteral extends Component {
         propPredicate: this.props.propPredicate
       }]
       this.setPayLoad(this.state.defaults)
+      if (this.props.propertyTemplate.repeatable == "false") {
+        this.state.disabled = true
+      }
     } catch (error) {
       console.log(`defaults not defined in the property template: ${error}`)
     }
@@ -67,7 +70,7 @@ export class InputLiteral extends Component {
   notRepeatable = (userInputArray, currentcontent) => {
     if (this.props.formData == undefined || this.props.formData.items < 1){
       this.addUserInput(userInputArray, currentcontent)
-      this.setState({ disabled: true})
+      this.setState({ disabled: true })
     }
   }
 


### PR DESCRIPTION
Adds missing functionality discovered by UAT, when repeatable is false and default values exist. Also fixes incorrect spacing noted by @mjgiarlo in his comments on PR#350. 