### PR TITLE
Default values and entered values on ResourceTemplateForm, styled

### DIFF
--- a/__tests__/components/editor/InputLiteral.test.js
+++ b/__tests__/components/editor/InputLiteral.test.js
@@ -172,27 +172,17 @@ describe('When the user enters input into field', ()=>{
 })
 
 describe('when there is a default literal value in the property template', () => {
-  plProps.propertyTemplate['valueConstraint'] = valConstraintProps
-  const mockFormDataFn = jest.fn()
-  const wrapper = shallow(<InputLiteral {...plProps} id={12}
-                                        blankNodeForLiteral={{ termType: 'BlankNode', value: 'n3-0'}}
-                                        rtId={'resourceTemplate:bf2:Monograph:Instance'}
-                                        handleMyItemsChange={mockFormDataFn} />)
-
   it('sets the default values according to the property template if they exist', () => {
-    const defaults = [{
-      content: 'DLC',
-      id: 0,
-      bnode: { termType: 'BlankNode', value: 'n3-0'}
-    }]
-    expect(wrapper.state('defaults')).toEqual(defaults)
-    expect(mockFormDataFn.mock.calls[0][0]).toEqual(
-      {
-        uri: "http://id.loc.gov/ontologies/bibframe/instanceOf",
-        items:[{ content: 'DLC', id: 0, bnode: { termType: 'BlankNode', value: 'n3-0' }, propPredicate: undefined }],
-        rtId: "resourceTemplate:bf2:Monograph:Instance"
-      }
-    )
+    plProps.propertyTemplate['valueConstraint'] = valConstraintProps
+    const setDefaultsForLiteralWithPayLoad = jest.fn()
+    const defaultsForLiteral = jest.fn()
+    shallow(<InputLiteral {...plProps} id={12}
+                          blankNodeForLiteral={{ termType: 'BlankNode', value: 'n3-0'}}
+                          rtId={'resourceTemplate:bf2:Monograph:Instance'}
+                          setDefaultsForLiteralWithPayLoad={setDefaultsForLiteralWithPayLoad}
+                          defaultsForLiteral={defaultsForLiteral} />)
+    expect(setDefaultsForLiteralWithPayLoad).toHaveBeenCalledTimes(1)
+    expect(defaultsForLiteral).toHaveBeenCalledTimes(1)
   })
 
   describe('when repeatable="false"', () => {

--- a/__tests__/components/editor/InputLiteral.test.js
+++ b/__tests__/components/editor/InputLiteral.test.js
@@ -88,7 +88,7 @@ describe('When the user enters input into field', ()=>{
     mock_wrapper.find('input').simulate('keypress', {key: 'Enter', preventDefault: () => {}})
     // test to see arguments used after its been submitted
     expect(mockFormDataFn.mock.calls[1][0]).toEqual(
-      {id: "http://id.loc.gov/ontologies/bibframe/instanceOf", items:[{content: 'foo', id: 0}], "rtId": "resourceTemplate:bf2:Monograph:Instance"}
+      {uri: "http://id.loc.gov/ontologies/bibframe/instanceOf", items:[{content: 'foo', id: 0}], "rtId": "resourceTemplate:bf2:Monograph:Instance"}
     )
     mockFormDataFn.mock.calls = [] // reset the redux store to empty
   })
@@ -102,10 +102,10 @@ describe('When the user enters input into field', ()=>{
     mock_wrapper.find('input').simulate('keypress', {key: 'Enter', preventDefault: () => {}})
 
     expect(mockFormDataFn.mock.calls[0][0]).toEqual(
-      {id: "http://id.loc.gov/ontologies/bibframe/instanceOf", items:[{content: 'fooby', id: 1}], "rtId": "resourceTemplate:bf2:Monograph:Instance"}
+      {uri: "http://id.loc.gov/ontologies/bibframe/instanceOf", items:[{content: 'fooby', id: 1}], "rtId": "resourceTemplate:bf2:Monograph:Instance"}
     )
     expect(mockFormDataFn.mock.calls[1][0]).toEqual(
-      {id: "http://id.loc.gov/ontologies/bibframe/instanceOf", items:[{content: 'bar', id: 2}], "rtId": "resourceTemplate:bf2:Monograph:Instance"}
+      {uri: "http://id.loc.gov/ontologies/bibframe/instanceOf", items:[{content: 'bar', id: 2}], "rtId": "resourceTemplate:bf2:Monograph:Instance"}
     )
     mockFormDataFn.mock.calls = [] // reset the redux store to empty
   })
@@ -117,16 +117,16 @@ describe('When the user enters input into field', ()=>{
     mock_wrapper.find('input').simulate("change", { target: { value: "fooby" }})
     mock_wrapper.find('input').simulate('keypress', {key: 'Enter', preventDefault: () => {}})
 
-    mock_wrapper.setProps({formData: { id: "http://id.loc.gov/ontologies/bibframe/instanceOf", items: [{content: "fooby", id: 0}]} })
+    mock_wrapper.setProps({formData: { uri: "http://id.loc.gov/ontologies/bibframe/instanceOf", items: [{content: "fooby", id: 0}]} })
 
     mock_wrapper.find('input').simulate("change", { target: { value: "bar" }})
     mock_wrapper.find('input').simulate('keypress', {key: 'Enter', preventDefault: () => {}})
 
     expect(mockFormDataFn.mock.calls[0][0]).toEqual(
-      {id: "http://id.loc.gov/ontologies/bibframe/instanceOf", items:[{content: 'fooby', id: 3}], "rtId": "resourceTemplate:bf2:Monograph:Instance"}
+      {uri: "http://id.loc.gov/ontologies/bibframe/instanceOf", items:[{content: 'fooby', id: 3}], "rtId": "resourceTemplate:bf2:Monograph:Instance"}
     )
     expect(mockFormDataFn.mock.calls[1][0]).toEqual(
-      {id: "http://id.loc.gov/ontologies/bibframe/instanceOf", items:[], "rtId": "resourceTemplate:bf2:Monograph:Instance"}
+      {uri: "http://id.loc.gov/ontologies/bibframe/instanceOf", items:[], "rtId": "resourceTemplate:bf2:Monograph:Instance"}
     )
     mockFormDataFn.mock.calls = [] // reset the redux store to empty
 
@@ -141,7 +141,7 @@ describe('When the user enters input into field', ()=>{
     mock_wrapper.find('input').simulate("change", { target: { value: "foo" }})
     expect(mock_wrapper.state('content_add')).toEqual('foo')
     mock_wrapper.find('input').simulate('keypress', {key: 'Enter', preventDefault: () => {}})
-    mock_wrapper.setProps({formData: { id: "http://id.loc.gov/ontologies/bibframe/instanceOf", items: [{content: "foo", id: 4}]} })
+    mock_wrapper.setProps({formData: { uri: "http://id.loc.gov/ontologies/bibframe/instanceOf", items: [{content: "foo", id: 4}]} })
     expect(mock_wrapper.find('input').prop('required')).toBeFalsy()
     mock_wrapper.setProps({formData: undefined }) // reset props for next test
   })
@@ -149,14 +149,14 @@ describe('When the user enters input into field', ()=>{
   it('item appears when user inputs text into the field', () => {
     mock_wrapper.instance().props.propertyTemplate.repeatable = "false"
     mock_wrapper.instance().forceUpdate()
-    mock_wrapper.setProps({formData: { id: "http://id.loc.gov/ontologies/bibframe/instanceOf", items: [{content: "foo", id: 4}]} })
+    mock_wrapper.setProps({formData: { uri: "http://id.loc.gov/ontologies/bibframe/instanceOf", items: [{content: "foo", id: 4}]} })
     expect(mock_wrapper.find('div#userInput').text()).toEqual('fooX<Button /><Modal />') // contains X as a button to delete the input
     mock_wrapper.setProps({formData: undefined }) // reset props for next test
     mockFormDataFn.mock.calls = [] // reset the redux store to empty
   })
 
   it('should call the removeMockDataFn when X is clicked', () => {
-    mock_wrapper.setProps({formData: { id: "http://id.loc.gov/ontologies/bibframe/instanceOf", items: [{content: "test", id: 5}]} })
+    mock_wrapper.setProps({formData: { uri: "http://id.loc.gov/ontologies/bibframe/instanceOf", items: [{content: "test", id: 5}]} })
     expect(removeMockDataFn.mock.calls.length).toEqual(0);
     mock_wrapper.find('button#displayedItem').first().simulate('click', { target: { "dataset": {"item": 5 }}})
     expect(removeMockDataFn.mock.calls.length).toEqual(1);
@@ -188,7 +188,7 @@ describe('when there is a default literal value in the property template', () =>
     expect(wrapper.state('defaults')).toEqual(defaults)
     expect(mockFormDataFn.mock.calls[0][0]).toEqual(
       {
-        id: "http://id.loc.gov/ontologies/bibframe/instanceOf",
+        uri: "http://id.loc.gov/ontologies/bibframe/instanceOf",
         items:[{ content: 'DLC', id: 0, bnode: { termType: 'BlankNode', value: 'n3-0' }, propPredicate: undefined }],
         rtId: "resourceTemplate:bf2:Monograph:Instance"
       }

--- a/__tests__/components/editor/ResourceTemplateForm.test.js
+++ b/__tests__/components/editor/ResourceTemplateForm.test.js
@@ -61,7 +61,10 @@ const rtProps = {
   ]
 }
 
-const lits = { id: 0, content: 'content' }
+// const lits = { id: 0, content: 'content' }
+const lits =  {formData: [{id: 0, uri: 'http://uri', items: [
+        {content: '12345', id: 0, bnode: {termType: 'BlankNode', value: 'n3-0'}, propPredicate: 'http://predicate'}
+      ], rtId: 'resourceTemplate:bf2'}]}
 const lups = { id: 'id', uri: 'uri', label: 'label' }
 const ld = {
   "@context": {

--- a/__tests__/reducers/literal.test.js
+++ b/__tests__/reducers/literal.test.js
@@ -11,31 +11,31 @@ describe('literal reducer', () => {
     expect(
       literal({formData: []}, {
         type: 'SET_ITEMS',
-        payload: {id:'Run the tests', items: []}
+        payload: {uri:'Run the tests', items: []}
       })
     ).toEqual({
       "formData": [{
-        "id": "Run the tests", "items": []
+        "uri": "Run the tests", "items": []
       }]
     })
 
     expect(
       literal({
         "formData": [{
-          "id": "Run the tests", "items": []
+          "uri": "Run the tests", "items": []
         }]}, {
         type: 'SET_ITEMS',
-        payload: {id: "add this!", items: []}
+        payload: {uri: "add this!", items: []}
       })
     ).toEqual({
       "formData": [
-        {"id": "Run the tests", "items": []},
-        {"id": "add this!", "items": []}
+        {"uri": "Run the tests", "items": []},
+        {"uri": "add this!", "items": []}
     ]})
   })
   it('should handle REMOVE_ITEM', () => {
     expect(
-      literal({formData: [{id:"Test", items:[
+      literal({formData: [{uri:"Test", items:[
         {content: "test content", id: 0},
         {content: "more content", id: 1}
         ]}]}, {
@@ -44,23 +44,23 @@ describe('literal reducer', () => {
       })
     ).toEqual({
       "formData": [{
-        "id": "Test", "items": [{content: "more content", id: 1}]
+        "uri": "Test", "items": [{content: "more content", id: 1}]
       }]
     })
 
 
     expect(
       literal({formData: [
-        {id:"Test", items:[{content: "test content", id: 0}]},
-        {id:"Statement", items:[{content: "more test content", id: 0}]}
+        {uri:"Test", items:[{content: "test content", id: 0}]},
+        {uri:"Statement", items:[{content: "more test content", id: 0}]}
       ]}, {
         type: 'REMOVE_ITEM',
         payload: {id: 0, label: "Statement"}
       })
     ).toEqual({
       "formData": [
-        {"id": "Test", "items": [{content: "test content", id: 0}]},
-        {"id": "Statement", "items": []}
+        {"uri": "Test", "items": [{content: "test content", id: 0}]},
+        {"uri": "Statement", "items": []}
       ]
     })
   })

--- a/src/components/editor/InputLiteral.jsx
+++ b/src/components/editor/InputLiteral.jsx
@@ -254,9 +254,9 @@ InputLiteral.propTypes = {
   rtId: PropTypes.string,
   blankNodeForLiteral: PropTypes.object,
   propPredicate: PropTypes.string,
-  buttonID: PropTypes.string,
-  setDefaultsForLiteralWithPayLoad: PropTypes.func.isRequired,
-  defaultsForLiteral: PropTypes.func.isRequired
+  buttonID: PropTypes.number,
+  setDefaultsForLiteralWithPayLoad: PropTypes.func,
+  defaultsForLiteral: PropTypes.func
 }
 
 const mapStatetoProps = (state, props) => {

--- a/src/components/editor/InputLiteral.jsx
+++ b/src/components/editor/InputLiteral.jsx
@@ -24,24 +24,19 @@ export class InputLiteral extends Component {
     this.lastId = -1
 
     try {
-      if (this.props.propertyTemplate.repeatable == "false") {
-        this.state.disabled = true
-      }
-    } catch (error) {
-      console.log(`repeatable not defined in the property template: ${error}`)
-    }
-
-    try {
       const defaultValue = this.props.propertyTemplate.valueConstraint.defaults[0]
       const propPredicate = this.props.propPredicate
       let defaults = this.props.defaultsForLiteral(defaultValue.defaultLiteral, propPredicate)
       this.props.setDefaultsForLiteralWithPayLoad(this.props.buttonID, this.props.propertyTemplate.propertyURI, defaults, this.props.rtId)
+      if (this.props.propertyTemplate.repeatable == "false") {
+        this.state.disabled = true
+      }
     } catch (error) {
       console.log(`defaults not defined in the property template: ${error}`)
     }
   }
 
-  handleShow() {
+  handleShow = () => {
     this.setState({ show: true })
   }
 
@@ -58,7 +53,7 @@ export class InputLiteral extends Component {
     this.setState({ content_add: usr_input })
   }
 
-  notRepeatable = (userInputArray, currentcontent) => {
+  notRepeatableAfterUserInput = (userInputArray, currentcontent) => {
     if (this.props.formData == undefined || this.props.formData.items < 1){
       this.addUserInput(userInputArray, currentcontent)
       this.setState({ disabled: true })
@@ -86,7 +81,7 @@ export class InputLiteral extends Component {
         this.addUserInput(userInputArray, currentcontent)
       /** Input field is not repeatable **/
       } else if (this.props.propertyTemplate.repeatable == "false") {
-        this.notRepeatable(userInputArray, currentcontent)
+        this.notRepeatableAfterUserInput(userInputArray, currentcontent)
       }
       const user_input = {
         id: this.props.buttonID,

--- a/src/components/editor/InputLiteral.jsx
+++ b/src/components/editor/InputLiteral.jsx
@@ -253,7 +253,10 @@ InputLiteral.propTypes = {
   handleRemoveItem: PropTypes.func,
   rtId: PropTypes.string,
   blankNodeForLiteral: PropTypes.object,
-  propPredicate: PropTypes.string
+  propPredicate: PropTypes.string,
+  buttonID: PropTypes.string,
+  setDefaultsForLiteralWithPayLoad: PropTypes.func.isRequired,
+  defaultsForLiteral: PropTypes.func.isRequired
 }
 
 const mapStatetoProps = (state, props) => {

--- a/src/components/editor/InputLiteral.jsx
+++ b/src/components/editor/InputLiteral.jsx
@@ -19,38 +19,29 @@ export class InputLiteral extends Component {
     this.state = {
       show: false,
       content_add: "",
-      defaults: [],
       disabled: false
     }
     this.lastId = -1
 
     try {
-     const defaultValue = this.props.propertyTemplate.valueConstraint.defaults[0]
-      this.state.defaults = [{
-        content: defaultValue.defaultLiteral,
-        id: ++this.lastId,
-        bnode: this.props.blankNodeForLiteral,
-        propPredicate: this.props.propPredicate
-      }]
-      this.setPayLoad(this.state.defaults)
       if (this.props.propertyTemplate.repeatable == "false") {
         this.state.disabled = true
       }
+    } catch (error) {
+      console.log(`repeatable not defined in the property template: ${error}`)
+    }
+
+    try {
+      const defaultValue = this.props.propertyTemplate.valueConstraint.defaults[0]
+      const propPredicate = this.props.propPredicate
+      let defaults = this.props.defaultsForLiteral(defaultValue.defaultLiteral, propPredicate)
+      this.props.setDefaultsForLiteralWithPayLoad(this.props.buttonID, this.props.propertyTemplate.propertyURI, defaults, this.props.rtId)
     } catch (error) {
       console.log(`defaults not defined in the property template: ${error}`)
     }
   }
 
-  setPayLoad = (defaults) => {
-    const payload = {
-      id: this.props.propertyTemplate.propertyURI,
-      items: defaults,
-      rtId: this.props.rtId
-    }
-    this.props.handleMyItemsChange(payload)
-  }
-
-  handleShow = () => {
+  handleShow() {
     this.setState({ show: true })
   }
 
@@ -98,7 +89,8 @@ export class InputLiteral extends Component {
         this.notRepeatable(userInputArray, currentcontent)
       }
       const user_input = {
-        id: this.props.propertyTemplate.propertyURI,
+        id: this.props.buttonID,
+        uri: this.props.propertyTemplate.propertyURI,
         rtId: this.props.rtId,
         items: userInputArray
       }
@@ -201,7 +193,7 @@ export class InputLiteral extends Component {
           onClick={this.handleClick}
           key={obj.id}
           data-item={obj.id}
-          data-label={formInfo.id}
+          data-label={formInfo.uri}
         >X
         </button>
         <Button
@@ -254,7 +246,7 @@ InputLiteral.propTypes = {
     })
   }).isRequired,
   formData: PropTypes.shape({
-    id: PropTypes.string.isRequired,
+    uri: PropTypes.string.isRequired,
     items: PropTypes.array
   }),
   handleMyItemsChange: PropTypes.func,
@@ -266,7 +258,7 @@ InputLiteral.propTypes = {
 
 const mapStatetoProps = (state, props) => {
   return {
-    formData: state.literal.formData.find(obj => obj.id === props.propertyTemplate.propertyURI)
+    formData: state.literal.formData.find(obj => obj.uri === props.propertyTemplate.propertyURI)
   }
 }
 

--- a/src/components/editor/ModalToggle.jsx
+++ b/src/components/editor/ModalToggle.jsx
@@ -33,6 +33,7 @@ class ModalToggle extends Component {
         <ResourceTemplateModal
           modalId={modalId}
           rtId={rtId}
+          buttonID={this.props.buttonID}
           resourceTemplate={this.props.resourceTemplate}
           propertyTemplates={this.props.propertyTemplates}
           visible={this.state.visible}

--- a/src/components/editor/ModalToggle.jsx
+++ b/src/components/editor/ModalToggle.jsx
@@ -53,7 +53,7 @@ ModalToggle.propTypes = {
   rtId: PropTypes.string.isRequired,
   rdfOuterSubject: PropTypes.object,
   propPredicate: PropTypes.string,
-  buttonID: PropTypes.string
+  buttonID: PropTypes.number
 }
 
 export default ModalToggle

--- a/src/components/editor/ModalToggle.jsx
+++ b/src/components/editor/ModalToggle.jsx
@@ -53,6 +53,7 @@ ModalToggle.propTypes = {
   rtId: PropTypes.string.isRequired,
   rdfOuterSubject: PropTypes.object,
   propPredicate: PropTypes.string,
+  buttonID: PropTypes.string
 }
 
 export default ModalToggle

--- a/src/components/editor/ResourceTemplate.jsx
+++ b/src/components/editor/ResourceTemplate.jsx
@@ -74,7 +74,7 @@ class ResourceTemplate extends Component {
 
 ResourceTemplate.propTypes = {
   resourceTemplateId: PropTypes.string,
-  resourceTemplateData: PropTypes.object
+  resourceTemplateData: PropTypes.string
 }
 
 export default  ResourceTemplate

--- a/src/components/editor/ResourceTemplateForm.jsx
+++ b/src/components/editor/ResourceTemplateForm.jsx
@@ -13,7 +13,7 @@ import RequiredSuperscript from './RequiredSuperscript'
 import ModalToggle from './ModalToggle'
 import RDFModal from './RDFModal'
 import lookupConfig from '../../../static/spoofedFilesFromServer/fromSinopiaServer/lookupConfig.json'
-import { getLD } from '../../actions/index'
+import { getLD, setItems } from '../../actions/index'
 const { getResourceTemplate } = require('../../sinopiaServerSpoof.js')
 const N3 = require('n3')
 const { DataFactory } = N3
@@ -54,21 +54,61 @@ class ResourceTemplateForm extends Component {
     this.setState( { showRdf: false } )
   }
 
+  // TODO: deal with more than one default value?
+  defaultsForLiteral = (content, predicate) => {
+    return [{
+      content: content,
+      id: 0,
+      bnode: this.state.rdfOuterSubject,
+      propPredicate: predicate
+    }]
+  }
+
+  setDefaultsForLiteralWithPayLoad = (button, propURI, defaults, rtid) => {
+    const payload = {
+      id: button,
+      uri: propURI,
+      items: defaults,
+      rtId: rtid
+    }
+    if (defaults != undefined) {
+      this.props.handleMyItemsChange(payload)
+    }
+  }
+
+  getContentForModalButton = (rtId) => {
+    let content
+    let resourceTemplate = getResourceTemplate(rtId)
+    const pt = resourceTemplate.propertyTemplates[0]
+    if (this.isLiteralWithDefaultValue(pt)) {
+      content = pt.valueConstraint.defaults[0].defaultLiteral
+    }
+    return content
+  }
+
   // Note: rtIds is expected to be an array of length at least one
-  resourceTemplateButtons = (rtIds, propURI) => {
+  resourceTemplateButtons = (rtIds, propURI, buttonID) => {
     let buttons = []
     rtIds.map((rtId, i) => {
-      buttons.push(<ButtonGroup key={`${rtId}-${i}`}>{this.rtModalButton(rtId, propURI)}</ButtonGroup>)
+      buttons.push(<ButtonGroup key={`${rtId}-${i}`}>{this.rtModalButton(rtId, propURI, buttonID)}</ButtonGroup>)
+      let content = this.getContentForModalButton(rtId)
+      let defaults = this.defaultsForLiteral(content, propURI)
+      if (defaults[0].content !== undefined) {
+        if (this.props.literals.formData.length === 0) {
+          this.setDefaultsForLiteralWithPayLoad(buttonID, propURI, defaults, rtId)
+        }
+      }
     })
     return buttons
   }
 
-  rtModalButton = (rtId, propURI) => {
+  rtModalButton = (rtId, propURI, buttonID) => {
     let resourceTemplate = getResourceTemplate(rtId)
     return (
       <ModalToggle
         key={rtId}
         rtId={rtId}
+        buttonID={buttonID}
         buttonLabel={resourceTemplate.resourceLabel}
         propertyTemplates={resourceTemplate.propertyTemplates}
         resourceTemplate={resourceTemplate}
@@ -104,7 +144,25 @@ class ResourceTemplateForm extends Component {
     })
   }
 
-  setInputs = () => {
+  isLiteralWithDefaultValue = (pt) => {
+    return Boolean(
+      pt.type === 'literal' &&
+      pt.valueConstraint !== undefined &&
+      pt.valueConstraint.defaults !== undefined &&
+      pt.valueConstraint.defaults.length > 0
+    )
+  }
+
+  isResourceWithValueTemplateRef = (pt) => {
+    return Boolean(
+      pt.type === 'resource' &&
+      pt.valueConstraint != null &&
+      pt.valueConstraint.valueTemplateRefs != null &&
+      pt.valueConstraint.valueTemplateRefs.length > 0
+    )
+  }
+
+  setInputs() {
     let inputs = {}
     inputs['literals'] = this.props.literals
     inputs['lookups'] = this.props.lookups
@@ -155,43 +213,61 @@ class ResourceTemplateForm extends Component {
                       }
                     }
 
-                  let isResourceWithValueTemplateRefs = Boolean(
-                    pt.type == 'resource' &&
-                    pt.valueConstraint != null &&
-                    pt.valueConstraint.valueTemplateRefs != null
-                    && pt.valueConstraint.valueTemplateRefs.length > 0
-                  )
-
-                  if (listComponent === 'list'){
-                    return (
-                      <InputListLOC propertyTemplate = {pt} lookupConfig = {lookupConfigItem} key = {index} rtId = {this.props.rtId} />
-                    )
-                  }
-                  else if (listComponent ===  'lookup'){
-                    return(
-                      <InputLookupQA propertyTemplate = {pt} lookupConfig = {lookupConfigItem} key = {index} rtId = {this.props.rtId} />
-                    )
-                  }
-                  else if(pt.type == 'literal'){
-                    return(
-                      <InputLiteral propertyTemplate = {pt} key = {index} id = {index} rtId = {this.props.rtId} blankNodeForLiteral={this.state.rdfOuterSubject} propPredicate={this.props.propPredicate}/>
-                    )
-                  }
-                  else if (isResourceWithValueTemplateRefs) {
-                    // TODO: some valueTemplateRefs may be lookups??
-                    return (
-                      <ButtonToolbar key={index}>
-                        <div>
-                          <label title={pt.remark}>{this.hasPropertyRemark(pt)}{this.mandatorySuperscript(pt.mandatory)}</label>
-                        </div>
-                        {this.resourceTemplateButtons(pt.valueConstraint.valueTemplateRefs, pt.propertyURI)}
-                      </ButtonToolbar>
+                    if (listComponent === 'list'){
+                      return (
+                        <InputListLOC propertyTemplate = {pt} lookupConfig = {lookupConfigItem} key = {index} rtId = {this.props.rtId} />
                       )
                     }
-                    else if (pt.type == 'resource'){
-                      return (<p key={index}><b>{pt.propertyLabel}</b>: <i>NON-modal resource</i></p>)
+                    else if (listComponent ===  'lookup'){
+                      return(
+                        <InputLookupQA propertyTemplate = {pt} lookupConfig = {lookupConfigItem} key = {index} rtId = {this.props.rtId} />
+                      )
                     }
-                  })
+                    else if(pt.type == 'literal'){
+                      return(
+                        <InputLiteral propertyTemplate={pt} key={index} id={index}
+                                      rtId={this.props.rtId}
+                                      blankNodeForLiteral={this.state.rdfOuterSubject}
+                                      propPredicate={this.props.propPredicate}
+                                      buttonID={this.props.buttonID}
+                                      defaultsForLiteral={this.defaultsForLiteral}
+                                      setDefaultsForLiteralWithPayLoad={this.setDefaultsForLiteralWithPayLoad} />
+                      )
+                    }
+                    else if (this.isResourceWithValueTemplateRef(pt)) {
+                      let buttonId
+                      let littleButton
+                      this.props.literals.formData.map((obj) => {
+                        buttonId = obj.id
+                        if (buttonId !== undefined && buttonId === index) {
+                          const buttonContent = obj.items
+                          if (buttonContent == undefined) return
+                          buttonContent.map((item) => {
+                            littleButton = item.content
+                          })
+                        }
+                      })
+                      // TODO: some valueTemplateRefs may be lookups??
+                      return (
+                        <ButtonToolbar key={index}>
+                          <div>
+                            <label title={pt.remark}>{this.hasPropertyRemark(pt)}{this.mandatorySuperscript(pt.mandatory)}</label>
+                          </div>
+                          <div>
+                            {this.resourceTemplateButtons(pt.valueConstraint.valueTemplateRefs, pt.propertyURI, index)}
+                          </div>
+                          <br/><br/>
+                          <div>
+                            {littleButton}
+                          </div>
+                        </ButtonToolbar>
+                        )
+                      }
+                      else if (pt.type == 'resource'){
+                        return (<p key={index}><b>{pt.propertyLabel}</b>: <i>NON-modal resource</i></p>)
+                      }
+                    }
+                  )
                  }
                 </div>
               <p>END ResourceTemplateForm</p>
@@ -228,8 +304,12 @@ const mapStateToProps = (state) => {
 }
 
 const mapDispatchToProps = dispatch => ({
+  handleMyItemsChange(user_input){
+    dispatch(setItems(user_input))
+  },
   handleGenerateLD(inputs){
-    dispatch(getLD(inputs))}
+    dispatch(getLD(inputs))
+  }
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(ResourceTemplateForm)

--- a/src/components/editor/ResourceTemplateForm.jsx
+++ b/src/components/editor/ResourceTemplateForm.jsx
@@ -292,7 +292,9 @@ ResourceTemplateForm.propTypes = {
   parentResourceTemplate: PropTypes.string,
   rdfOuterSubject: PropTypes.object,
   propPredicate: PropTypes.string,
-  generateLD: PropTypes.object.isRequired
+  buttonID: PropTypes.string,
+  generateLD: PropTypes.object.isRequired,
+  handleMyItemsChange: PropTypes.object.isRequired
 }
 
 const mapStateToProps = (state) => {

--- a/src/components/editor/ResourceTemplateForm.jsx
+++ b/src/components/editor/ResourceTemplateForm.jsx
@@ -172,6 +172,18 @@ class ResourceTemplateForm extends Component {
     return inputs
   }
 
+  renderValueButton(buttonValue) {
+    if (buttonValue != undefined) {
+      return (
+        <div className="btn-group btn-group-xs">
+          <button type="button" className="btn btn-sm btn-default">{buttonValue}</button>
+          <button disabled className="btn btn-warning" type="button"><span className="glyphicon glyphicon-pencil"></span></button>
+          <button disabled className="btn btn-danger" type="button"><span className="glyphicon glyphicon-trash"></span> </button>
+        </div>
+      )
+    }
+  }
+
   render() {
     let dashedBorder = {
       border: '1px dashed',
@@ -236,14 +248,14 @@ class ResourceTemplateForm extends Component {
                     }
                     else if (this.isResourceWithValueTemplateRef(pt)) {
                       let buttonId
-                      let littleButton
+                      let valueButton
                       this.props.literals.formData.map((obj) => {
                         buttonId = obj.id
                         if (buttonId !== undefined && buttonId === index) {
                           const buttonContent = obj.items
                           if (buttonContent == undefined) return
                           buttonContent.map((item) => {
-                            littleButton = item.content
+                            valueButton = item.content
                           })
                         }
                       })
@@ -257,9 +269,7 @@ class ResourceTemplateForm extends Component {
                             {this.resourceTemplateButtons(pt.valueConstraint.valueTemplateRefs, pt.propertyURI, index)}
                           </div>
                           <br/><br/>
-                          <div>
-                            {littleButton}
-                          </div>
+                          {this.renderValueButton(valueButton)}
                         </ButtonToolbar>
                         )
                       }
@@ -292,9 +302,9 @@ ResourceTemplateForm.propTypes = {
   parentResourceTemplate: PropTypes.string,
   rdfOuterSubject: PropTypes.object,
   propPredicate: PropTypes.string,
-  buttonID: PropTypes.string,
+  buttonID: PropTypes.number,
   generateLD: PropTypes.object.isRequired,
-  handleMyItemsChange: PropTypes.object.isRequired
+  handleMyItemsChange: PropTypes.func
 }
 
 const mapStateToProps = (state) => {

--- a/src/components/editor/ResourceTemplateModal.jsx
+++ b/src/components/editor/ResourceTemplateModal.jsx
@@ -54,7 +54,8 @@ ResourceTemplateModal.propTypes = {
   toggleVisibility: PropTypes.func.isRequired,
   visible: PropTypes.bool.isRequired,
   rdfOuterSubject: PropTypes.object,
-  propPredicate: PropTypes.string
+  propPredicate: PropTypes.string,
+  buttonID: PropTypes.string
 }
 
 const mapDispatchToProps = dispatch => (

--- a/src/components/editor/ResourceTemplateModal.jsx
+++ b/src/components/editor/ResourceTemplateModal.jsx
@@ -34,6 +34,7 @@ class ResourceTemplateModal extends Component {
               rdfOuterSubject={this.props.rdfOuterSubject}
               propPredicate={this.props.propPredicate}
               rtId={this.props.rtId}
+              buttonID={this.props.buttonID}
             />
           </Modal.Body>
           <Modal.Footer>

--- a/src/components/editor/ResourceTemplateModal.jsx
+++ b/src/components/editor/ResourceTemplateModal.jsx
@@ -55,7 +55,7 @@ ResourceTemplateModal.propTypes = {
   visible: PropTypes.bool.isRequired,
   rdfOuterSubject: PropTypes.object,
   propPredicate: PropTypes.string,
-  buttonID: PropTypes.string
+  buttonID: PropTypes.number
 }
 
 const mapDispatchToProps = dispatch => (

--- a/src/reducers/literal.js
+++ b/src/reducers/literal.js
@@ -13,9 +13,9 @@ const removeMyItem = (state, action) => {
   let newListItems = state.formData.slice(0)
   const itemToDelete = action.payload
   let new_state = newListItems.map(obj => {
-    if(obj.id == itemToDelete.label){
+    if(obj.uri == itemToDelete.label){
       const newItemArray = deleteItem(obj, itemToDelete)
-      return {id: obj.id, items: newItemArray}
+      return {uri: obj.uri, items: newItemArray}
     } else {
       return obj
     }
@@ -27,7 +27,7 @@ const setMyItems = (state, action) => {
   let newFormData = state.formData.slice(0)
   let needNewItemArray = true;
   for (let field of newFormData) {
-    if (field.id == action.payload.id) {
+    if (field.uri == action.payload.uri) {
       field.items = field.items.concat(action.payload.items)
       needNewItemArray = false;
       break;


### PR DESCRIPTION
Fixes #345 
- Changes formData `id` to `uri` to accommodate having a unique ID to display the input value for a resource on the main form
- Able to read and update redux `formData` items from `ResourceTemplateForm` with default values and create a styled button from that data
- Callback functions to `ResourceTemplateForm` from `InputLiteral` to update the redux state
- Make functions for checking whether something is resource template with value constraints
- Pass the ID for a resource modal button around and back to `ResourceTemplateForm` for use in identifying which values will show with each button.
- Changes `notRepeatable`  to `notRepeatableAfterUserInput` for clarity
- Adds new PropType validations where needed