### PR TITLE
Decode JWT and add username to state

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -47,7 +47,7 @@ module.exports = {
   },
   overrides: [
     {
-      "files": ["**/*.jsx", "src/index.js", "src/*/*.js", "src/store.js", "src/Config.js", "src/Logout.js"],
+      "files": ["**/*.jsx", "src/index.js", "src/*/*.js", "src/store.js", "src/Config.js", "src/LoginData.js", "src/Logout.js"],
       "rules": {
         // See https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/no-unsupported-features/es-syntax.md
         //   rule supposedly matches ECMA version with node

--- a/__mocks__/mockAWSData.js
+++ b/__mocks__/mockAWSData.js
@@ -1,0 +1,24 @@
+const mockAWSHeader = {
+  "kid":"x24+y25+z26",
+  "alg":"RS256"
+}
+const mockAWSReponse = {
+  "sub": "a1b2c3",
+  "token_use": "access",
+  "scope": "openid email",
+  "auth_time": 1234567890,
+  "iss": "https://cognito-idp.fake-region.amazonaws.com/fake-region_1a2b",
+  "exp": 1234567890,
+  "iat": 1234567890,
+  "version": 2,
+  "jti": "1a-2b-3c",
+  "client_id": "1a2b3c",
+  "username": "fake"
+}
+const mockAWSsigniture = 'fake-signature'
+const mockHeader = Buffer.from(JSON.stringify(mockAWSHeader)).toString('base64').slice(0, -2)
+const mockToken = Buffer.from(JSON.stringify(mockAWSReponse)).toString('base64').slice(0, -2)
+const mockSignature = Buffer.from(JSON.stringify(mockAWSsigniture)).toString('base64').slice(0, -2)
+const mockJWTString = mockHeader + '.' + mockToken + '.' + mockSignature
+
+module.exports = mockJWTString

--- a/__tests__/LoginData.test.js
+++ b/__tests__/LoginData.test.js
@@ -1,0 +1,16 @@
+import LoginData from '../src/LoginData'
+
+const mockJWTString = require('../__mocks__/mockAWSData')
+const login = new LoginData(mockJWTString)
+
+describe('decode AWS token when logging in', () => {
+
+  it('has access token from aws cognito', () => {
+    expect(login.access_token).toEqual(mockJWTString)
+  })
+
+  it('decodes the base64 encoded string and returns the username', () => {
+    expect(login.cognitoLoginData(mockJWTString)).toEqual('fake')
+  })
+
+})

--- a/__tests__/components/HomePage.test.js
+++ b/__tests__/components/HomePage.test.js
@@ -7,8 +7,10 @@ import Header from '../../src/components/Header'
 import NewsPanel from '../../src/components/NewsPanel'
 import DescPanel from '../../src/components/DescPanel'
 
+const mockJWTString = require('../../__mocks__/mockAWSData')
+
 describe('<HomePage />', () =>{
-  let location = { hash: 'id_token=abcd1234' }
+  let location = { hash: `id_token=abcd1234&access_token=${mockJWTString}`}
 
   const mockJwtAuth = {
     isAuthenticated: false,
@@ -18,7 +20,11 @@ describe('<HomePage />', () =>{
   }
 
   const mockAuthenticate = jest.fn()
-  const wrapper = shallow(<HomePage.WrappedComponent location={location} jwtAuth={{mockJwtAuth}} authenticate={mockAuthenticate}/>)
+  const mockLoginData = jest.fn()
+  const wrapper = shallow(<HomePage.WrappedComponent location={location}
+                                                     jwtAuth={{mockJwtAuth}}
+                                                     loginData={mockLoginData}
+                                                     authenticate={mockAuthenticate}/>)
 
   it('selectable by id "home-page"', () => {
     expect(wrapper.is('#home-page')).toBe(true)

--- a/__tests__/components/LoginPanel.test.js
+++ b/__tests__/components/LoginPanel.test.js
@@ -30,12 +30,12 @@ describe('<LoginPanel /> when the user is authenticated', () => {
   const mockLogOut = jest.fn()
   const wrapper = mount(
     <MemoryRouter>
-      <LoginPanel jwtAuth={{isAuthenticated: true}} logOut={mockLogOut}/>
+      <LoginPanel jwtAuth={{isAuthenticated: true}} logOut={mockLogOut} userName={'some-user'}/>
     </MemoryRouter>
   )
 
-  it('renders Welcome! text', () => {
-    expect(wrapper.find('form').text()).toMatch('Welcome!')
+  it('renders the welcome text with username', () => {
+    expect(wrapper.find('form').text()).toMatch('Welcome some-user!')
   })
 
   it ('renders a sign-out button', () => {

--- a/__tests__/reducers/authenticate.test.js
+++ b/__tests__/reducers/authenticate.test.js
@@ -12,10 +12,10 @@ describe('changing the reducer state', () => {
     expect(
       authenticate({loginJwt: {}}, {
         type: 'LOG_IN',
-        payload: {id_token: '1a2b3c', access_token: 'a1b2c3', expires_in: 3600, isAuthenticated: true}
+        payload: {id_token: '1a2b3c', access_token: 'a1b2c3', expires_in: 3600, username: 'some-user', isAuthenticated: true}
       })
     ).toEqual(
-      {loginJwt: {id_token: '1a2b3c', access_token: 'a1b2c3', isAuthenticated: true}}
+      {loginJwt: {id_token: '1a2b3c', access_token: 'a1b2c3', username: 'some-user', isAuthenticated: true}}
     )
   })
 
@@ -25,7 +25,7 @@ describe('changing the reducer state', () => {
         type: 'LOG_OUT'
       })
     ).toEqual(
-      {loginJwt: {id_token: '', access_token: '', isAuthenticated: false}}
+      {loginJwt: {id_token: '', access_token: '', username: '', isAuthenticated: false}}
     )
   })
 

--- a/src/LoginData.js
+++ b/src/LoginData.js
@@ -1,0 +1,19 @@
+class LoginData {
+  constructor(access_token) {
+    this.access_token = access_token
+  }
+
+  //TODO: if we need to strongly verify the JWT claims we can also implement this:
+  // https://aws.amazon.com/premiumsupport/knowledge-center/decode-verify-cognito-json-token/
+  cognitoLoginData(access_token) {
+    let userName = ''
+    if(access_token !== undefined) {
+      const data = access_token.split('.')[1]
+      const cognitoPayload = JSON.parse((Buffer.from(data, 'base64')).toString('utf8'))
+      userName = cognitoPayload.username
+    }
+    return userName
+  }
+}
+
+export default LoginData

--- a/src/components/HomePage.jsx
+++ b/src/components/HomePage.jsx
@@ -6,6 +6,7 @@ import { logIn, logOut } from '../actions/index'
 import PropTypes from 'prop-types'
 import Header from './Header'
 import NewsPanel from './NewsPanel'
+import LoginData from '../../src/LoginData'
 import Logout from '../../src/Logout'
 import DescPanel from './DescPanel'
 const qs = require('query-string')
@@ -26,9 +27,13 @@ class HomePage extends Component {
     const jwtHash = qs.parse(this.props.location.hash)
     const user = this.props.jwtAuth
 
+    const loginData = new LoginData()
+    const userName = loginData.cognitoLoginData(jwtHash.access_token)
+
     if (user !== undefined) {
       if (!user.isAuthenticated) {
         if(!_.isEmpty(jwtHash)) {
+          jwtHash['username'] = userName
           this.props.authenticate(jwtHash)
         }
       }
@@ -37,7 +42,7 @@ class HomePage extends Component {
     return(
       <div id="home-page">
         <Header triggerHomePageMenu={this.props.triggerHandleOffsetMenu} />
-        <NewsPanel jwtAuth={this.props.jwtAuth} logOut={this.logOut}/>
+        <NewsPanel jwtAuth={this.props.jwtAuth} logOut={this.logOut} userName={userName}/>
         <DescPanel />
       </div>
     )
@@ -69,3 +74,4 @@ const mapDispatchToProps = dispatch => ({
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(HomePage)
+// export default HomePage

--- a/src/components/LoginPanel.jsx
+++ b/src/components/LoginPanel.jsx
@@ -14,7 +14,7 @@ class LoginPanel extends Component {
     const AuthButton = withRouter(() =>
         this.props.jwtAuth.isAuthenticated ? (
           <p>
-            Welcome!{" "}
+            Welcome{` ${this.props.userName}`}!
             <button onClick={() => {
               this.props.logOut()
             }}>
@@ -60,7 +60,8 @@ class LoginPanel extends Component {
 LoginPanel.propTypes = {
   signout: PropTypes.func,
   logOut: PropTypes.func,
-  jwtAuth: PropTypes.object
+  jwtAuth: PropTypes.object,
+  userName: PropTypes.string
 }
 
 export default LoginPanel

--- a/src/components/NewsPanel.jsx
+++ b/src/components/NewsPanel.jsx
@@ -20,7 +20,7 @@ class NewsPanel extends Component {
                 <NewsItem />
               </div>
               <div className="col-md-4 login-sec">
-                <LoginPanel jwtAuth={this.props.jwtAuth} logOut={this.props.logOut}/>
+                <LoginPanel jwtAuth={this.props.jwtAuth} logOut={this.props.logOut} userName={this.props.userName}/>
               </div>
             </div>
           </div>
@@ -32,7 +32,8 @@ class NewsPanel extends Component {
 
 NewsPanel.propTypes = {
   jwtAuth: PropTypes.object,
-  logOut: PropTypes.func
+  logOut: PropTypes.func,
+  userName: PropTypes.string
 }
 
 export default NewsPanel

--- a/src/reducers/authenticate.js
+++ b/src/reducers/authenticate.js
@@ -9,6 +9,7 @@ const logInWithJWT = (state, action) => {
 
   const id_token = action.payload.id_token
   const access_token = action.payload.access_token
+  const username = action.payload.username
   //TODO: expire token after the specified time
   const expires_in = action.payload.expires_in
 
@@ -21,23 +22,28 @@ const logInWithJWT = (state, action) => {
     if (access_token !== undefined && access_token !== state.loginJwt.access_token) {
       loginState['access_token'] = access_token
 
-      if (expires_in !== undefined && expiry > new Date()) {
-        isAuthenticated = true
+      if (username !== undefined && username !== state.loginJwt.username) {
+        loginState['username'] = username
+
+        if (expires_in !== undefined && expiry > new Date()) {
+          isAuthenticated = true
+        }
       }
     }
   }
 
-  if (isAuthenticated) {
-    loginState = {loginJwt: {id_token: id_token, access_token: access_token, isAuthenticated: isAuthenticated}}
-  } else {
-    loginState = {loginJwt: {id_token: '', access_token: '', isAuthenticated: false}}
-  }
 
+  if (isAuthenticated) {
+    loginState = {loginJwt: {id_token: id_token, access_token: access_token, username: username, isAuthenticated: isAuthenticated}}
+  } else {
+    loginState = {loginJwt: {id_token: '', access_token: '', username: '', isAuthenticated: false}}
+  }
+  
   return loginState
 }
 
 const logOut = () => {
-  return {loginJwt: {id_token: '', access_token: '', isAuthenticated: false}}
+  return {loginJwt: {id_token: '', access_token: '', username: '', isAuthenticated: false}}
 }
 
 const authenticate = (state=DEFAULT_STATE, action) => {


### PR DESCRIPTION
Fixes #381 

- Adds a `username` attribute to loginJWT hash
- Class to decode JWT and pick out username
- passes username down to LoginPanel for display
- mock test file for AWS JWT values, used in multiple tests

<img width="847" alt="screen shot 2019-03-05 at 3 43 07 pm" src="https://user-images.githubusercontent.com/3093850/53845338-8d801280-3f5d-11e9-86a1-b8ff5d2437e2.png">
