### PR TITLE
Use localStorage to manage the authentication status if the user 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -47,7 +47,14 @@ module.exports = {
   },
   overrides: [
     {
-      "files": ["**/*.jsx", "src/index.js", "src/*/*.js", "src/store.js", "src/Config.js", "src/LoginData.js", "src/Logout.js"],
+      "files": ["**/*.jsx",
+                "src/index.js",
+                "src/*/*.js",
+                "src/store.js",
+                "src/Config.js",
+                "src/LoginData.js",
+                "src/Logout.js",
+                "src/localStorage.js"],
       "rules": {
         // See https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/no-unsupported-features/es-syntax.md
         //   rule supposedly matches ECMA version with node

--- a/__tests__/components/LoginPanel.test.js
+++ b/__tests__/components/LoginPanel.test.js
@@ -11,7 +11,7 @@ describe('<LoginPanel /> when the user is not authenticated', () => {
 
   let wrapper = mount(
     <MemoryRouter>
-      <LoginPanel jwtAuth={{isAuthenticated: false}} />
+      <LoginPanel />
     </MemoryRouter>
   )
 
@@ -30,9 +30,12 @@ describe('<LoginPanel /> when the user is authenticated', () => {
   const mockLogOut = jest.fn()
   const wrapper = mount(
     <MemoryRouter>
-      <LoginPanel jwtAuth={{isAuthenticated: true}} logOut={mockLogOut} userName={'some-user'}/>
+      <LoginPanel logOut={mockLogOut} />
     </MemoryRouter>
   )
+
+  wrapper.find(LoginPanel).instance().setState({userAuthenticated: true, userName: 'some-user'})
+  wrapper.update()
 
   it('renders the welcome text with username', () => {
     expect(wrapper.find('form').text()).toMatch('Welcome some-user!')

--- a/__tests__/components/editor/Editor.test.js
+++ b/__tests__/components/editor/Editor.test.js
@@ -1,5 +1,4 @@
 // Copyright 2018 Stanford University see Apache2.txt for license
-
 import React from 'react'
 import { shallow } from 'enzyme'
 import Editor from '../../../src/components/editor/Editor'
@@ -13,10 +12,9 @@ const props = {
 
 describe('<Editor />', () => {
   const handleGenerateLDFn = jest.fn()
+  const wrapper = shallow(<Editor.WrappedComponent {...props} handleGenerateLD={handleGenerateLDFn} />)
+
   describe('any user', () => {
-    const wrapper = shallow(<Editor.WrappedComponent {...props}
-                                                     handleGenerateLD={handleGenerateLDFn}
-                                                     jwtAuth={{isAuthenticated: false}} />)
 
     it('has div with id "editor"', () => {
       expect(wrapper.find('div#editor').length).toBe(1)
@@ -45,13 +43,12 @@ describe('<Editor />', () => {
   })
 
   describe('authenticated user', () => {
-    const wrapper = shallow(<Editor.WrappedComponent {...props}
-                                                     handleGenerateLD={handleGenerateLDFn}
-                                                     jwtAuth={{isAuthenticated: true}} />)
 
     it('does not displays a login warning message', () => {
+      wrapper.setState({userAuthenticated: true})
       expect(wrapper.find('div.alert-warning').exists()).toBeFalsy()
     })
+
   })
 
 })

--- a/__tests__/localStorage.test.js
+++ b/__tests__/localStorage.test.js
@@ -1,0 +1,21 @@
+import { loadState, saveState, clearState } from '../src/localStorage'
+
+const stored = {loginJwt: {id_token: '1a2b3c', access_token: 'a1b2c3', username: 'some-user', isAuthenticated: true, expiry: 12345}}
+
+describe('managing state with localStorage', () => {
+
+  it('saves the state to localStorage', () => {
+    saveState(stored)
+  })
+
+  it('retrieves the state from localStorage', () => {
+    const state = loadState('jwtAuth')
+    expect(state).toMatchObject(stored)
+  })
+
+  it('clears out the state', () => {
+    clearState()
+    const state = loadState('jwtAuth')
+    expect(state).toBeUndefined()
+  })
+})

--- a/__tests__/reducers/authenticate.test.js
+++ b/__tests__/reducers/authenticate.test.js
@@ -9,14 +9,24 @@ describe('changing the reducer state', () => {
   })
 
   it('handles LOG_IN', () => {
+    let time = new Date()
+    const expiry = time.setSeconds(time.getSeconds() + 3600)
+
     expect(
       authenticate({loginJwt: {}}, {
         type: 'LOG_IN',
         payload: {id_token: '1a2b3c', access_token: 'a1b2c3', expires_in: 3600, username: 'some-user', isAuthenticated: true}
       })
-    ).toEqual(
+    ).toMatchObject(
       {loginJwt: {id_token: '1a2b3c', access_token: 'a1b2c3', username: 'some-user', isAuthenticated: true}}
     )
+
+    const expires = authenticate({loginJwt: {}}, {
+      type: 'LOG_IN',
+      payload: {id_token: '1a2b3c', access_token: 'a1b2c3', expires_in: 3600, username: 'some-user', isAuthenticated: true}
+    }).loginJwt['expiry']
+
+    expect(expires).toBeGreaterThanOrEqual(expiry)
   })
 
   it('handles LOG_OUT', () => {
@@ -25,7 +35,7 @@ describe('changing the reducer state', () => {
         type: 'LOG_OUT'
       })
     ).toEqual(
-      {loginJwt: {id_token: '', access_token: '', username: '', isAuthenticated: false}}
+      {loginJwt: {id_token: '', access_token: '', username: '', isAuthenticated: false, expiry: 0}}
     )
   })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8943,6 +8943,12 @@
         "pretty-format": "^23.6.0"
       }
     },
+    "jest-localstorage-mock": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/jest-localstorage-mock/-/jest-localstorage-mock-2.4.0.tgz",
+      "integrity": "sha512-/mC1JxnMeuIlAaQBsDMilskC/x/BicsQ/BXQxEOw+5b1aGZkkOAqAF3nu8yq449CpzGtp5jJ5wCmDNxLgA2m6A==",
+      "dev": true
+    },
     "jest-matcher-utils": {
       "version": "23.6.0",
       "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-23.6.0.tgz",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "html-webpack-plugin": "^3.2.0",
     "jest": "^23.6.0",
     "jest-junit": "^5.2.0",
+    "jest-localstorage-mock": "^2.4.0",
     "jest-puppeteer": "^3.9.0",
     "jsdom": "13.0.0",
     "jsdom-global": "3.0.2",
@@ -124,6 +125,9 @@
     ],
     "testPathIgnorePatterns": [
       "/node_modules/"
+    ],
+    "setupFiles": [
+      "jest-localstorage-mock"
     ]
   }
 }

--- a/src/Logout.js
+++ b/src/Logout.js
@@ -7,8 +7,11 @@ class Logout {
   }
 
   cognitoLogout() {
-    clearState()
     window.location = this.url
+  }
+
+  stateLogout() {
+    clearState()
   }
 }
 

--- a/src/Logout.js
+++ b/src/Logout.js
@@ -1,4 +1,5 @@
 import Config from './Config'
+import { clearState } from './localStorage'
 
 class Logout {
   constructor() {
@@ -6,6 +7,7 @@ class Logout {
   }
 
   cognitoLogout() {
+    clearState()
     window.location = this.url
   }
 }

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -8,10 +8,10 @@ import '../styles/main.css'
 import Editor from './editor/Editor'
 import Footer from './Footer'
 import { Route, Switch, Redirect, withRouter } from 'react-router-dom'
-import { logIn } from '../actions/index'
 import ImportResourceTemplate from './editor/ImportResourceTemplate'
 import Browse from './editor/Browse'
 import Login from './Login'
+import { loadState } from '../localStorage'
 
 const FourOhFour = () => <h1>404</h1>
 
@@ -25,11 +25,13 @@ class App extends Component{
   }
 
   render() {
+    const user = loadState('jwtAuth')
+
     const PrivateRoute = ({ component: ImportResourceTemplate, ...rest }) => (
       <Route
         {...rest}
         render={props =>
-          this.props.jwtAuth.isAuthenticated ? (
+          (user !== undefined && user.isAuthenticated) ? (
             <ImportResourceTemplate {...props} />
           ) : (
             <Redirect
@@ -65,10 +67,4 @@ const mapStateToProps = (state) => {
   }
 }
 
-const mapDispatchToProps = dispatch => ({
-  authenticate(jwt){
-    dispatch(logIn(jwt))
-  }
-})
-
-export default withRouter(connect(mapStateToProps, mapDispatchToProps)(App))
+export default withRouter(connect(mapStateToProps, null)(App))

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -1,7 +1,6 @@
 // Copyright 2018 Stanford University see Apache2.txt for license
 
 import React, { Component } from 'react'
-import { connect } from 'react-redux'
 import 'react-bootstrap-typeahead/css/Typeahead.css'
 import HomePage from './HomePage'
 import '../styles/main.css'
@@ -61,10 +60,4 @@ class App extends Component{
   }
 }
 
-const mapStateToProps = (state) => {
-  return {
-    jwtAuth: state.authenticate.loginJwt
-  }
-}
-
-export default withRouter(connect(mapStateToProps, null)(App))
+export default withRouter(App)

--- a/src/components/HomePage.jsx
+++ b/src/components/HomePage.jsx
@@ -9,6 +9,7 @@ import NewsPanel from './NewsPanel'
 import LoginData from '../../src/LoginData'
 import Logout from '../../src/Logout'
 import DescPanel from './DescPanel'
+import { saveState } from '../localStorage'
 const qs = require('query-string')
 const _ = require('lodash')
 
@@ -25,24 +26,22 @@ class HomePage extends Component {
 
   render() {
     const jwtHash = qs.parse(this.props.location.hash)
-    const user = this.props.jwtAuth
-
     const loginData = new LoginData()
     const userName = loginData.cognitoLoginData(jwtHash.access_token)
 
-    if (user !== undefined) {
-      if (!user.isAuthenticated) {
-        if(!_.isEmpty(jwtHash)) {
-          jwtHash['username'] = userName
-          this.props.authenticate(jwtHash)
-        }
+    if (!this.props.jwtAuth.isAuthenticated) {
+      if(!_.isEmpty(jwtHash)) {
+        jwtHash['username'] = userName
+        this.props.authenticate(jwtHash)
       }
+    } else {
+      saveState(this.props.jwtAuth)
     }
 
     return(
       <div id="home-page">
         <Header triggerHomePageMenu={this.props.triggerHandleOffsetMenu} />
-        <NewsPanel jwtAuth={this.props.jwtAuth} logOut={this.logOut} userName={userName}/>
+        <NewsPanel logOut={this.logOut} />
         <DescPanel />
       </div>
     )

--- a/src/components/HomePage.jsx
+++ b/src/components/HomePage.jsx
@@ -21,6 +21,7 @@ class HomePage extends Component {
   logOut = () => {
     this.props.signout()
     const logout = new Logout()
+    logout.stateLogout()
     logout.cognitoLogout()
   }
 

--- a/src/components/Login.jsx
+++ b/src/components/Login.jsx
@@ -29,13 +29,13 @@ class Login extends React.Component {
       authenticationMessage = <div className="alert alert-warning alert-dismissible">
         <a href="#" className="close" data-dismiss="alert" aria-label="close">&times;</a>
         You must be logged in to access the {pathName} path
-        <p>Please wait to be directed to the login service...</p>
       </div>;
     }
 
     return (
       <div className="jumbotron center-block">
         { authenticationMessage }
+        <p>Please wait to be directed to the login service...</p>
         {this.cognitoLogin(Config.awsCognitoLoginUrl)}
       </div>
     )

--- a/src/components/LoginPanel.jsx
+++ b/src/components/LoginPanel.jsx
@@ -4,17 +4,28 @@ import React, {Component} from 'react'
 import PropTypes from 'prop-types'
 import { NavLink, withRouter } from 'react-router-dom'
 import Config from '../Config.js'
+import { loadState } from '../localStorage'
 
 class LoginPanel extends Component {
   constructor(props){
     super(props)
+    this.state = {
+      userAuthenticated: false
+    }
   }
 
   render(){
+    const user = loadState('jwtAuth')
+    if (user !== undefined && user.isAuthenticated) {
+      if (!this.state.userAuthenticated) {
+        this.setState({userAuthenticated: true, userName: user.username})
+      }
+    }
+
     const AuthButton = withRouter(() =>
-        this.props.jwtAuth.isAuthenticated ? (
+        (this.state.userAuthenticated) ? (
           <p>
-            Welcome{` ${this.props.userName}`}!
+            Welcome{` ${this.state.userName}`}!
             <button onClick={() => {
               this.props.logOut()
             }}>
@@ -30,7 +41,7 @@ class LoginPanel extends Component {
       <NavLink className="btn btn-block btn-primary nav-link" type="button" to="/login">Login</NavLink>
     </div>;
 
-    if (this.props.jwtAuth.isAuthenticated) {
+    if (this.state.userAuthenticated) {
       loginButton = <p/>;
     }
 
@@ -38,7 +49,7 @@ class LoginPanel extends Component {
       <form className="login-form">
         <div className="form-group">
           <div className="row">
-            <AuthButton jwtAuth={this.props.jwtAuth} signout={this.props.signout}/>
+            <AuthButton />
             {loginButton}
           </div>
           <div className="row">

--- a/src/components/NewsPanel.jsx
+++ b/src/components/NewsPanel.jsx
@@ -20,7 +20,7 @@ class NewsPanel extends Component {
                 <NewsItem />
               </div>
               <div className="col-md-4 login-sec">
-                <LoginPanel jwtAuth={this.props.jwtAuth} logOut={this.props.logOut} userName={this.props.userName}/>
+                <LoginPanel logOut={this.props.logOut} />
               </div>
             </div>
           </div>

--- a/src/components/editor/Editor.jsx
+++ b/src/components/editor/Editor.jsx
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types'
 import ResourceTemplate from './ResourceTemplate'
 import Header from './Header'
 import StartingPoints from './StartingPoints'
+import { loadState } from '../../localStorage'
 
 class Editor extends Component {
   constructor(props) {
@@ -19,7 +20,8 @@ class Editor extends Component {
     const defaultRtId = 'resourceTemplate:bf2:Monograph:Instance'
     this.state = {
       resourceTemplateId: defaultRtId,
-      tempRtState: true
+      tempRtState: true,
+      userAuthenticated: false
     }
   }
 
@@ -34,18 +36,22 @@ class Editor extends Component {
   }
 
   render() {
-    const user = this.props.jwtAuth
-
     let authenticationMessage = <div className="alert alert-warning alert-dismissible">
       <a href="#" className="close" data-dismiss="alert" aria-label="close">&times;</a>
       Alert! No data can be saved unless you are logged in with group permissions.
       Log in <Link to={{pathname: "/login", state: { from: this.props.location }}} ><span className="alert-link" href="/login">here</span>.</Link>
     </div>;
 
-    if (user !== undefined) {
-      if (user.isAuthenticated) {
-        authenticationMessage = ''
+    const user = loadState('jwtAuth')
+
+    if (user !== undefined && user.isAuthenticated) {
+      if (!this.state.userAuthenticated) {
+        this.setState({userAuthenticated: true})
       }
+    }
+
+    if (this.state.userAuthenticated) {
+      authenticationMessage = <span/>
     }
 
     return(

--- a/src/localStorage.js
+++ b/src/localStorage.js
@@ -4,7 +4,15 @@ export const loadState = (stored) => {
     if (serializedState === null) {
       return undefined
     } else {
-      return JSON.parse(serializedState)
+      let state = JSON.parse(serializedState)
+
+      let time = new Date()
+      const expires = time.setSeconds(time.getSeconds())
+
+      if (expires > state.expiry) {
+        state = undefined
+      }
+      return state
     }
   } catch (err) {
     return undefined

--- a/src/localStorage.js
+++ b/src/localStorage.js
@@ -1,0 +1,29 @@
+export const loadState = (stored) => {
+  try {
+    const serializedState = localStorage.getItem(stored)
+    if (serializedState === null) {
+      return undefined
+    } else {
+      return JSON.parse(serializedState)
+    }
+  } catch (err) {
+    return undefined
+  }
+}
+
+export const saveState = (state) => {
+  try {
+    const serializedState = JSON.stringify(state)
+    localStorage.setItem('jwtAuth', serializedState)
+  } catch (err) {
+    // Ignore write errors
+  }
+}
+
+export const clearState = () => {
+  try {
+    localStorage.removeItem('jwtAuth')
+  } catch (err) {
+    // Ignore write errors
+  }
+}

--- a/src/reducers/authenticate.js
+++ b/src/reducers/authenticate.js
@@ -32,18 +32,41 @@ const logInWithJWT = (state, action) => {
     }
   }
 
-
   if (isAuthenticated) {
-    loginState = {loginJwt: {id_token: id_token, access_token: access_token, username: username, isAuthenticated: isAuthenticated}}
+    loginState = {
+      loginJwt: {
+        id_token: id_token,
+        access_token: access_token,
+        username: username,
+        isAuthenticated: isAuthenticated,
+        expiry: expiry
+      }
+    }
   } else {
-    loginState = {loginJwt: {id_token: '', access_token: '', username: '', isAuthenticated: false}}
+    loginState = {
+      loginJwt: {
+        id_token: '',
+        access_token: '',
+        username: '',
+        isAuthenticated: false,
+        expiry: 0
+      }
+    }
   }
   
   return loginState
 }
 
 const logOut = () => {
-  return {loginJwt: {id_token: '', access_token: '', username: '', isAuthenticated: false}}
+  return {
+    loginJwt: {
+      id_token: '',
+      access_token: '',
+      username: '',
+      isAuthenticated: false,
+      expiry: 0
+    }
+  }
 }
 
 const authenticate = (state=DEFAULT_STATE, action) => {


### PR DESCRIPTION
Fixes #316 

On the `HomePage` it checks whether the user is authenticated in redux; if not, it will look for the JWT query param and authenticate them. When the component updates it will then save the authentication state to localStorage via the `saveState()` call.

The `LoginPanel`, `Editor`, and other child components then look for the authentication state via the `loadState()` call and set their local state accordingly. 

The HomePage `logOut()` function gets passed to the `LoginPanel` child component (other child components will need it later) and when called it clears the localStorage state and then redirects to cognito for the destruction of the JWT.

