### PR TITLE
When setting default literal values, make sure to increment last id

### DIFF
--- a/__tests__/components/editor/InputLiteral.test.js
+++ b/__tests__/components/editor/InputLiteral.test.js
@@ -174,15 +174,25 @@ describe('When the user enters input into field', ()=>{
 describe('when there is a default literal value in the property template', () => {
   it('sets the default values according to the property template if they exist', () => {
     plProps.propertyTemplate['valueConstraint'] = valConstraintProps
+
     const setDefaultsForLiteralWithPayLoad = jest.fn()
     const defaultsForLiteral = jest.fn()
-    shallow(<InputLiteral {...plProps} id={12}
+    defaultsForLiteral.mockReturnValue({
+      content: "content",
+      id: 0,
+      bnode: { termType: 'BlankNode', value: 'n3-0'},
+      propPredicate: "predicate"
+    })
+
+    const wrapper = shallow(<InputLiteral {...plProps} id={12}
                           blankNodeForLiteral={{ termType: 'BlankNode', value: 'n3-0'}}
                           rtId={'resourceTemplate:bf2:Monograph:Instance'}
                           setDefaultsForLiteralWithPayLoad={setDefaultsForLiteralWithPayLoad}
-                          defaultsForLiteral={defaultsForLiteral} />)
+                          defaultsForLiteral={defaultsForLiteral}
+    />)
     expect(setDefaultsForLiteralWithPayLoad).toHaveBeenCalledTimes(1)
     expect(defaultsForLiteral).toHaveBeenCalledTimes(1)
+    expect(wrapper.instance().lastId).toEqual(0)
   })
 
   describe('when repeatable="false"', () => {

--- a/src/components/editor/InputLiteral.jsx
+++ b/src/components/editor/InputLiteral.jsx
@@ -27,6 +27,7 @@ export class InputLiteral extends Component {
       const defaultValue = this.props.propertyTemplate.valueConstraint.defaults[0]
       const propPredicate = this.props.propPredicate
       let defaults = this.props.defaultsForLiteral(defaultValue.defaultLiteral, propPredicate)
+      if (defaults !== undefined) ++this.lastId
       this.props.setDefaultsForLiteralWithPayLoad(this.props.buttonID, this.props.propertyTemplate.propertyURI, defaults, this.props.rtId)
       if (this.props.propertyTemplate.repeatable == "false") {
         this.state.disabled = true
@@ -241,7 +242,8 @@ InputLiteral.propTypes = {
     })
   }).isRequired,
   formData: PropTypes.shape({
-    uri: PropTypes.string.isRequired,
+    id: PropTypes.string,
+    uri: PropTypes.string,
     items: PropTypes.array
   }),
   handleMyItemsChange: PropTypes.func,


### PR DESCRIPTION
Fixes #361 

Also, making the proptype validation for `formData.uri` not required, because we do not always have this value, for example, in the tests and in the removeAllItems function when we empty out the formData state completely.