### PR TITLE
Working PropertyTemplateOutline using embedded Resource Template in PropertyPanel Component

### DIFF
--- a/__tests__/components/editor/PropertyActionButtons.test.js
+++ b/__tests__/components/editor/PropertyActionButtons.test.js
@@ -6,22 +6,14 @@ import { shallow } from 'enzyme'
 import PropertyActionButtons from '../../../src/components/editor/PropertyActionButtons'
 
 describe('<PropertyActionButtons />', () => {
-  const props = {
-    handleAddClick: jest.fn(),
-    handleMintUri: jest.fn()
-  }
-  const wrapper = shallow(<PropertyActionButtons {...props} />)
+
+  const wrapper = shallow(<PropertyActionButtons />)
   const buttons = wrapper.find('button')
 
   it('has two buttons', () => {
     expect(buttons.length).toEqual(2)
+    expect(buttons.find('.btn-default')).toBeTruthy()
+    expect(buttons.find('.btn-success')).toBeTruthy()
   })
 
-  it('calls handleAddClick', () => {
-    console.log(`buttons `)
-    console.log(buttons.debug())
-    buttons.find('.btn-default').simulate('click', { target: {}})
-    //.simulate('click', { target: {}})
-    expect(props.handleAddClick.mock.calls.length).toEqual(1)
-  })
 })

--- a/__tests__/components/editor/PropertyActionButtons.test.js
+++ b/__tests__/components/editor/PropertyActionButtons.test.js
@@ -1,0 +1,27 @@
+// Copyright 2019 Stanford University see Apache2.txt for license
+
+import React from 'react'
+import { shallow } from 'enzyme'
+
+import PropertyActionButtons from '../../../src/components/editor/PropertyActionButtons'
+
+describe('<PropertyActionButtons />', () => {
+  const props = {
+    handleAddClick: jest.fn(),
+    handleMintUri: jest.fn()
+  }
+  const wrapper = shallow(<PropertyActionButtons {...props} />)
+  const buttons = wrapper.find('button')
+
+  it('has two buttons', () => {
+    expect(buttons.length).toEqual(2)
+  })
+
+  it('calls handleAddClick', () => {
+    console.log(`buttons `)
+    console.log(buttons.debug())
+    buttons.find('.btn-default').simulate('click', { target: {}})
+    //.simulate('click', { target: {}})
+    expect(props.handleAddClick.mock.calls.length).toEqual(1)
+  })
+})

--- a/__tests__/components/editor/PropertyResourceTemplate.test.js
+++ b/__tests__/components/editor/PropertyResourceTemplate.test.js
@@ -1,7 +1,9 @@
 // Copyright 2019 Stanford University see Apache2.txt for license
 
 import React from 'react'
-import { shallow } from 'enzyme'
+import 'jsdom-global/register'
+import { shallow, mount } from 'enzyme'
+import PropertyActionButtons from '../../../src/components/editor/PropertyActionButtons'
 import PropertyResourceTemplate from '../../../src/components/editor/PropertyResourceTemplate'
 import PropertyTemplateOutline from '../../../src/components/editor/PropertyTemplateOutline'
 
@@ -31,5 +33,28 @@ describe('<PropertyResourceTemplate />', () => {
       const propTemplateOutline = wrapper.find(PropertyTemplateOutline)
       expect(propTemplateOutline.props().propertyTemplate).toBeTruthy()
   })
+
+  describe('<PropertyResourceTemplate /> has the "Add Click" and "Mint URI" buttons', () => {
+
+    const wrapper = mount(<PropertyResourceTemplate {...propertyRtProps} />)
+    const actionButtons = wrapper.find(PropertyActionButtons)
+
+    it("Contains a PropertyActionButtons component", () => {
+      expect(actionButtons).toBeTruthy()
+    })
+
+    it('handles "Add" button click', () => {
+      const addEvent = { preventDefault: jest.fn() }
+      actionButtons.props().handleAddClick(addEvent)
+      expect(addEvent.preventDefault.mock.calls.length).toBe(1)
+    })
+
+    it('handles "Mint URI" button click', () => {
+      const mintEvent = { preventDefault: jest.fn() }
+      actionButtons.props().handleMintUri(mintEvent)
+      expect(mintEvent.preventDefault.mock.calls.length).toBe(1)
+    })
+  })
+
 
 })

--- a/__tests__/components/editor/PropertyResourceTemplate.test.js
+++ b/__tests__/components/editor/PropertyResourceTemplate.test.js
@@ -3,13 +3,18 @@
 import React from 'react'
 import { shallow } from 'enzyme'
 import PropertyResourceTemplate from '../../../src/components/editor/PropertyResourceTemplate'
-import PropertyTypeRow from '../../../src/components/editor/PropertyTypeRow'
+import PropertyTemplateOutline from '../../../src/components/editor/PropertyTemplateOutline'
 
-describe('<PropertyPanel />', () => {
+describe('<PropertyResourceTemplate />', () => {
   let propertyRtProps = {
     resourceTemplate: {
       resourceLabel: "Test Schema Thing Template",
-      propertyTemplates: []
+      propertyTemplates: [
+        {
+          propertyLabel: "Description",
+          propertyURI: "http://schema.org/"
+        }
+      ]
     }
   }
   const wrapper = shallow(<PropertyResourceTemplate {...propertyRtProps} />)
@@ -18,11 +23,13 @@ describe('<PropertyPanel />', () => {
     expect(wrapper.find("h4").text()).toBe(`${propertyRtProps.resourceTemplate.resourceLabel}`)
   })
 
-  it('Contains a <PropertyTypeRow />', () => {
-    expect(wrapper.find(PropertyTypeRow)).toBeTruthy()
+  it('Contains a <PropertyTemplateOutline />', () => {
+      expect(wrapper.find(PropertyTemplateOutline)).toBeTruthy()
+    })
+
+  it('<PropertyTemplateOutline /> contains a propertyTemplate', () => {
+      const propTemplateOutline = wrapper.find(PropertyTemplateOutline)
+      expect(propTemplateOutline.props().propertyTemplate).toBeTruthy()
   })
 
-  it('Contains a <PropertyTypeRow />', () => {
-    expect(wrapper.find(PropertyTypeRow)).toBeTruthy()
-  })
 })

--- a/__tests__/components/editor/PropertyTemplateOutline.test.js
+++ b/__tests__/components/editor/PropertyTemplateOutline.test.js
@@ -2,6 +2,7 @@
 
 import React from 'react'
 import { shallow } from 'enzyme'
+import InputLiteral from '../../../src/components/editor/InputLiteral'
 import PropertyTemplateOutline from '../../../src/components/editor/PropertyResourceTemplate'
 import PropertyTypeRow from '../../../src/components/editor/PropertyTypeRow'
 
@@ -9,7 +10,12 @@ describe('<PropertyTemplateOutline />', () => {
   let propertyRtProps = {
     resourceTemplate: {
       resourceLabel: "Test Schema Thing Template",
-      propertyTemplates: []
+      propertyTemplates: [
+        {
+          propertyLabel: "Test Schema name as a literal",
+          propertyURI: "http://schema.org/name"
+        }
+      ]
     }
   }
   const wrapper = shallow(<PropertyTemplateOutline {...propertyRtProps} />)
@@ -21,4 +27,14 @@ describe('<PropertyTemplateOutline />', () => {
   it('Contains a <PropertyTypeRow />', () => {
     expect(wrapper.find(PropertyTypeRow)).toBeTruthy()
   })
+
+  it('has an <PropertyTemplateOutline /> as a child', () => {
+     expect(wrapper.find(PropertyTemplateOutline)).toBeTruthy()
+  })
+
+  it('child PropertyTemplateOutline has an InputLiteral', () => {
+    const childPropertyTemplateOutline = wrapper.find(PropertyTemplateOutline)
+    expect(childPropertyTemplateOutline.find(InputLiteral)).toBeTruthy()
+  })
+  
 })

--- a/__tests__/components/editor/PropertyTemplateOutline.test.js
+++ b/__tests__/components/editor/PropertyTemplateOutline.test.js
@@ -1,8 +1,10 @@
 // Copyright 2019 Stanford University see Apache2.txt for license
 
 import React from 'react'
-import { shallow } from 'enzyme'
+import 'jsdom-global/register'
+import { shallow, mount } from 'enzyme'
 import InputLiteral from '../../../src/components/editor/InputLiteral'
+import OutlineHeader from '../../../src/components/editor/OutlineHeader'
 import PropertyTemplateOutline from '../../../src/components/editor/PropertyResourceTemplate'
 import PropertyTypeRow from '../../../src/components/editor/PropertyTypeRow'
 
@@ -36,5 +38,45 @@ describe('<PropertyTemplateOutline />', () => {
     const childPropertyTemplateOutline = wrapper.find(PropertyTemplateOutline)
     expect(childPropertyTemplateOutline.find(InputLiteral)).toBeTruthy()
   })
-  
+})
+
+describe('<PropertyTemplateOutline /> with propertyTemplate Refs', () => {
+  const mockHandleCollapsed = jest.fn()
+  const propertyRtProps = {
+    resourceTemplate: {
+      resourceLabel: "Test Schema Thing CreativeWork",
+      propertyTemplates: [
+        {
+          "propertyLabel": "Notes about the CreativeWork",
+          "remark": "This is a great note",
+          "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+          "mandatory": "false",
+          "repeatable": "true",
+          "type": "resource",
+          "resourceTemplates": [],
+          "valueConstraint": {
+            "valueTemplateRefs": [
+              "resourceTemplate:bf2:Note"
+            ],
+            "useValuesFrom": [],
+            "valueDataType": {},
+            "defaults": []
+          }
+        }
+      ]
+    }
+  }
+  const wrapper = mount(<PropertyTemplateOutline {...propertyRtProps}
+    handleCollapsed={mockHandleCollapsed} />)
+  const childOutlineHeader = wrapper.find(OutlineHeader)
+
+  it('displays a collapsed OutlineHeader of the propertyTemplate label', () => {
+    expect(childOutlineHeader.props().label).toEqual(propertyRtProps.resourceTemplate.propertyTemplates[0].propertyLabel)
+    expect(childOutlineHeader.props().collapsed).toBeTruthy()
+  })
+
+  it('clicking removes collapsed state', () => {
+    childOutlineHeader.find('a').simulate('click')
+    expect(wrapper.state().collapsed).toBeFalsy()
+  })
 })

--- a/__tests__/components/editor/PropertyTemplateOutline.test.js
+++ b/__tests__/components/editor/PropertyTemplateOutline.test.js
@@ -4,27 +4,50 @@ import React from 'react'
 import 'jsdom-global/register'
 import { shallow, mount } from 'enzyme'
 import InputLiteral from '../../../src/components/editor/InputLiteral'
+import InputListLOC from '../../../src/components/editor/InputListLOC'
+import InputLookupQA from '../../../src/components/editor/InputLookupQA'
 import OutlineHeader from '../../../src/components/editor/OutlineHeader'
-import PropertyTemplateOutline from '../../../src/components/editor/PropertyResourceTemplate'
+import PropertyActionButtons from '../../../src/components/editor/PropertyActionButtons'
+import { getLookupConfigItem, PropertyTemplateOutline } from '../../../src/components/editor/PropertyTemplateOutline'
 import PropertyTypeRow from '../../../src/components/editor/PropertyTypeRow'
+
+describe('getLookupConfigItem module function', () => {
+
+  const property = {
+    "mandatory": "true",
+    "repeatable": "true",
+    "type": "lookup",
+    "resourceTemplates": [],
+    "valueConstraint": {
+      "valueTemplateRefs": [],
+      "useValuesFrom": [
+        "urn:ld4p:qa:sharevde_stanford_instance_ld4l_cache"
+      ],
+      "valueDataType": {
+        "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Instance"
+      },
+      "defaults": []
+    },
+    "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasInstance",
+    "propertyLabel": "ShareVDE Stanford Instances"
+  }
+
+ it('returns a JSON array based on useValuesForm', () => {
+   const shareVdeStanfordInstancesConfig = getLookupConfigItem(property)
+ })
+
+})
 
 describe('<PropertyTemplateOutline />', () => {
   let propertyRtProps = {
-    resourceTemplate: {
-      resourceLabel: "Test Schema Thing Template",
-      propertyTemplates: [
+    propertyTemplate:
         {
           propertyLabel: "Test Schema name as a literal",
           propertyURI: "http://schema.org/name"
         }
-      ]
-    }
   }
   const wrapper = shallow(<PropertyTemplateOutline {...propertyRtProps} />)
-
-  it('Contains label from props', () => {
-    expect(wrapper.find("h4").text()).toBe(`${propertyRtProps.resourceTemplate.resourceLabel}`)
-  })
+  const childPropertyTemplateOutline = wrapper.find(PropertyTemplateOutline)
 
   it('Contains a <PropertyTypeRow />', () => {
     expect(wrapper.find(PropertyTypeRow)).toBeTruthy()
@@ -35,43 +58,110 @@ describe('<PropertyTemplateOutline />', () => {
   })
 
   it('child PropertyTemplateOutline has an InputLiteral', () => {
-    const childPropertyTemplateOutline = wrapper.find(PropertyTemplateOutline)
     expect(childPropertyTemplateOutline.find(InputLiteral)).toBeTruthy()
+  })
+
+})
+
+describe('<PropertyTemplateOutline /> with InputListLOC component', () => {
+  const property = {
+    propertyTemplate: {
+      "mandatory": "true",
+        "repeatable": "true",
+        "type": "lookup",
+        "resourceTemplates": [],
+        "valueConstraint": {
+          "valueTemplateRefs": [],
+          "useValuesFrom": [
+            "urn:ld4p:qa:sharevde_stanford_instance_ld4l_cache"
+          ],
+          "valueDataType": {
+            "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Instance"
+          },
+          "defaults": []
+        },
+        "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasInstance",
+        "propertyLabel": "ShareVDE Stanford Instances"
+     }
+  }
+  const wrapper = mount(<PropertyTemplateOutline {...property} />)
+  const childPropertyTemplateOutline = wrapper.find(PropertyTemplateOutline)
+
+  it('child PropertyTemplateOutline has an InputListLOC component', () => {
+    expect(childPropertyTemplateOutline.find(InputListLOC)).toBeTruthy()
+  })
+})
+
+describe('<PropertyTemplateOutline /> with <InputLookupQA /> component', () => {
+  const property = {
+    propertyTemplate: {
+       "propertyLabel": "Carrier Type (RDA 3.3)",
+       "propertyURI": "http://id.loc.gov/ontologies/bibframe/carrier",
+       "repeatable": "true",
+       "resourceTemplates": [],
+       "type": "resource",
+       "valueConstraint": {
+         "valueTemplateRefs": [],
+         "useValuesFrom": [
+           "https://id.loc.gov/vocabulary/carriers"
+         ],
+         "valueDataType": {
+           "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Carrier"
+         },
+         "repeatable": "true",
+         "editable": "false",
+         "defaults": [
+           {
+             "defaultURI": "http://id.loc.gov/vocabulary/carriers/nc",
+             "defaultLiteral": "volume"
+           }
+         ]
+       },
+       "mandatory": "false",
+       "remark": "http://access.rdatoolkit.org/3.3.html"
+     }
+  }
+
+  const wrapper = mount(<PropertyTemplateOutline {...property} />)
+  const childPropertyTemplateOutline = wrapper.find(PropertyTemplateOutline)
+
+  it('child PropertyTemplateOutline has an InputLookupQA component', () => {
+    expect(childPropertyTemplateOutline .find(InputLookupQA)).toBeTruthy()
   })
 })
 
 describe('<PropertyTemplateOutline /> with propertyTemplate Refs', () => {
   const mockHandleCollapsed = jest.fn()
-  const propertyRtProps = {
-    resourceTemplate: {
-      resourceLabel: "Test Schema Thing CreativeWork",
-      propertyTemplates: [
-        {
-          "propertyLabel": "Notes about the CreativeWork",
-          "remark": "This is a great note",
-          "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-          "mandatory": "false",
-          "repeatable": "true",
-          "type": "resource",
-          "resourceTemplates": [],
-          "valueConstraint": {
-            "valueTemplateRefs": [
-              "resourceTemplate:bf2:Note"
-            ],
-            "useValuesFrom": [],
-            "valueDataType": {},
-            "defaults": []
-          }
+  const mockHandleAddClick = jest.fn()
+  const mockHandleMintUri = jest.fn()
+  const property = {
+    propertyTemplate: {
+        "propertyLabel": "Notes about the CreativeWork",
+        "remark": "This is a great note",
+        "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+        "mandatory": "false",
+        "repeatable": "true",
+        "type": "resource",
+        "resourceTemplates": [],
+        "valueConstraint": {
+          "valueTemplateRefs": [
+            "resourceTemplate:bf2:Note"
+          ],
+          "useValuesFrom": [],
+          "valueDataType": {},
+          "defaults": []
         }
-      ]
-    }
-  }
-  const wrapper = mount(<PropertyTemplateOutline {...propertyRtProps}
-    handleCollapsed={mockHandleCollapsed} />)
+      }
+   }
+  const wrapper = mount(<PropertyTemplateOutline {...property}
+    handleCollapsed={mockHandleCollapsed}
+    handleAddClick={mockHandleAddClick}
+    handleMintUri={mockHandleMintUri} />)
   const childOutlineHeader = wrapper.find(OutlineHeader)
+  const actionButtons = wrapper.find(PropertyActionButtons)
 
   it('displays a collapsed OutlineHeader of the propertyTemplate label', () => {
-    expect(childOutlineHeader.props().label).toEqual(propertyRtProps.resourceTemplate.propertyTemplates[0].propertyLabel)
+    expect(childOutlineHeader.props().label).toEqual(property.propertyTemplate.propertyLabel)
     expect(childOutlineHeader.props().collapsed).toBeTruthy()
   })
 
@@ -79,4 +169,17 @@ describe('<PropertyTemplateOutline /> with propertyTemplate Refs', () => {
     childOutlineHeader.find('a').simulate('click')
     expect(wrapper.state().collapsed).toBeFalsy()
   })
+
+  it('handles "Add" button click', () => {
+    const addButton = wrapper.find('.btn-default')
+    addButton.simulate('click')
+    expect(mockHandleAddClick.mock.calls.length).toBe(1)
+  })
+
+  it('handles "Mint URI" button click', () => {
+    const mintButton = wrapper.find('.btn-success')
+    mintButton.simulate('click')
+    expect(mockHandleMintUri.mock.calls.length).toBe(1)
+  })
+
 })

--- a/src/components/editor/PropertyActionButtons.jsx
+++ b/src/components/editor/PropertyActionButtons.jsx
@@ -1,0 +1,25 @@
+// Copyright 2019 Stanford University see Apache2.txt for license
+
+import React, {Component} from 'react'
+import PropTypes from 'prop-types'
+
+export class PropertyButtonActions extends Component {
+
+  constructor(props) {
+    super(props)
+  }
+
+  render() {
+    return(<div className="btn-group" role="group" aria-label="...">
+      <button onClick={this.handleMintUri} className="btn btn-success btn-sm">Mint URI</button>
+      <button className="btn btn-default btn-sm" onClick={this.handleAddClick}>Add</button>
+    </div>)
+  }
+}
+
+PropertyButtonActions.propTypes = {
+  handleAddClick: PropTypes.func,
+  handleMintUri: PropTypes.func
+}
+
+export default PropertyButtonActions;

--- a/src/components/editor/PropertyActionButtons.jsx
+++ b/src/components/editor/PropertyActionButtons.jsx
@@ -3,7 +3,7 @@
 import React, {Component} from 'react'
 import PropTypes from 'prop-types'
 
-export class PropertyButtonActions extends Component {
+export class PropertyActionButtons extends Component {
 
   constructor(props) {
     super(props)
@@ -17,9 +17,9 @@ export class PropertyButtonActions extends Component {
   }
 }
 
-PropertyButtonActions.propTypes = {
+PropertyActionButtons.propTypes = {
   handleAddClick: PropTypes.func,
   handleMintUri: PropTypes.func
 }
 
-export default PropertyButtonActions;
+export default PropertyActionButtons;

--- a/src/components/editor/PropertyActionButtons.jsx
+++ b/src/components/editor/PropertyActionButtons.jsx
@@ -11,8 +11,8 @@ export class PropertyButtonActions extends Component {
 
   render() {
     return(<div className="btn-group" role="group" aria-label="...">
-      <button onClick={this.handleMintUri} className="btn btn-success btn-sm">Mint URI</button>
-      <button className="btn btn-default btn-sm" onClick={this.handleAddClick}>Add</button>
+      <button onClick={this.props.handleMintUri} className="btn btn-success btn-sm">Mint URI</button>
+      <button className="btn btn-default btn-sm" onClick={this.props.handleAddClick}>Add</button>
     </div>)
   }
 }

--- a/src/components/editor/PropertyResourceTemplate.jsx
+++ b/src/components/editor/PropertyResourceTemplate.jsx
@@ -20,6 +20,10 @@ class PropertyResourceTemplate extends Component {
      event.preventDefault()
   }
 
+  handleMintUri = (event) => {
+    event.preventDefault()
+  }
+
   render() {
     return (
       <div>

--- a/src/components/editor/PropertyResourceTemplate.jsx
+++ b/src/components/editor/PropertyResourceTemplate.jsx
@@ -1,7 +1,9 @@
 // Copyright 2019 Stanford University see Apache2.txt for license
 
 import React, { Component } from 'react'
+import PropertyActionButtons from './PropertyActionButtons'
 import PropertyTemplateOutline from './PropertyTemplateOutline'
+
 import shortid from 'shortid'
 import PropTypes from 'prop-types'
 
@@ -26,10 +28,8 @@ class PropertyResourceTemplate extends Component {
             <h4>{this.props.resourceTemplate.resourceLabel}</h4>
           </section>
           <section className="col-md-4">
-            <div className="btn-group" role="group" aria-label="...">
-              <button onClick={this.handleMintUri} className="btn btn-success btn-sm">Mint URI</button>
-              <button className="btn btn-default btn-sm" onClick={this.handleAddClick}>Add</button>
-            </div>
+            <PropertyActionButtons handleAddClick={this.handleAddClick}
+              handleMintUri={this.handleMintUri} key={shortid.generate()} />
           </section>
         </div>
         <div>

--- a/src/components/editor/PropertyTemplateOutline.jsx
+++ b/src/components/editor/PropertyTemplateOutline.jsx
@@ -18,6 +18,17 @@ export const valueTemplateRefTest = (property) => {
    property.valueConstraint.valueTemplateRefs.length > 0)
 }
 
+export const getLookupConfigItem = (property) => {
+  let templateUri = property.valueConstraint.useValuesFrom[0]
+  let templateConfigItem
+  lookupConfig.forEach((configItem) => {
+    if (configItem.uri === templateUri) {
+      templateConfigItem = { value: configItem }
+    }
+  })
+  return templateConfigItem
+}
+
 export class PropertyTemplateOutline extends Component {
 
   constructor(props) {
@@ -26,17 +37,6 @@ export class PropertyTemplateOutline extends Component {
       collapsed: true,
       output: []
     }
-  }
-
-  getLookupConfigItem = (property) => {
-    let templateUri = property.valueConstraint.useValuesFrom[0]
-    let templateConfigItem
-    lookupConfig.forEach((configItem) => {
-      if (configItem.uri === templateUri) {
-        templateConfigItem = { value: configItem }
-      }
-    })
-    return templateConfigItem
   }
 
   handleAddClick = (event) => {
@@ -61,7 +61,7 @@ export class PropertyTemplateOutline extends Component {
         break;
 
       case "lookup":
-        lookupConfigItem = this.getLookupConfigItem(property)
+        lookupConfigItem = getLookupConfigItem(property)
         input = <InputLookupQA propertyTemplate={property}
              lookupConfig={lookupConfigItem}
              rtId = {property.rtId} />
@@ -80,7 +80,7 @@ export class PropertyTemplateOutline extends Component {
           })
           break;
         }
-        lookupConfigItem = this.getLookupConfigItem(property)
+        lookupConfigItem = getLookupConfigItem(property)
         input = <InputListLOC propertyTemplate = {property}
              lookupConfig = {lookupConfigItem}
              rtId = {property.rtId} />

--- a/src/components/editor/PropertyTemplateOutline.jsx
+++ b/src/components/editor/PropertyTemplateOutline.jsx
@@ -30,16 +30,17 @@ export class PropertyTemplateOutline extends Component {
 
   getLookupConfigItem = (property) => {
     let templateUri = property.valueConstraint.useValuesFrom[0]
+    let templateConfigItem
     lookupConfig.forEach((configItem) => {
       if (configItem.uri === templateUri) {
-        return { value: configItem }
+        templateConfigItem = { value: configItem }
       }
     })
+    return templateConfigItem
   }
 
   handleAddClick = (event) => {
     event.preventDefault()
-    console.log(`In HandleAddClick`)
   }
 
   handleMintUri = (event) => {
@@ -61,8 +62,6 @@ export class PropertyTemplateOutline extends Component {
 
       case "lookup":
         lookupConfigItem = this.getLookupConfigItem(property)
-        console.log(`lookupConfigItem`)
-        console.warn(lookupConfigItem)
         input = <InputLookupQA propertyTemplate={property}
              lookupConfig={lookupConfigItem}
              rtId = {property.rtId} />

--- a/src/components/editor/PropertyTemplateOutline.jsx
+++ b/src/components/editor/PropertyTemplateOutline.jsx
@@ -73,7 +73,8 @@ export class PropertyTemplateOutline extends Component {
           property.valueConstraint.valueTemplateRefs.map((rtId) => {
             let resourceTemplate = getResourceTemplate(rtId)
             resourceTemplate.propertyTemplates.map((rtProperty, i) => {
-              input.push(<PropertyTemplateOutline key={i} propertyTemplate={rtProperty}
+              input.push(<PropertyTemplateOutline key={shortid.generate()}
+                propertyTemplate={rtProperty}
                 resourceTemplate={getResourceTemplate(rtId)} />)
             })
           })
@@ -86,14 +87,22 @@ export class PropertyTemplateOutline extends Component {
 
         break;
     }
-    // Needs to dedup property in state before pushing
-    newOutput.push(<PropertyTypeRow
-      key={shortid.generate()}
-      handleAddClick={this.props.handleAddClick}
-      handleMintUri={this.props.handleMintUri}
-      propertyTemplate={property}>
-      {input}
-    </PropertyTypeRow>)
+    let existingInput
+    newOutput.forEach((input) => {
+      if (this.props.propertyTemplate.propertyURI === input.props.propertyTemplate.propertyURI) {
+        existingInput = input
+        return
+      }
+    })
+    if (existingInput === undefined) {
+      newOutput.push(<PropertyTypeRow
+          key={shortid.generate()}
+          handleAddClick={this.props.handleAddClick}
+          handleMintUri={this.props.handleMintUri}
+          propertyTemplate={property}>
+          {input}
+        </PropertyTypeRow>)
+    }
     this.setState( { collapsed: !this.state.collapsed,
                      output: newOutput })
   }
@@ -113,9 +122,10 @@ export class PropertyTemplateOutline extends Component {
 
 
   render() {
-    return(<div className="rtOutline">
+    return(<div className="rtOutline" key={shortid.generate()}>
             <OutlineHeader label={this.props.propertyTemplate.propertyLabel}
               collapsed={this.state.collapsed}
+              key={shortid.generate()}
               isRequired={this.isRequired(this.props.propertyTemplate)}
               handleCollapsed={this.handleClick(this.props.propertyTemplate)} />
             <div className={this.outlinerClasses()}>

--- a/src/components/editor/PropertyTemplateOutline.jsx
+++ b/src/components/editor/PropertyTemplateOutline.jsx
@@ -1,9 +1,9 @@
 // Copyright 2019 Stanford University see Apache2.txt for license
 
 import React, {Component} from 'react'
-import ReactDOM from 'react-dom'
 import InputLiteral from './InputLiteral'
 import InputListLOC from './InputListLOC'
+import InputLookupQA from './InputLookupQA'
 import OutlineHeader from './OutlineHeader'
 import PropertyTypeRow from './PropertyTypeRow'
 import RequiredSuperscript from './RequiredSuperscript'
@@ -12,7 +12,11 @@ import lookupConfig from '../../../static/spoofedFilesFromServer/fromSinopiaServ
 import PropTypes from 'prop-types'
 import shortid from 'shortid'
 
-
+export const valueTemplateRefTest = (property) => {
+  return Boolean(property.valueConstraint != null &&
+   property.valueConstraint.valueTemplateRefs != null &&
+   property.valueConstraint.valueTemplateRefs.length > 0)
+}
 
 export class PropertyTemplateOutline extends Component {
 
@@ -33,12 +37,20 @@ export class PropertyTemplateOutline extends Component {
     })
   }
 
-  handleCollapsed = (property) => (event) => {
+  handleAddClick = (event) => {
+    event.preventDefault()
+    console.log(`In HandleAddClick`)
+  }
+
+  handleMintUri = (event) => {
+    event.preventDefault()
+  }
+
+  handleClick = (property) => (event) => {
     event.preventDefault()
     let newOutput = this.state.output
-
     let input
-
+    let lookupConfigItem
     switch (property.type) {
       case "literal":
         input = <InputLiteral id={this.props.count}
@@ -47,27 +59,40 @@ export class PropertyTemplateOutline extends Component {
               rtId={property.rtId} />
         break;
 
-      case "resource":
-          if (this.valueTemplateRefTest(property)){
-            input = []
-            property.valueConstraint.valueTemplateRefs.map((rtId, i) => {
-              let resourceTemplate = getResourceTemplate(rtId)
-              resourceTemplate.propertyTemplates.map((rtProperty) => {
-                input.push(<PropertyTemplateOutline propertyTemplate={rtProperty}
-                  resourceTemplate={getResourceTemplate(rtId)} />)
-              })
-            })
-            break;
-          }
-          let lookupConfigItem = this.getLookupConfigItem(property)
-          input = <InputListLOC propertyTemplate = {property}
-               lookupConfig = {lookupConfigItem}
-               rtId = {property.rtId} />
+      case "lookup":
+        lookupConfigItem = this.getLookupConfigItem(property)
+        console.log(`lookupConfigItem`)
+        console.warn(lookupConfigItem)
+        input = <InputLookupQA propertyTemplate={property}
+             lookupConfig={lookupConfigItem}
+             rtId = {property.rtId} />
+        break;
 
+      case "resource":
+        if (valueTemplateRefTest(property)){
+          input = []
+          property.valueConstraint.valueTemplateRefs.map((rtId) => {
+            let resourceTemplate = getResourceTemplate(rtId)
+            resourceTemplate.propertyTemplates.map((rtProperty, i) => {
+              input.push(<PropertyTemplateOutline key={i} propertyTemplate={rtProperty}
+                resourceTemplate={getResourceTemplate(rtId)} />)
+            })
+          })
           break;
+        }
+        lookupConfigItem = this.getLookupConfigItem(property)
+        input = <InputListLOC propertyTemplate = {property}
+             lookupConfig = {lookupConfigItem}
+             rtId = {property.rtId} />
+
+        break;
     }
     // Needs to dedup property in state before pushing
-    newOutput.push(<PropertyTypeRow key={shortid.generate()} propertyTemplate={property}>
+    newOutput.push(<PropertyTypeRow
+      key={shortid.generate()}
+      handleAddClick={this.props.handleAddClick}
+      handleMintUri={this.props.handleMintUri}
+      propertyTemplate={property}>
       {input}
     </PropertyTypeRow>)
     this.setState( { collapsed: !this.state.collapsed,
@@ -86,19 +111,17 @@ export class PropertyTemplateOutline extends Component {
     return classNames
   }
 
-  valueTemplateRefTest = (property) => {
-    return Boolean(property.valueConstraint != null &&
-     property.valueConstraint.valueTemplateRefs != null &&
-     property.valueConstraint.valueTemplateRefs.length > 0)
-  }
+
 
   render() {
     return(<div className="rtOutline">
             <OutlineHeader label={this.props.propertyTemplate.propertyLabel}
               collapsed={this.state.collapsed}
               isRequired={this.isRequired(this.props.propertyTemplate)}
-              handleCollapsed={this.handleCollapsed(this.props.propertyTemplate)} />
-            <div className={this.outlinerClasses()}>{this.state.output}</div>
+              handleCollapsed={this.handleClick(this.props.propertyTemplate)} />
+            <div className={this.outlinerClasses()}>
+              {this.state.output}
+            </div>
         </div>)
   }
 

--- a/src/components/editor/PropertyTemplateOutline.jsx
+++ b/src/components/editor/PropertyTemplateOutline.jsx
@@ -72,7 +72,7 @@ export class PropertyTemplateOutline extends Component {
           input = []
           property.valueConstraint.valueTemplateRefs.map((rtId) => {
             let resourceTemplate = getResourceTemplate(rtId)
-            resourceTemplate.propertyTemplates.map((rtProperty, i) => {
+            resourceTemplate.propertyTemplates.map((rtProperty) => {
               input.push(<PropertyTemplateOutline key={shortid.generate()}
                 propertyTemplate={rtProperty}
                 resourceTemplate={getResourceTemplate(rtId)} />)
@@ -139,6 +139,8 @@ export class PropertyTemplateOutline extends Component {
 PropertyTemplateOutline.propTypes = {
   count: PropTypes.number,
   depth: PropTypes.number,
+  handleAddClick: PropTypes.func,
+  handleMintUri: PropTypes.func,
   handleCollapsed: PropTypes.func,
   isRequired: PropTypes.func,
   propertyTemplate: PropTypes.object,

--- a/src/components/editor/PropertyTypeRow.jsx
+++ b/src/components/editor/PropertyTypeRow.jsx
@@ -2,6 +2,9 @@
 
 import React, {Component} from 'react'
 import PropTypes from 'prop-types'
+import PropertyActionButtons from './PropertyActionButtons'
+import { valueTemplateRefTest } from './PropertyTemplateOutline'
+import shortid from 'shortid'
 
 export class PropertyTypeRow extends Component {
 
@@ -9,21 +12,35 @@ export class PropertyTypeRow extends Component {
     super(props)
   }
 
+  addButtons = () => {
+    if (valueTemplateRefTest(this.props.propertyTemplate)) {
+      return <PropertyActionButtons handleAddClick={this.props.handleAddClick}
+        handleMintUri={this.props.handleMintUri} key={shortid.generate()}/>
+    }
+  }
+
   render() {
-    return(<div className="row" >
-      <section className="col-sm-4">
+    console.log(`PropertyTypeRow ${this.props.propertyTemplate.propertyLabel} ${valueTemplateRefTest(this.props.propertyTemplate)}`)
+    console.log()
+    return(<React.Fragment>
+      <div className="row">
+        <section className="col-sm-8">
         {this.props.propertyTemplate.propertyLabel}
-      </section>
-      <section className="col-sm-8">
-        { this.props.children }
-      </section>
-    </div>)
+        </section>
+        <section className="col-sm-4">
+          {this.addButtons()}
+        </section>
+      </div>
+      { this.props.children }
+    </React.Fragment>)
   }
 }
 
 PropertyTypeRow.propTypes = {
   children: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
-  propertyTemplate: PropTypes.object
+  handleAddUri: PropTypes.func,
+  handleMintUri: PropTypes.func,
+  propertyTemplate: PropTypes.object,
 }
 
 export default PropertyTypeRow;

--- a/src/components/editor/PropertyTypeRow.jsx
+++ b/src/components/editor/PropertyTypeRow.jsx
@@ -36,7 +36,7 @@ export class PropertyTypeRow extends Component {
 
 PropertyTypeRow.propTypes = {
   children: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
-  handleAddUri: PropTypes.func,
+  handleAddClick: PropTypes.func,
   handleMintUri: PropTypes.func,
   propertyTemplate: PropTypes.object,
 }

--- a/src/components/editor/PropertyTypeRow.jsx
+++ b/src/components/editor/PropertyTypeRow.jsx
@@ -20,9 +20,7 @@ export class PropertyTypeRow extends Component {
   }
 
   render() {
-    console.log(`PropertyTypeRow ${this.props.propertyTemplate.propertyLabel} ${valueTemplateRefTest(this.props.propertyTemplate)}`)
-    console.log()
-    return(<React.Fragment>
+    return(<React.Fragment key={shortid.generate()}>
       <div className="row">
         <section className="col-sm-8">
         {this.props.propertyTemplate.propertyLabel}


### PR DESCRIPTION
As documented in issue #388, in the current master branch, for embedded resource templates in a `PropertyPanel` is not rendering the Resource Template, like **Has Bibframe Instance** below:
![Screen Shot 2019-03-15 at 10 16 00 AM](https://user-images.githubusercontent.com/71847/54445907-64087900-470b-11e9-9856-8cbea3f92fa1.png)

This PR adds that rendering support:
![Screen Shot 2019-03-15 at 3 43 03 PM](https://user-images.githubusercontent.com/71847/54463560-20c4ff00-4739-11e9-84fd-e0d211b63c66.png)


Remaining TODOs:
- [x] Add support for `InputLookupQA`
- [x] Deduplicate `this.state.output`
- [x] CSS and/or HTML changes to reduce left margin.
- [x] Unit tests for this expansion