### PR TITLE
Use COGNITO_CLIENT_ID as environment variable name

### DIFF
--- a/__tests__/Config.test.js
+++ b/__tests__/Config.test.js
@@ -53,7 +53,7 @@ describe('Config', () => {
     beforeAll(() => {
       process.env = {
         SINOPIA_URI: 'sinopia.foo',
-        AWS_CLIENT_ID: '1a2b3c',
+        COGNITO_CLIENT_ID: '1a2b3c',
         AWS_COGNITO_DOMAIN: 'sinopia-foo.amazoncognito.com'
       }
     })

--- a/src/Config.js
+++ b/src/Config.js
@@ -8,7 +8,7 @@ class Config {
   }
 
   static get awsClientID() {
-    return process.env.AWS_CLIENT_ID || '543cav95u0q1rqcags1nedc68a'
+    return process.env.COGNITO_CLIENT_ID || '543cav95u0q1rqcags1nedc68a'
   }
 
   static get awsCognitoDomain() {


### PR DESCRIPTION
The client ID is already passed in the container environment as COGNITO_CLIENT_ID. See: https://github.com/sul-dlss/terraform-aws/blob/ecea89a3694fcf49d19040102a1d3da0328ece9d/organizations/development/sinopia/container_definitions/homepage.json#L29