### PR TITLE
Login functionality

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -47,7 +47,7 @@ module.exports = {
   },
   overrides: [
     {
-      "files": ["**/*.jsx", "src/index.js", "src/*/*.js", "src/store.js"],
+      "files": ["**/*.jsx", "src/index.js", "src/*/*.js", "src/store.js", "src/Config.js", "src/Logout.js"],
       "rules": {
         // See https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/no-unsupported-features/es-syntax.md
         //   rule supposedly matches ECMA version with node

--- a/__tests__/Config.test.js
+++ b/__tests__/Config.test.js
@@ -1,0 +1,100 @@
+import Config from '../src/Config'
+
+const OLD_ENV = process.env
+
+describe('Config', () => {
+  describe('static default values', () => {
+    it('sinopia uri has static value', () => {
+      expect(Config.sinopiaUri).toEqual('https://sinopia.io')
+    })
+
+    it('aws client ID has static value', () => {
+      expect(Config.awsClientID).toEqual('69u288s9ia8ible8gg1n4k0gou')
+    })
+
+    it('aws cognito domain has static value', () => {
+      expect(Config.awsCognitoDomain).toEqual('sinopia-development.auth.us-west-2.amazoncognito.com')
+    })
+
+    describe('interpolated links from default values', () => {
+      it('', () => {
+        expect(Config.awsCognitoLoginUrl).toEqual(
+          'https://sinopia-development.auth.us-west-2.amazoncognito.com/login?response_type=token&client_id=69u288s9ia8ible8gg1n4k0gou&redirect_uri=https://sinopia.io'
+        )
+      })
+
+      it('', () => {
+        expect(Config.awsCognitoLogoutUrl).toEqual(
+          'https://sinopia-development.auth.us-west-2.amazoncognito.com/logout?response_type=token&client_id=69u288s9ia8ible8gg1n4k0gou&logout_uri=https://sinopia.io&redirect_uri=https://sinopia.io'
+        )
+      })
+
+      it('', () => {
+        expect(Config.awsCognitoForgotPasswordUrl).toEqual(
+          'https://sinopia-development.auth.us-west-2.amazoncognito.com/forgotPassword?response_type=token&client_id=69u288s9ia8ible8gg1n4k0gou&redirect_uri=https://sinopia.io'
+        )
+      })
+
+      it('', () => {
+        expect(Config.awsCognitoResetPasswordUrl).toEqual(
+          'https://sinopia-development.auth.us-west-2.amazoncognito.com/signup?response_type=token&client_id=69u288s9ia8ible8gg1n4k0gou&redirect_uri=https://sinopia.io'
+        )
+      })
+    })
+
+  })
+
+  describe('static environmental values overrides', () => {
+
+    beforeAll(() => {
+      process.env = {
+        SINOPIA_URI: 'https://sinopia.foo',
+        AWS_CLIENT_ID: '1a2b3c',
+        AWS_COGNITO_DOMAIN: 'sinopia-foo.amazoncognito.com'
+      }
+    })
+
+    it('sinopia uri has static value', () => {
+      expect(Config.sinopiaUri).toEqual('https://sinopia.foo')
+    })
+
+    it('aws client ID has static value', () => {
+      expect(Config.awsClientID).toEqual('1a2b3c')
+    })
+
+    it('aws cognito domain has static value', () => {
+      expect(Config.awsCognitoDomain).toEqual('sinopia-foo.amazoncognito.com')
+    })
+
+    describe('interpolated links from environmental overrides', () => {
+      it('', () => {
+        expect(Config.awsCognitoLoginUrl).toEqual(
+          'https://sinopia-foo.amazoncognito.com/login?response_type=token&client_id=1a2b3c&redirect_uri=https://sinopia.foo'
+        )
+      })
+
+      it('', () => {
+        expect(Config.awsCognitoLogoutUrl).toEqual(
+          'https://sinopia-foo.amazoncognito.com/logout?response_type=token&client_id=1a2b3c&logout_uri=https://sinopia.foo&redirect_uri=https://sinopia.foo'
+        )
+      })
+
+      it('', () => {
+        expect(Config.awsCognitoForgotPasswordUrl).toEqual(
+          'https://sinopia-foo.amazoncognito.com/forgotPassword?response_type=token&client_id=1a2b3c&redirect_uri=https://sinopia.foo'
+        )
+      })
+
+      it('', () => {
+        expect(Config.awsCognitoResetPasswordUrl).toEqual(
+          'https://sinopia-foo.amazoncognito.com/signup?response_type=token&client_id=1a2b3c&redirect_uri=https://sinopia.foo'
+        )
+      })
+    })
+
+    afterAll(() => {
+      process.env = OLD_ENV
+    })
+  })
+
+})

--- a/__tests__/Logout.test.js
+++ b/__tests__/Logout.test.js
@@ -1,0 +1,9 @@
+import Config from '../src/Config'
+import Logout from '../src/Logout'
+
+const logout = new Logout()
+describe('Logging out', () => {
+  it('has a redirect url to aws cognito', () => {
+    expect(logout.url).toEqual(Config.awsCognitoLogoutUrl)
+  })
+})

--- a/__tests__/actions/index.test.js
+++ b/__tests__/actions/index.test.js
@@ -39,3 +39,21 @@ describe('getLD action', () => {
     })
   })
 })
+
+describe('logIn action', () => {
+  it('logIn should create LOG_IN action', () => {
+    const jwt = {login: {id_token: '1a2b3c', access_token: 'a1b2c3', expires_in: 3600, isAuthenticated: true} }
+    expect(actions.logIn(jwt)).toEqual({
+      type: 'LOG_IN',
+      payload: jwt
+    })
+  })
+})
+
+describe('logOut action', () => {
+  it('logOut should create LOG_OUT action', () => {
+    expect(actions.logOut()).toEqual({
+      type: 'LOG_OUT'
+    })
+  })
+})

--- a/__tests__/components/App.test.js
+++ b/__tests__/components/App.test.js
@@ -4,47 +4,86 @@ import 'jsdom-global/register'
 import React from 'react'
 import { mount, shallow } from "enzyme"
 import { MemoryRouter } from "react-router"
+import RootContainer from '../../src/components/RootContainer'
 import App from '../../src/components/App'
 import HomePage from '../../src/components/HomePage'
 import Editor from '../../src/components/editor/Editor'
+import Browse from '../../src/components/editor/Browse'
+import ImportResourceTemplate from "../../src/components/editor/ImportResourceTemplate";
+import Login from '../../src/components/Login'
 import Footer from '../../src/components/Footer'
 
-
 describe('<App />', () =>{
-  const wrapper = shallow(<App />)
+  const wrapper = shallow(<App.WrappedComponent />)
+
   it('selectable by id "#app"', () => {
     expect(wrapper.find('div#app').length).toEqual(1)
   })
+
   it('renders <Footer />', () => {
     expect(wrapper.find(Footer).length).toBe(1)
   })
+
 })
 
 describe("#routes", () => {
-  const renderRoutes = path =>
-    mount(
-      <MemoryRouter initialEntries={[path]}>
-        <App />
-      </MemoryRouter>
-    )
 
-  it("root renders HomePage component", () => {
-    const component = renderRoutes("/")
-    expect(component.find(HomePage).length).toEqual(1)
+  describe('public routes', () => {
+    const renderRoutes = path =>
+      mount(
+        <MemoryRouter initialEntries={[path]}>
+          <RootContainer />
+        </MemoryRouter>
+      )
+
+    it('root renders HomePage component', async () => {
+      const component = renderRoutes("/")
+      await expect(component.find(HomePage).length).toEqual(1)
+    })
+
+    it('/editor renders Editor component', () => {
+      const component = renderRoutes("/editor")
+      expect(component.find(Editor).length).toEqual(1)
+    })
+
+    it('/import renders the Login component if the user is not authenticated', () => {
+      const component = renderRoutes("/import")
+      expect(component.find(Login).length).toEqual(1)
+    })
+
+    it('/browse renders the Browse component', () => {
+      const component = renderRoutes("/browse")
+      expect(component.find(Browse).length).toEqual(1)
+    })
+
+    it("invalid path renders a 404", () => {
+      const component = renderRoutes("/blah")
+      expect(component.contains(<h1>404</h1>)).toEqual(true)
+    })
+
+    afterAll(() => {
+      renderRoutes.unmount()
+    })
+
   })
 
-  it("/editor renders Editor component", () => {
-    const component = renderRoutes("/editor")
-    expect(component.find(Editor).length).toEqual(1)
-  })
-
-  it("invalid path renders a 404", () => {
-    const component = renderRoutes("/blah")
-    expect(component.contains(<h1>404</h1>)).toEqual(true)
-  })
-
-  afterAll(() => {
-    renderRoutes.unmount()
-  })
+  //TODO: Fix getting jwtAuth props to appear in the App component so that PrivateRoute will not trigger the Login component
+  // describe('Private route', () => {
+  //   const renderRoutes = path =>
+  //     mount(
+  //       <MemoryRouter initialEntries={[path]}>
+  //         <RootContainer>
+  //           <App />
+  //         </RootContainer>
+  //       </MemoryRouter>
+  //     )
+  //
+  //   it('/import renders the Import component if user is authenticated', () => {
+  //     const component = renderRoutes("/import").setProps({jwtAuth:{isAuthenticated: true}})
+  //     console.warn(component.props())
+  //     component.update()
+  //     expect(component.find(ImportResourceTemplate).length).toEqual(1)
+  //   })
+  // })
 
 })

--- a/__tests__/components/HomePage.test.js
+++ b/__tests__/components/HomePage.test.js
@@ -7,14 +7,24 @@ import Header from '../../src/components/Header'
 import NewsPanel from '../../src/components/NewsPanel'
 import DescPanel from '../../src/components/DescPanel'
 
-
 describe('<HomePage />', () =>{
+  let location = { hash: 'id_token=abcd1234' }
+
+  const mockJwtAuth = {
+    isAuthenticated: false,
+    authenticate() {
+      this.isAuthenticated = true;
+    }
+  }
+
+  const mockAuthenticate = jest.fn()
+  const wrapper = shallow(<HomePage.WrappedComponent location={location} jwtAuth={{mockJwtAuth}} authenticate={mockAuthenticate}/>)
+
   it('selectable by id "home-page"', () => {
-    expect(shallow(<HomePage />).is('#home-page')).toBe(true)
+    expect(wrapper.is('#home-page')).toBe(true)
   })
 
   it('renders four <HomePage /> components', () => {
-    const wrapper = shallow(<HomePage />)
     expect(wrapper.find(Header).length).toBe(1)
     expect(wrapper.find(NewsPanel).length).toBe(1)
     expect(wrapper.find(DescPanel).length).toBe(1)

--- a/__tests__/components/Login.test.js
+++ b/__tests__/components/Login.test.js
@@ -1,0 +1,14 @@
+import 'jsdom-global/register'
+import Login from '../../src/components/Login'
+import React from 'react'
+import { mount } from "enzyme"
+
+describe('Login', () => {
+  it('should call the cognitoLogin function', () => {
+    const context = { state: 'fake' };
+    const wrapper = mount(<Login location={context}/>)
+    const spy = jest.spyOn(wrapper.instance(), 'cognitoLogin');
+    spy.mockImplementation(() => "mock");
+    expect(wrapper.instance().cognitoLogin('url')).toEqual('mock')
+  })
+})

--- a/__tests__/components/LoginPanel.test.js
+++ b/__tests__/components/LoginPanel.test.js
@@ -1,24 +1,50 @@
 // Copyright 2018 Stanford University see Apache2.txt for license
 
+import 'jsdom-global/register'
 import React from 'react'
-import { shallow, render } from 'enzyme'
+import { mount } from 'enzyme'
+import { MemoryRouter } from "react-router"
 import LoginPanel from '../../src/components/LoginPanel'
+import Config from '../../src/Config'
 
-describe('<LoginPanel />', () => {
-  const wrapper = shallow(<LoginPanel />)
-  const formGrpSel = "form.login-form > div.form-group"
-  it ('renders the username field', () => {
-    expect(wrapper.find(`${formGrpSel} > label`).at(0).text()).toEqual("Username")
-    expect(wrapper.find(`${formGrpSel} > input[type="text"]`)).toBeDefined()
-  })
+describe('<LoginPanel /> when the user is not authenticated', () => {
 
-  it ('renders the password field', () => {
-    expect(wrapper.find(`${formGrpSel} > label`).at(1).text()).toEqual("Password")
-    expect(wrapper.find(`${formGrpSel} > input[type="password"]`)).toBeDefined()
+  let wrapper = mount(
+    <MemoryRouter>
+      <LoginPanel jwtAuth={{isAuthenticated: false}} />
+    </MemoryRouter>
+  )
+
+  it('renders text You are not logged in', () => {
+    expect(wrapper.find('form').text()).toMatch('You are not logged in.')
   })
 
   it ('renders a login button', () => {
-    expect(wrapper.find('.btn[type="submit"]').text()).toEqual("Login")
+    expect(wrapper.find('a.nav-link[type="button"]').text()).toEqual("Login")
+  })
+
+})
+
+describe('<LoginPanel /> when the user is authenticated', () => {
+
+  const mockLogOut = jest.fn()
+  const wrapper = mount(
+    <MemoryRouter>
+      <LoginPanel jwtAuth={{isAuthenticated: true}} logOut={mockLogOut}/>
+    </MemoryRouter>
+  )
+
+  it('renders Welcome! text', () => {
+    expect(wrapper.find('form').text()).toMatch('Welcome!')
+  })
+
+  it ('renders a sign-out button', () => {
+    expect(wrapper.find('button').text()).toEqual("Sign out")
+  })
+
+  it('does a cognito aws logout', () => {
+    wrapper.find('button').simulate('click')
+    expect(mockLogOut).toHaveBeenCalled()
   })
 
   it ('renders forgot password link', () => {
@@ -27,6 +53,11 @@ describe('<LoginPanel />', () => {
 
   it ('renders request account link', () => {
     expect(wrapper.find('.login-form').text()).toMatch("Request Account")
+  })
+
+  it('renders both links with AWS client id and domain name', () => {
+    expect(wrapper.find(`a[href^="${Config.awsCognitoForgotPasswordUrl}"]`)).toHaveLength(1)
+    expect(wrapper.find(`a[href^="${Config.awsCognitoResetPasswordUrl}"]`)).toHaveLength(1)
   })
 
 })

--- a/__tests__/components/RootComponent.test.js
+++ b/__tests__/components/RootComponent.test.js
@@ -1,0 +1,22 @@
+import React from 'react'
+import { shallow } from "enzyme"
+import { MemoryRouter } from "react-router"
+import RootContainer from '../../src/components/RootContainer'
+import { OffCanvas } from 'react-offcanvas'
+import { Provider } from 'react-redux'
+
+describe('<RootComponent />', () => {
+  const wrapper = shallow(<RootContainer/>)
+
+  it('renders the home-page div', () => {
+    expect(wrapper.find('div#home-page').length).toEqual(1)
+  })
+
+  it('contains the OffCanvas component', () => {
+    expect(wrapper.find(OffCanvas)).toHaveLength(1)
+  })
+
+  it('wraps the App in a store Provider', () => {
+    expect(wrapper.find(Provider)).toHaveLength(1)
+  })
+})

--- a/__tests__/components/editor/StartingPoints.test.js
+++ b/__tests__/components/editor/StartingPoints.test.js
@@ -1,16 +1,13 @@
 // Copyright 2018 Stanford University see Apache2.txt for license
 
+import 'jsdom-global/register'
 import React from 'react'
 import { shallow, mount } from 'enzyme'
 import StartingPoints from '../../../src/components/editor/StartingPoints'
 import DropZone from '../../../src/components/editor/StartingPoints'
 import { MemoryRouter } from 'react-router-dom'
 import { Link } from 'react-router-dom'
-
-const jsdom = require("jsdom")
 require('isomorphic-fetch')
-
-setUpDomEnvironment()
 
 describe('<StartingPoints />', () => {
   const reloadEditor = jest.fn()
@@ -85,23 +82,3 @@ describe('<DropZone />', () => {
     })
   })
 })
-
-function setUpDomEnvironment() {
-  const { JSDOM } = jsdom
-  const dom = new JSDOM('<!doctype html><html><body></body></html>', {url: 'http://localhost/'})
-  const { window } = dom
-
-  global.window = window
-  global.document = window.document
-  global.navigator = {
-    userAgent: 'node.js'
-  }
-  copyProps(window, global)
-}
-function copyProps(src, target) {
-  const props = Object.getOwnPropertyNames(src)
-    .filter(prop => typeof target[prop] === 'undefined')
-    .map(prop => Object.getOwnPropertyDescriptor(src, prop))
-  Object.defineProperties(target, props)
-
-}

--- a/__tests__/reducers/authenticate.test.js
+++ b/__tests__/reducers/authenticate.test.js
@@ -1,0 +1,32 @@
+import authenticate from '../../src/reducers/authenticate'
+
+describe('changing the reducer state', () => {
+
+  it('should handle initial state', () => {
+    expect(
+      authenticate(undefined, {})
+    ).toEqual({loginJwt: {}})
+  })
+
+  it('handles LOG_IN', () => {
+    expect(
+      authenticate({loginJwt: {}}, {
+        type: 'LOG_IN',
+        payload: {id_token: '1a2b3c', access_token: 'a1b2c3', expires_in: 3600, isAuthenticated: true}
+      })
+    ).toEqual(
+      {loginJwt: {id_token: '1a2b3c', access_token: 'a1b2c3', isAuthenticated: true}}
+    )
+  })
+
+  it('handles LOG_OUT', () => {
+    expect(
+      authenticate({loginJwt: {}}, {
+        type: 'LOG_OUT'
+      })
+    ).toEqual(
+      {loginJwt: {id_token: '', access_token: '', isAuthenticated: false}}
+    )
+  })
+
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -3256,9 +3256,9 @@
       "dev": true
     },
     "colors": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
+      "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==",
       "dev": true
     },
     "combined-stream": {
@@ -3784,8 +3784,7 @@
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-      "dev": true
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
     "deep-equal": {
       "version": "1.0.1",
@@ -4145,7 +4144,7 @@
     },
     "duplexer": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
     },
     "duplexify": {
@@ -4391,7 +4390,7 @@
       "dependencies": {
         "acorn-jsx": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
           "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
           "dev": true,
           "requires": {
@@ -4400,7 +4399,7 @@
           "dependencies": {
             "acorn": {
               "version": "3.3.0",
-              "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+              "resolved": "http://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
               "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
               "dev": true
             }
@@ -4458,7 +4457,7 @@
         },
         "eslint": {
           "version": "4.19.0",
-          "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.0.tgz",
+          "resolved": "http://registry.npmjs.org/eslint/-/eslint-4.19.0.tgz",
           "integrity": "sha512-r83L5CuqaocDvfwdojbz68b6tCUk8KJkqfppO+gmSAQqYCzTr0bCSMu6A6yFCLKG65j5eKcKUw4Cw4Yl4gfWkg==",
           "dev": true,
           "requires": {
@@ -4504,7 +4503,7 @@
         },
         "eslint-plugin-react": {
           "version": "7.7.0",
-          "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.7.0.tgz",
+          "resolved": "http://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.7.0.tgz",
           "integrity": "sha512-KC7Snr4YsWZD5flu6A5c0AcIZidzW3Exbqp7OT67OaD2AppJtlBr/GuPrW/vaQM/yfZotEvKAdrxrO+v8vwYJA==",
           "dev": true,
           "requires": {
@@ -4536,7 +4535,7 @@
         },
         "external-editor": {
           "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
           "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
           "dev": true,
           "requires": {
@@ -5173,9 +5172,9 @@
       }
     },
     "eslint-takeoff": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-takeoff/-/eslint-takeoff-0.0.1.tgz",
-      "integrity": "sha512-8bBDd1j5O0fgrmp1dL9+WyCK4bPIPE/J6OOqyvhTZvMTzAzoPzIe8Suhnlvmdj8cyzBowjusj8OpX2Ry2q9FWw==",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-takeoff/-/eslint-takeoff-0.0.3.tgz",
+      "integrity": "sha512-gKI7Ym9Rhiq42cXNuIodqXSIORtaYn/PB/tyLhpmSQvuUn8LeP+OFRQFOb+IAJ390Wu1GX1F7O21RaAKcvzKCg==",
       "dev": true,
       "requires": {
         "caporal": "^0.10.0",
@@ -5184,16 +5183,10 @@
         "yamljs": "^0.3.0"
       },
       "dependencies": {
-        "esprima": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-          "dev": true
-        },
         "js-yaml": {
-          "version": "3.12.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-          "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+          "version": "3.12.2",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.2.tgz",
+          "integrity": "sha512-QHn/Lh/7HhZ/Twc7vJYQTkjuCa0kaCcDcjK5Zlk2rvnUpy7DxMJ23+Jc2dcyvltwQVg1nygAVlB2oRDFHoRS5Q==",
           "dev": true,
           "requires": {
             "argparse": "^1.0.7",
@@ -6251,8 +6244,7 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6276,15 +6268,13 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6301,22 +6291,19 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6447,8 +6434,7 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6462,7 +6448,6 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6479,7 +6464,6 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6488,15 +6472,13 @@
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
           "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -6517,7 +6499,6 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6606,8 +6587,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6621,7 +6601,6 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6717,8 +6696,7 @@
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
           "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6760,7 +6738,6 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6782,7 +6759,6 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6831,15 +6807,13 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
           "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -8588,6 +8562,53 @@
             "strip-ansi": "^4.0.0",
             "which": "^1.2.12",
             "yargs": "^11.0.0"
+          },
+          "dependencies": {
+            "jest-environment-jsdom": {
+              "version": "23.4.0",
+              "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-23.4.0.tgz",
+              "integrity": "sha1-BWp5UrP+pROsYqFAosNox52eYCM=",
+              "dev": true,
+              "requires": {
+                "jest-mock": "^23.2.0",
+                "jest-util": "^23.4.0",
+                "jsdom": "^11.5.1"
+              }
+            }
+          }
+        },
+        "jsdom": {
+          "version": "11.12.0",
+          "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.12.0.tgz",
+          "integrity": "sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==",
+          "dev": true,
+          "requires": {
+            "abab": "^2.0.0",
+            "acorn": "^5.5.3",
+            "acorn-globals": "^4.1.0",
+            "array-equal": "^1.0.0",
+            "cssom": ">= 0.3.2 < 0.4.0",
+            "cssstyle": "^1.0.0",
+            "data-urls": "^1.0.0",
+            "domexception": "^1.0.1",
+            "escodegen": "^1.9.1",
+            "html-encoding-sniffer": "^1.0.2",
+            "left-pad": "^1.3.0",
+            "nwsapi": "^2.0.7",
+            "parse5": "4.0.0",
+            "pn": "^1.1.0",
+            "request": "^2.87.0",
+            "request-promise-native": "^1.0.5",
+            "sax": "^1.2.4",
+            "symbol-tree": "^3.2.2",
+            "tough-cookie": "^2.3.4",
+            "w3c-hr-time": "^1.0.1",
+            "webidl-conversions": "^4.0.2",
+            "whatwg-encoding": "^1.0.3",
+            "whatwg-mimetype": "^2.1.0",
+            "whatwg-url": "^6.4.1",
+            "ws": "^5.2.0",
+            "xml-name-validator": "^3.0.0"
           }
         },
         "strip-ansi": {
@@ -8671,6 +8692,51 @@
             "minimatch": "^3.0.4",
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
+          }
+        },
+        "jest-environment-jsdom": {
+          "version": "23.4.0",
+          "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-23.4.0.tgz",
+          "integrity": "sha1-BWp5UrP+pROsYqFAosNox52eYCM=",
+          "dev": true,
+          "requires": {
+            "jest-mock": "^23.2.0",
+            "jest-util": "^23.4.0",
+            "jsdom": "^11.5.1"
+          }
+        },
+        "jsdom": {
+          "version": "11.12.0",
+          "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.12.0.tgz",
+          "integrity": "sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==",
+          "dev": true,
+          "requires": {
+            "abab": "^2.0.0",
+            "acorn": "^5.5.3",
+            "acorn-globals": "^4.1.0",
+            "array-equal": "^1.0.0",
+            "cssom": ">= 0.3.2 < 0.4.0",
+            "cssstyle": "^1.0.0",
+            "data-urls": "^1.0.0",
+            "domexception": "^1.0.1",
+            "escodegen": "^1.9.1",
+            "html-encoding-sniffer": "^1.0.2",
+            "left-pad": "^1.3.0",
+            "nwsapi": "^2.0.7",
+            "parse5": "4.0.0",
+            "pn": "^1.1.0",
+            "request": "^2.87.0",
+            "request-promise-native": "^1.0.5",
+            "sax": "^1.2.4",
+            "symbol-tree": "^3.2.2",
+            "tough-cookie": "^2.3.4",
+            "w3c-hr-time": "^1.0.1",
+            "webidl-conversions": "^4.0.2",
+            "whatwg-encoding": "^1.0.3",
+            "whatwg-mimetype": "^2.1.0",
+            "whatwg-url": "^6.4.1",
+            "ws": "^5.2.0",
+            "xml-name-validator": "^3.0.0"
           }
         },
         "source-map": {
@@ -8772,53 +8838,6 @@
       "requires": {
         "chalk": "^2.0.1",
         "pretty-format": "^23.6.0"
-      }
-    },
-    "jest-environment-jsdom": {
-      "version": "23.4.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-23.4.0.tgz",
-      "integrity": "sha1-BWp5UrP+pROsYqFAosNox52eYCM=",
-      "dev": true,
-      "requires": {
-        "jest-mock": "^23.2.0",
-        "jest-util": "^23.4.0",
-        "jsdom": "^11.5.1"
-      },
-      "dependencies": {
-        "jsdom": {
-          "version": "11.12.0",
-          "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.12.0.tgz",
-          "integrity": "sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==",
-          "dev": true,
-          "requires": {
-            "abab": "^2.0.0",
-            "acorn": "^5.5.3",
-            "acorn-globals": "^4.1.0",
-            "array-equal": "^1.0.0",
-            "cssom": ">= 0.3.2 < 0.4.0",
-            "cssstyle": "^1.0.0",
-            "data-urls": "^1.0.0",
-            "domexception": "^1.0.1",
-            "escodegen": "^1.9.1",
-            "html-encoding-sniffer": "^1.0.2",
-            "left-pad": "^1.3.0",
-            "nwsapi": "^2.0.7",
-            "parse5": "4.0.0",
-            "pn": "^1.1.0",
-            "request": "^2.87.0",
-            "request-promise-native": "^1.0.5",
-            "sax": "^1.2.4",
-            "symbol-tree": "^3.2.2",
-            "tough-cookie": "^2.3.4",
-            "w3c-hr-time": "^1.0.1",
-            "webidl-conversions": "^4.0.2",
-            "whatwg-encoding": "^1.0.3",
-            "whatwg-mimetype": "^2.1.0",
-            "whatwg-url": "^6.4.1",
-            "ws": "^5.2.0",
-            "xml-name-validator": "^3.0.0"
-          }
-        }
       }
     },
     "jest-environment-node": {
@@ -10710,7 +10729,7 @@
     },
     "pause-stream": {
       "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "resolved": "http://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
       "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
       "requires": {
         "through": "~2.3"
@@ -11129,6 +11148,15 @@
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+    },
+    "query-string": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.2.0.tgz",
+      "integrity": "sha512-5wupExkIt8RYL4h/FE+WTg3JHk62e6fFPWtAZA9J5IWK1PfTfKkMS93HBUHcFpeYi9KsY5pFbh+ldvEyaz5MyA==",
+      "requires": {
+        "decode-uri-component": "^0.2.0",
+        "strict-uri-encode": "^2.0.0"
+      }
     },
     "querystring": {
       "version": "0.2.0",
@@ -13292,6 +13320,11 @@
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
       "dev": true
     },
+    "strict-uri-encode": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
+    },
     "string-length": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
@@ -15003,7 +15036,7 @@
           "dependencies": {
             "pify": {
               "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+              "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
               "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
               "dev": true
             }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "eslint-plugin-node": "^7.0.1",
     "eslint-plugin-react": "^7.11.1",
     "eslint-plugin-security": "^1.4.0",
-    "eslint-takeoff": "0.0.1",
+    "eslint-takeoff": "0.0.3",
     "expect-puppeteer": "^3.5.1",
     "file-loader": "^2.0.0",
     "html-webpack-plugin": "^3.2.0",
@@ -77,9 +77,8 @@
     "eslint": "eslint --max-warnings 34 --color -c .eslintrc.js --ext js,jsx ./src",
     "jest-cov": "jest --coverage --colors --silent --runInBand",
     "jest-ci": "jest  --colors --silent --ci --runInBand --coverage --reporters=default --reporters=jest-junit && cat ./coverage/lcov.info | coveralls",
-    "test": "jest --colors --silent --runInBand",
-    "test-verbose": "jest --colors --runInBand",
-    "test-async": "jest --colors --runInBand --detectOpenHandles"
+    "test": "jest --colors --silent --runInBand --detectOpenHandles",
+    "test-verbose": "jest --colors --runInBand"
   },
   "license": "ISC",
   "dependencies": {
@@ -94,6 +93,7 @@
     "lodash": "^4.17.11",
     "merge": "^1.2.1",
     "n3": "^1.0.2",
+    "query-string": "^6.2.0",
     "react": "^16.6.3",
     "react-bootstrap": "^0.32.4",
     "react-bootstrap-typeahead": "^3.2.4",

--- a/src/Config.js
+++ b/src/Config.js
@@ -1,0 +1,31 @@
+class Config {
+  static get sinopiaUri() {
+    return process.env.SINOPIA_URI || 'https://sinopia.io'
+  }
+
+  static get awsClientID() {
+    return process.env.AWS_CLIENT_ID || '69u288s9ia8ible8gg1n4k0gou'
+  }
+
+  static get awsCognitoDomain() {
+    return process.env.AWS_COGNITO_DOMAIN || 'sinopia-development.auth.us-west-2.amazoncognito.com'
+  }
+
+  static get awsCognitoLoginUrl() {
+    return `https://${this.awsCognitoDomain}/login?response_type=token&client_id=${this.awsClientID}&redirect_uri=${this.sinopiaUri}`
+  }
+
+  static get awsCognitoLogoutUrl() {
+    return `https://${this.awsCognitoDomain}/logout?response_type=token&client_id=${this.awsClientID}&logout_uri=${this.sinopiaUri}&redirect_uri=${this.sinopiaUri}`
+  }
+
+  static get awsCognitoForgotPasswordUrl() {
+    return `https://${this.awsCognitoDomain}/forgotPassword?response_type=token&client_id=${this.awsClientID}&redirect_uri=${this.sinopiaUri}`
+  }
+
+  static get awsCognitoResetPasswordUrl() {
+    return `https://${this.awsCognitoDomain}/signup?response_type=token&client_id=${this.awsClientID}&redirect_uri=${this.sinopiaUri}`
+  }
+}
+
+export default Config

--- a/src/Logout.js
+++ b/src/Logout.js
@@ -1,0 +1,13 @@
+import Config from './Config'
+
+class Logout {
+  constructor() {
+    this.url = Config.awsCognitoLogoutUrl
+  }
+
+  cognitoLogout() {
+    window.location = this.url
+  }
+}
+
+export default Logout

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -32,3 +32,12 @@ export const setLang = item => ({
   type: "SET_LANG",
   payload: item
 })
+
+export const logIn = jwt => ({
+  type: "LOG_IN",
+  payload: jwt
+})
+
+export const logOut = () => ({
+  type: "LOG_OUT"
+})

--- a/src/components/HomePage.jsx
+++ b/src/components/HomePage.jsx
@@ -1,17 +1,43 @@
 // Copyright 2018 Stanford University see Apache2.txt for license
 
 import React, { Component } from 'react'
+import { connect } from 'react-redux'
+import { logIn, logOut } from '../actions/index'
 import PropTypes from 'prop-types'
 import Header from './Header'
 import NewsPanel from './NewsPanel'
+import Logout from '../../src/Logout'
 import DescPanel from './DescPanel'
+const qs = require('query-string')
+const _ = require('lodash')
 
 class HomePage extends Component {
+  constructor(props) {
+    super(props)
+  }
+
+  logOut = () => {
+    this.props.signout()
+    const logout = new Logout()
+    logout.cognitoLogout()
+  }
+
   render() {
+    const jwtHash = qs.parse(this.props.location.hash)
+    const user = this.props.jwtAuth
+
+    if (user !== undefined) {
+      if (!user.isAuthenticated) {
+        if(!_.isEmpty(jwtHash)) {
+          this.props.authenticate(jwtHash)
+        }
+      }
+    }
+
     return(
       <div id="home-page">
         <Header triggerHomePageMenu={this.props.triggerHandleOffsetMenu} />
-        <NewsPanel />
+        <NewsPanel jwtAuth={this.props.jwtAuth} logOut={this.logOut}/>
         <DescPanel />
       </div>
     )
@@ -19,9 +45,27 @@ class HomePage extends Component {
 }
 
 HomePage.propTypes = {
-  // Passed through ...Props
   children: PropTypes.array,
-  triggerHandleOffsetMenu: PropTypes.func
+  triggerHandleOffsetMenu: PropTypes.func,
+  location: PropTypes.object,
+  jwtAuth: PropTypes.object,
+  authenticate: PropTypes.func,
+  signout: PropTypes.func
 }
 
-export default HomePage
+const mapStateToProps = (state) => {
+  return {
+    jwtAuth: state.authenticate.loginJwt
+  }
+}
+
+const mapDispatchToProps = dispatch => ({
+  authenticate(jwt){
+    dispatch(logIn(jwt))
+  },
+  signout() {
+    dispatch(logOut())
+  }
+})
+
+export default connect(mapStateToProps, mapDispatchToProps)(HomePage)

--- a/src/components/Login.jsx
+++ b/src/components/Login.jsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import Config from '../../src/Config'
+
+class Login extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      redirectToReferrer: false,
+    }
+  }
+
+  cognitoLogin = (url) => {
+    setTimeout(function(){
+      window.location.assign(url)
+    }, 500);
+  }
+
+  render() {
+    return (
+      <div className="jumbotron center-block">
+        <p>Please wait to be directed to the login service...</p>
+        {this.cognitoLogin(Config.awsCognitoLoginUrl)}
+      </div>
+    )
+  }
+}
+
+Login.propTypes = {
+  location: PropTypes.object
+}
+
+export default Login

--- a/src/components/LoginPanel.jsx
+++ b/src/components/LoginPanel.jsx
@@ -1,29 +1,66 @@
 // Copyright 2018 Stanford University see Apache2.txt for license
 
-import React from 'react'
+import React, {Component} from 'react'
+import PropTypes from 'prop-types'
+import { NavLink, withRouter } from 'react-router-dom'
+import Config from '../Config.js'
 
-// TODO: This will need to be re-written in the correct "react" way.
-const LoginPanel = () => (
-  <form className="login-form">
-    <div className = "form-group">
-      <label htmlFor="exampleInputEmail1" className="text-uppercase">Username</label>
-      <input type="text" className="form-control" placeholder=""></input>
-    </div>
-    <div className="form-group">
-      <label htmlFor="exampleInputPassword1" className="text-uppercase">Password</label>
-      <input type="password" className="form-control" placeholder=""></input>
-    </div>
-    <div className="row">
-      <div className="col-xs-6">
-        <button className="btn btn-block btn-primary" type="submit">Login</button>
-      </div>
-      <div className="col-xs-6">
-        <a href="#"><small>Forgot Password</small></a>
-        <br></br>
-        <a href="#"><small>Request Account</small></a>
-      </div>
-    </div>
-  </form>
-)
+class LoginPanel extends Component {
+  constructor(props){
+    super(props)
+  }
+
+  render(){
+    const AuthButton = withRouter(() =>
+        this.props.jwtAuth.isAuthenticated ? (
+          <p>
+            Welcome!{" "}
+            <button onClick={() => {
+              this.props.logOut()
+            }}>
+              Sign out
+            </button>
+          </p>
+        ) : (
+        <p>You are not logged in.</p>
+      )
+    )
+
+    let loginButton = <div className="col-xs-6">
+      <NavLink className="btn btn-block btn-primary nav-link" type="button" to="/login">Login</NavLink>
+    </div>;
+
+    if (this.props.jwtAuth.isAuthenticated) {
+      loginButton = <p/>;
+    }
+
+    return(
+      <form className="login-form">
+        <div className="form-group">
+          <div className="row">
+            <AuthButton jwtAuth={this.props.jwtAuth} signout={this.props.signout}/>
+            {loginButton}
+          </div>
+          <div className="row">
+            <div className="col-xs-8">
+              <a href={Config.awsCognitoForgotPasswordUrl}><small>Forgot Password?</small></a>
+            </div>
+          </div>
+          <div className="row">
+            <div className="col-xs-8">
+              <a href={Config.awsCognitoResetPasswordUrl}><small>Request Account</small></a>
+            </div>
+          </div>
+        </div>
+      </form>
+    )
+  }
+}
+
+LoginPanel.propTypes = {
+  signout: PropTypes.func,
+  logOut: PropTypes.func,
+  jwtAuth: PropTypes.object
+}
 
 export default LoginPanel

--- a/src/components/NewsPanel.jsx
+++ b/src/components/NewsPanel.jsx
@@ -1,25 +1,38 @@
 // Copyright 2018 Stanford Junior University see Apache2.txt for license
 
-import React from 'react'
+import React, {Component} from 'react'
+import PropTypes from 'prop-types'
 import NewsItem from './NewsItem.jsx'
 import LoginPanel from './LoginPanel.jsx'
 
-const NewsPanel = () => (
-  <div className="jumbotron banner center-block">
-    <div className="panel panel-default">
-      <div className="panel-body">
-        <div className="row">
-          <div className="col-md-7">
-            <NewsItem />
-          </div>
-          <div className="col-md-4 login-sec">
-            <LoginPanel />
+class NewsPanel extends Component {
+  constructor(props) {
+    super(props)
+  }
+
+  render(){
+    return(
+      <div className="jumbotron banner center-block">
+        <div className="panel panel-default">
+          <div className="panel-body">
+            <div className="row">
+              <div className="col-md-7">
+                <NewsItem />
+              </div>
+              <div className="col-md-4 login-sec">
+                <LoginPanel jwtAuth={this.props.jwtAuth} logOut={this.props.logOut}/>
+              </div>
+            </div>
           </div>
         </div>
       </div>
-    </div>
-  </div>
+    )
+  }
+}
 
-)
+NewsPanel.propTypes = {
+  jwtAuth: PropTypes.object,
+  logOut: PropTypes.func
+}
 
 export default NewsPanel

--- a/src/components/RootContainer.jsx
+++ b/src/components/RootContainer.jsx
@@ -1,0 +1,52 @@
+import React, { Component } from 'react'
+import { hot } from 'react-hot-loader'
+import App from './App'
+import CanvasMenu from './CanvasMenu'
+import { OffCanvas, OffCanvasMenu, OffCanvasBody } from 'react-offcanvas'
+import { BrowserRouter } from 'react-router-dom'
+import { Provider } from 'react-redux'
+import store from '../store'
+
+class RootContainer extends Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      isMenuOpened: false,
+      redirectToReferrer: false
+    }
+  }
+
+  closeMenu = () => {
+    this.setState({
+      isMenuOpened: false
+    })
+  }
+
+  handleOffsetMenu = () => {
+    this.setState({
+      isMenuOpened: !this.state.isMenuOpened
+    })
+  }
+
+  render(){
+    let offcanvas_class = this.state.isMenuOpened? "closeMargin" : null
+    return(
+      <div id="home-page">
+        <OffCanvas width={300} transitionDuration={300} isMenuOpened={this.state.isMenuOpened} position={"right"}>
+          <OffCanvasBody className={offcanvas_class}>
+            <BrowserRouter>
+              <Provider store={store}>
+                <App isMenuOpened={this.state.isMenuOpened} handleOffsetMenu={this.handleOffsetMenu}/>
+              </Provider>
+            </BrowserRouter>
+          </OffCanvasBody>
+          <OffCanvasMenu className="offcanvas-menu">
+            <CanvasMenu closeHandleMenu={this.closeMenu} />
+          </OffCanvasMenu>
+        </OffCanvas>
+      </div>
+    )
+  }
+}
+
+export default hot(module)(RootContainer)

--- a/src/index.js
+++ b/src/index.js
@@ -2,12 +2,12 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom';
-import App from './components/App';
+import RootContainer from './components/RootContainer';
 
 const root = document.createElement('div');
 document.body.appendChild(root);
 
 ReactDOM.render(
-  React.createElement(App),
+  React.createElement(RootContainer),
   root
 );

--- a/src/reducers/authenticate.js
+++ b/src/reducers/authenticate.js
@@ -1,0 +1,54 @@
+const DEFAULT_STATE = {
+  loginJwt: {}
+}
+
+const logInWithJWT = (state, action) => {
+
+  let loginState = {}
+  let isAuthenticated = false
+
+  const id_token = action.payload.id_token
+  const access_token = action.payload.access_token
+  //TODO: expire token after the specified time
+  const expires_in = action.payload.expires_in
+
+  let time = new Date()
+  const expiry = time.setSeconds(time.getSeconds() + parseInt(expires_in))
+
+  if (id_token !== undefined && id_token !== state.loginJwt.id_token) {
+    loginState['id_token'] = id_token
+
+    if (access_token !== undefined && access_token !== state.loginJwt.access_token) {
+      loginState['access_token'] = access_token
+
+      if (expires_in !== undefined && expiry > new Date()) {
+        isAuthenticated = true
+      }
+    }
+  }
+
+  if (isAuthenticated) {
+    loginState = {loginJwt: {id_token: id_token, access_token: access_token, isAuthenticated: isAuthenticated}}
+  } else {
+    loginState = {loginJwt: {id_token: '', access_token: '', isAuthenticated: false}}
+  }
+
+  return loginState
+}
+
+const logOut = () => {
+  return {loginJwt: {id_token: '', access_token: '', isAuthenticated: false}}
+}
+
+const authenticate = (state=DEFAULT_STATE, action) => {
+  switch(action.type) {
+    case 'LOG_IN':
+      return logInWithJWT(state, action)
+    case 'LOG_OUT':
+      return logOut()
+    default:
+      return state
+  }
+}
+
+export default authenticate

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -3,12 +3,14 @@ import { generateLD } from './linkedData'
 import lang from './lang'
 import literal from './literal'
 import lookups from './lookups'
+import authenticate from './authenticate'
 
 const appReducer = combineReducers({
   generateLD,
   lang,
   literal,
-  lookups
+  lookups,
+  authenticate
 })
 
 const rootReducer = (state, action) => {


### PR DESCRIPTION
Fixes #372 
Fixes #382 

- When rendering the login panel on the home page, conditionally display a login or sign-out button depending on the authentication state (redux)
- When going to the import profile route (by clicking on tab), conditionally render the import profile page based on authentication state (redux) or redirect to the login component
- Redux support and connections from the various components that require checking the authentication state: 
  - App: for routing; requires a higher-order component (RootComponent) to be the Provider for redux 
  - HomePage: getting/setting the authentication state
  - LoginPanel: for display of the login and sign-out buttons
- A Logout class that redirects to the AWS logout functionality, destroys the jwt, and redurects back to sinopia
- A Config class to provide the AWS Cognito details (based on the pattern by @mjgiarlo [thanks!])
- Some linting configuration changes to allow exporting classes
- ran `npm audit fix` to update dependencies after installing `lodash` module

In another PR need to parse the JWT and store the user information contained within it using the AWS SDK. 