### PR TITLE
Remove content for resource (modal) from store and main form

### DIFF
--- a/__tests__/reducers/literal.test.js
+++ b/__tests__/reducers/literal.test.js
@@ -64,5 +64,26 @@ describe('literal reducer', () => {
       ]
     })
   })
+
+  it('should handle REMOVE_ALL_CONTENT', () => {
+    expect(
+      literal({
+        formData: [
+          {id: 1, uri:"Test", items:[
+            {content: "test content", id: 0},
+            {content: "test content2", id: 1}
+          ]},
+          {id: 2, uri:"Test2", items:[
+            {content: "test2 content", id: 0},
+            {content: "test2 content2", id: 1}
+          ]}
+        ]},
+        { type: 'REMOVE_ALL_CONTENT', payload: 1})
+    ).toEqual({
+      "formData": [
+        {"id": 2, "uri": "Test2", "items": [{content: "test2 content", id: 0}, {content: "test2 content2", id: 1}]}
+      ]
+    })
+  })
 })
 

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -8,6 +8,11 @@ export const removeItem = item => ({
   payload: item
 })
 
+export const removeAllContent = item => ({
+  type: 'REMOVE_ALL_CONTENT',
+  payload: item
+})
+
 export const removeAllItems = item => ({
   type: 'REMOVE_ALL',
   payload: item

--- a/src/components/editor/InputLiteral.jsx
+++ b/src/components/editor/InputLiteral.jsx
@@ -97,7 +97,7 @@ export class InputLiteral extends Component {
     }
   }
 
-  handleClick = (event) => {
+  handleItemClick = (event) => {
     const labelToRemove = event.target.dataset["label"]
     const idToRemove = Number(event.target.dataset["item"])
     this.props.handleRemoveItem(
@@ -185,7 +185,7 @@ export class InputLiteral extends Component {
         <button
           id="displayedItem"
           type="button"
-          onClick={this.handleClick}
+          onClick={this.handleItemClick}
           key={obj.id}
           data-item={obj.id}
           data-label={formInfo.uri}

--- a/src/components/editor/ResourceTemplateForm.jsx
+++ b/src/components/editor/ResourceTemplateForm.jsx
@@ -13,7 +13,7 @@ import RequiredSuperscript from './RequiredSuperscript'
 import ModalToggle from './ModalToggle'
 import RDFModal from './RDFModal'
 import lookupConfig from '../../../static/spoofedFilesFromServer/fromSinopiaServer/lookupConfig.json'
-import { getLD, setItems } from '../../actions/index'
+import {getLD, setItems, removeAllContent} from '../../actions/index'
 const { getResourceTemplate } = require('../../sinopiaServerSpoof.js')
 const N3 = require('n3')
 const { DataFactory } = N3
@@ -172,13 +172,21 @@ class ResourceTemplateForm extends Component {
     return inputs
   }
 
-  renderValueButton(buttonValue) {
+  handleTrashValue = (buttonIndex) => {
+    this.props.handleRemoveAllContent(buttonIndex)
+  }
+
+  renderValueForButton(buttonValue, buttonIndex) {
     if (buttonValue != undefined) {
       return (
         <div className="btn-group btn-group-xs">
           <button type="button" className="btn btn-sm btn-default">{buttonValue}</button>
-          <button disabled className="btn btn-warning" type="button"><span className="glyphicon glyphicon-pencil"></span></button>
-          <button disabled className="btn btn-danger" type="button"><span className="glyphicon glyphicon-trash"></span> </button>
+          <button disabled className="btn btn-warning" type="button">
+            <span className="glyphicon glyphicon-pencil"/>
+          </button>
+          <button className="btn btn-danger" type="button" onClick={() => this.handleTrashValue(buttonIndex)}>
+            <span className="glyphicon glyphicon-trash"/>
+          </button>
         </div>
       )
     }
@@ -248,15 +256,16 @@ class ResourceTemplateForm extends Component {
                     }
                     else if (this.isResourceWithValueTemplateRef(pt)) {
                       let buttonId
-                      let valueButton
+                      let valueForButton
                       this.props.literals.formData.map((obj) => {
                         buttonId = obj.id
                         if (buttonId !== undefined && buttonId === index) {
                           const buttonContent = obj.items
-                          if (buttonContent == undefined) return
-                          buttonContent.map((item) => {
-                            valueButton = item.content
-                          })
+                          if (buttonContent !== undefined) {
+                            buttonContent.map((item, i) => {
+                              i === 0 ? valueForButton = `${item.content} ` : valueForButton += `${item.content} `
+                            })
+                          }
                         }
                       })
                       // TODO: some valueTemplateRefs may be lookups??
@@ -269,7 +278,7 @@ class ResourceTemplateForm extends Component {
                             {this.resourceTemplateButtons(pt.valueConstraint.valueTemplateRefs, pt.propertyURI, index)}
                           </div>
                           <br/><br/>
-                          {this.renderValueButton(valueButton)}
+                          {this.renderValueForButton(valueForButton, index)}
                         </ButtonToolbar>
                         )
                       }
@@ -318,6 +327,9 @@ const mapStateToProps = (state) => {
 const mapDispatchToProps = dispatch => ({
   handleMyItemsChange(user_input){
     dispatch(setItems(user_input))
+  },
+  handleRemoveAllContent(id){
+    dispatch(removeAllContent(id))
   },
   handleGenerateLD(inputs){
     dispatch(getLD(inputs))

--- a/src/components/editor/ResourceTemplateForm.jsx
+++ b/src/components/editor/ResourceTemplateForm.jsx
@@ -313,7 +313,8 @@ ResourceTemplateForm.propTypes = {
   propPredicate: PropTypes.string,
   buttonID: PropTypes.number,
   generateLD: PropTypes.object.isRequired,
-  handleMyItemsChange: PropTypes.func
+  handleMyItemsChange: PropTypes.func,
+  handleRemoveAllContent: PropTypes.func
 }
 
 const mapStateToProps = (state) => {

--- a/src/reducers/literal.js
+++ b/src/reducers/literal.js
@@ -2,6 +2,15 @@ const DEFAULT_STATE = {
   formData: []
 }
 
+const removeAllContent = (state, action) => {
+  let newFormData = state.formData.slice(0)
+  const idToDelete = action.payload
+  let new_state = newFormData.filter(data => {
+    return data.id !== idToDelete
+  })
+  return {formData: new_state}
+}
+
 const deleteItem = (obj, itemToDelete) => {
   const new_items = obj.items.filter(item => {
     return item.id != itemToDelete.id
@@ -46,6 +55,8 @@ const literal = (state=DEFAULT_STATE, action) => {
       return setMyItems(state,action)
     case 'REMOVE_ITEM':
       return removeMyItem(state,action)
+    case 'REMOVE_ALL_CONTENT':
+      return removeAllContent(state,action)
     default:
       return state
   }


### PR DESCRIPTION
Fixes #357 
- Create a REMOVE_ALL_CONTENT action for the `literal` reducer that removes all the items for `formData` when the little trash can icon is clicked on the main resource template form
- Renames the `handleClick` function in the `InputLiteral` component in order to better distinguish these separate actions.