### PR TITLE
Adds Stanford, Cornell, and UCSD ShareVDE authority sources

### DIFF
--- a/static/spoofedFilesFromServer/fromSinopiaServer/lookupConfig.json
+++ b/static/spoofedFilesFromServer/fromSinopiaServer/lookupConfig.json
@@ -728,6 +728,54 @@
     "component": "lookup"
   },
   {
+    "label": "SHAREVDE CORNELL INSTANCE",
+    "uri": "urn:ld4p:qa:sharevde_cornell_instance_ld4l_cache",
+    "authority": "sharevde_cornell_instance_ld4l_cache",
+    "subauthority": "",
+    "language": "en",
+    "component": "lookup"
+  },
+  {
+    "label": "SHAREVDE CORNELL WORK",
+    "uri": "urn:ld4p:qa:sharevde_cornell_work_ld4l_cache",
+    "authority": "sharevde_cornell_work_ld4l_cache",
+    "subauthority": "",
+    "language": "en",
+    "component": "lookup"
+  },
+  {
+    "label": "SHAREVDE STANFORD INSTANCE",
+    "uri": "urn:ld4p:qa:sharevde_stanford_instance_ld4l_cache",
+    "authority": "sharevde_stanford_instance_ld4l_cache",
+    "subauthority": "",
+    "language": "en",
+    "component": "lookup"
+  },
+  {
+    "label": "SHAREVDE STANFORD WORK",
+    "uri": "urn:ld4p:qa:sharevde_stanford_work_ld4l_cache",
+    "authority": "sharevde_stanford_work_ld4l_cache",
+    "subauthority": "",
+    "language": "en",
+    "component": "lookup"
+  },
+  {
+    "label": "SHAREVDE UCSD INSTANCE",
+    "uri": "urn:ld4p:qa:sharevde_ucsd_instance_ld4l_cache",
+    "authority": "sharevde_ucsd_instance_ld4l_cache",
+    "subauthority": "",
+    "language": "en",
+    "component": "lookup"
+  },
+  {
+    "label": "SHAREVDE UCSD WORK",
+    "uri": "urn:ld4p:qa:sharevde_ucsd_work_ld4l_cache",
+    "authority": "sharevde_ucsd_work_ld4l_cache",
+    "subauthority": "",
+    "language": "en",
+    "component": "lookup"
+  },
+  {
     "label": "MARC relator terms",
     "uri": "https://id.loc.gov/vocabulary/relators",
     "component": "list"


### PR DESCRIPTION
Adds QA authority lookup sources for Stanford, Cornell, and UCSD Works and Instances. **NOTE** currently QA is returning an URI instead of a text literal in the label field. This will be fixed soon.