### PR TITLE
Working selector and defaults for InputLiteral using common reducers

### DIFF
--- a/__tests__/components/editor/InputLiteral.test.js
+++ b/__tests__/components/editor/InputLiteral.test.js
@@ -1,5 +1,5 @@
 // Copyright 2018, 2019 Stanford University see Apache2.txt for license
-
+import 'jsdom-global/register'
 import React from 'react'
 import { shallow } from 'enzyme'
 import { InputLiteral } from '../../../src/components/editor/InputLiteral'
@@ -176,16 +176,33 @@ describe('when there is a default literal value in the property template', () =>
   const mockRemoveItem = jest.fn()
 
   it('sets the default values according to the property template if they exist', () => {
-    plProps.propertyTemplate['valueConstraint'] = valConstraintProps
-
-    const wrapper = shallow(<InputLiteral {...plProps} id={12}
+    const plProps =  {
+      "propertyTemplate":
+        {
+          "propertyLabel": "Instance of",
+          "propertyURI": "http://id.loc.gov/ontologies/bibframe/instanceOf",
+          "type": "literal",
+          "mandatory": "",
+          "repeatable": "",
+          "valueConstraint": valConstraintProps
+        }
+    }
+    const wrapper = shallow(<InputLiteral propertyTemplate={plProps.propertyTemplate} id={12}
                           blankNodeForLiteral={{ termType: 'BlankNode', value: 'n3-0'}}
                           handleMyItemsChange={mockMyItemsChange}
-                          rtId={'resourceTemplate:bf2:Monograph:Instance'}
-    />)
-    wrapper.setProps({ formData: { items: valConstraintProps.defaults } })
+                          rtId={'resourceTemplate:bf2:Monograph:Instance'} />)
+    // Mocking a call to the Redux store
+    const items = [{
+      "uri": "http://id.loc.gov/vocabulary/organizations/dlc",
+      "content": "DLC"
+    }]
+    wrapper.setProps({
+      formData: {
+        items: items
+      }
+    })
     wrapper.instance().forceUpdate()
-    expect(wrapper.find('#userInput')).toBeTruthy()
+    expect(wrapper.find('#userInput').text()).toMatch(items[0].content)
   })
 
   describe('when repeatable="false"', () => {

--- a/__tests__/components/editor/InputLiteral.test.js
+++ b/__tests__/components/editor/InputLiteral.test.js
@@ -172,27 +172,20 @@ describe('When the user enters input into field', ()=>{
 })
 
 describe('when there is a default literal value in the property template', () => {
+  const mockMyItemsChange = jest.fn()
+  const mockRemoveItem = jest.fn()
+
   it('sets the default values according to the property template if they exist', () => {
     plProps.propertyTemplate['valueConstraint'] = valConstraintProps
 
-    const setDefaultsForLiteralWithPayLoad = jest.fn()
-    const defaultsForLiteral = jest.fn()
-    defaultsForLiteral.mockReturnValue({
-      content: "content",
-      id: 0,
-      bnode: { termType: 'BlankNode', value: 'n3-0'},
-      propPredicate: "predicate"
-    })
-
     const wrapper = shallow(<InputLiteral {...plProps} id={12}
                           blankNodeForLiteral={{ termType: 'BlankNode', value: 'n3-0'}}
+                          handleMyItemsChange={mockMyItemsChange}
                           rtId={'resourceTemplate:bf2:Monograph:Instance'}
-                          setDefaultsForLiteralWithPayLoad={setDefaultsForLiteralWithPayLoad}
-                          defaultsForLiteral={defaultsForLiteral}
     />)
-    expect(setDefaultsForLiteralWithPayLoad).toHaveBeenCalledTimes(1)
-    expect(defaultsForLiteral).toHaveBeenCalledTimes(1)
-    expect(wrapper.instance().lastId).toEqual(0)
+    wrapper.setProps({ formData: { items: valConstraintProps.defaults } })
+    wrapper.instance().forceUpdate()
+    expect(wrapper.find('#userInput')).toBeTruthy()
   })
 
   describe('when repeatable="false"', () => {
@@ -206,9 +199,6 @@ describe('when there is a default literal value in the property template', () =>
         "repeatable": "false"
       }
     }
-
-    const mockMyItemsChange = jest.fn()
-    const mockRemoveItem = jest.fn()
 
     const nonrepeat_wrapper = shallow(
       <InputLiteral {...nrProps}

--- a/__tests__/reducers/literal.test.js
+++ b/__tests__/reducers/literal.test.js
@@ -1,88 +1,136 @@
-import { literal } from '../../src/reducers/literal'
+import { removeAllContent, removeMyItem, setMyItems  } from '../../src/reducers/literal'
 
 describe('literal reducer', () => {
-  it('should handle initial state', () => {
-    expect(
-      literal(undefined, {})
-    ).toEqual({formData: []})
-  })
 
   it('should handle SET_ITEMS', () => {
-    expect(
-      literal({formData: []}, {
-        type: 'SET_ITEMS',
-        payload: {id: 1, uri:'Run the tests', items: []}
-      })
-    ).toEqual({
-      "formData": [{
-        "id": 1, "uri": "Run the tests", "items": []
-      }]
+    const literalSetItems = setMyItems({ "resourceTemplate:Monograph:Instance": {
+      'http://schema.org/name': { items: [] }
+    }}, {
+      type: 'SET_ITEMS',
+      payload: {
+        rtId: 'resourceTemplate:Monograph:Instance',
+        uri:'http://schema.org/name',
+        items: [ { id: 0, content: 'Run the tests'} ]
+      }
+    })
+    expect(literalSetItems).toEqual({
+      "resourceTemplate:Monograph:Instance": {
+        'http://schema.org/name': {
+          items: [{ id: 0, content: 'Run the tests'}]
+        }
+      }
     })
 
     expect(
-      literal({
-        "formData": [{
-          "id": 1, "uri": "Run the tests", "items": []
-        }]}, {
+      setMyItems({ "resourceTemplate:Monograph:Instance": {
+        'http://schema.org/name': {
+          items: [{ id: 1, content: "Run the tests" }] },
+        'http://schema.org/description': {
+          items: []}
+        }
+      },
+      {
         type: 'SET_ITEMS',
-        payload: {id:2, uri: "add this!", items: []}
+        payload: {
+          rtId: "resourceTemplate:Monograph:Instance",
+          uri: 'http://schema.org/description',
+          items: [ { id: 2, content: "add this!"}]
+        }
       })
     ).toEqual({
-      "formData": [
-        {"id": 1, "uri": "Run the tests", "items": []},
-        {"id": 2, "uri": "add this!", "items": []}
-    ]})
+      "resourceTemplate:Monograph:Instance": {
+        'http://schema.org/name': {
+          items: [{ id: 1, content: 'Run the tests'}]
+        },
+        'http://schema.org/description': {
+          items: [{ id: 2, content: "add this!"}]
+        }
+      }
+    })
   })
   it('should handle REMOVE_ITEM', () => {
-    expect(
-      literal({formData: [{id: 1, uri:"Test", items:[
-        {content: "test content", id: 0},
-        {content: "more content", id: 1}
-        ]}]}, {
-        type: 'REMOVE_ITEM',
-        payload: {id: 0, label: "Test"}
-      })
-    ).toEqual({
-      "formData": [{
-        id: 1, uri: "Test", "items": [{content: "more content", id: 1}]
-      }]
+    expect(removeMyItem({
+      "resourceTemplate:Monograph:Instance": {
+       'http://schema.org/name': {
+         items: [
+           {content: "test content", id: 0},
+           {content: "more content", id: 1}
+         ]
+       }
+      }
+    },
+    {
+      type: 'REMOVE_ITEM',
+      payload: {
+        id: 0,
+        rtId: "resourceTemplate:Monograph:Instance",
+        uri: "http://schema.org/name",
+        content: "test content"
+      }
+    })).toEqual({
+      "resourceTemplate:Monograph:Instance": {
+        'http://schema.org/name': {
+          items: [{ id: 1, content: "more content" }]
+        }
+      }
     })
 
-
-    expect(
-      literal({formData: [
-        {id: 1, uri:"Test", items:[{content: "test content", id: 0}]},
-        {id: 2, uri:"Statement", items:[{content: "more test content", id: 0}]}
-      ]}, {
-        type: 'REMOVE_ITEM',
-        payload: {id: 0, label: "Statement"}
-      })
-    ).toEqual({
-      "formData": [
-        {"id": 1, "uri": "Test", "items": [{content: "test content", id: 0}]},
-        {"id": 2, "uri": "Statement", "items": []}
-      ]
+    expect(removeMyItem({
+      "resourceTemplate:Monograph:Instance": {
+       'http://schema.org/name': {
+         items: [
+           {content: "Test", id: 1},
+           {content: "Statement", id: 2}
+         ]
+       }
+      }
+    },
+    {
+      type: 'REMOVE_ITEM',
+      payload: {
+        id: 0,
+        rtId: "resourceTemplate:Monograph:Instance",
+        uri: "http://schema.org/name",
+        content: "test content"
+      }
     })
+  ).toEqual({
+    "resourceTemplate:Monograph:Instance": {
+     'http://schema.org/name': {
+       items: [
+         {content: "Test", id: 1},
+         {content: "Statement", id: 2}
+       ]
+     }
+    }
+   })
   })
 
   it('should handle REMOVE_ALL_CONTENT', () => {
     expect(
-      literal({
-        formData: [
-          {id: 1, uri:"Test", items:[
-            {content: "test content", id: 0},
-            {content: "test content2", id: 1}
-          ]},
-          {id: 2, uri:"Test2", items:[
-            {content: "test2 content", id: 0},
-            {content: "test2 content2", id: 1}
-          ]}
-        ]},
-        { type: 'REMOVE_ALL_CONTENT', payload: 1})
+      removeAllContent({
+        "resourceTemplate:Monograph:Instance": {
+          'http://schema.org/name': {
+            items: [
+              {content: "Test", id: 1},
+              {content: "Statement", id: 2}
+            ]
+          }
+        }
+      },
+      {
+        type: "REMOVE_ALL_CONTENT",
+        payload:{
+          rtId: "resourceTemplate:Monograph:Instance",
+          uri: 'http://schema.org/name'
+        }
+      })
     ).toEqual({
-      "formData": [
-        {"id": 2, "uri": "Test2", "items": [{content: "test2 content", id: 0}, {content: "test2 content2", id: 1}]}
-      ]
+      "resourceTemplate:Monograph:Instance": {
+        'http://schema.org/name': {
+          items: []
+        }
+      }
     })
   })
 })

--- a/__tests__/reducers/literal.test.js
+++ b/__tests__/reducers/literal.test.js
@@ -1,8 +1,8 @@
 import { removeAllContent, removeMyItem, setMyItems  } from '../../src/reducers/literal'
 
-describe('literal reducer', () => {
+describe('literal reducer functions', () => {
 
-  it('should handle SET_ITEMS', () => {
+  it('SET_ITEMS adds item to state', () => {
     const literalSetItems = setMyItems({ "resourceTemplate:Monograph:Instance": {
       'http://schema.org/name': { items: [] }
     }}, {
@@ -20,7 +20,9 @@ describe('literal reducer', () => {
         }
       }
     })
+  })
 
+  it('SET_ITEMS adds new item to state when state has existing selector for another literal', () => {
     expect(
       setMyItems({ "resourceTemplate:Monograph:Instance": {
         'http://schema.org/name': {
@@ -48,7 +50,8 @@ describe('literal reducer', () => {
       }
     })
   })
-  it('should handle REMOVE_ITEM', () => {
+
+  it('REMOVE_ITEM removes an item from state', () => {
     expect(removeMyItem({
       "resourceTemplate:Monograph:Instance": {
        'http://schema.org/name': {
@@ -74,7 +77,9 @@ describe('literal reducer', () => {
         }
       }
     })
+   })
 
+  it('Calling REMOVE_ITEMS with non-existent id does not change state', () => {
     expect(removeMyItem({
       "resourceTemplate:Monograph:Instance": {
        'http://schema.org/name': {
@@ -94,7 +99,7 @@ describe('literal reducer', () => {
         content: "test content"
       }
     })
-  ).toEqual({
+   ).toEqual({
     "resourceTemplate:Monograph:Instance": {
      'http://schema.org/name': {
        items: [

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -45,8 +45,6 @@ class App extends Component{
 
     const defaultRtId = 'resourceTemplate:bf2:Monograph:Instance'
 
-    // const defaultRtId = 'resourceTemplate:bf2:Identifiers:Barcode'
-
     return(
       <div id="app">
         <Switch>

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -45,6 +45,8 @@ class App extends Component{
 
     const defaultRtId = 'resourceTemplate:bf2:Monograph:Instance'
 
+    // const defaultRtId = 'resourceTemplate:bf2:Identifiers:Barcode'
+
     return(
       <div id="app">
         <Switch>

--- a/src/components/editor/InputLiteral.jsx
+++ b/src/components/editor/InputLiteral.jsx
@@ -146,9 +146,9 @@ export class InputLiteral extends Component {
 
   makeAddedList = () => {
     let formInfo = this.props.formData
-    // console.log(`makeAddedList ${this.props.propertyTemplate.propertyLabel}`)
-    // console.warn(formInfo)
-    if (formInfo == undefined || formInfo.items == undefined) return
+    if (formInfo == undefined || formInfo.items == undefined) {
+      return
+    }
     const elements = formInfo.items.map((obj, index) => {
       return <div id="userInput" key = {index} >
         {obj.content}

--- a/src/components/editor/InputLiteral.jsx
+++ b/src/components/editor/InputLiteral.jsx
@@ -15,12 +15,18 @@ export class InputLiteral extends Component {
 
   constructor(props) {
     super(props)
+    let lastId
+    try {
+      lastId =  Number(props.propertyTemplate.valueConstraint.defaults.length)-1
+    } catch (err) {
+      lastId = -1
+    }
     this.state = {
       show: false,
       content_add: "",
-      disabled: false
+      disabled: false,
+      lastId: lastId
     }
-    this.lastId = -1
   }
 
   handleShow = () => {
@@ -48,10 +54,12 @@ export class InputLiteral extends Component {
   }
 
   addUserInput = (userInputArray, currentcontent) => {
+    const newId = this.state.lastId + 1
     userInputArray.push({
       content: currentcontent,
-      id: ++this.lastId
+      id: newId
     })
+    this.setState( { lastId: newId } )
   }
 
   handleKeypress = (event) => {
@@ -84,6 +92,7 @@ export class InputLiteral extends Component {
   handleItemClick = (event) => {
     const labelToRemove = event.target.dataset["content"]
     const idToRemove = Number(event.target.dataset["item"])
+
     this.props.handleRemoveItem(
     {
       id: idToRemove,
@@ -91,7 +100,7 @@ export class InputLiteral extends Component {
       rtId: this.props.rtId,
       uri: this.props.propertyTemplate.propertyURI
     })
-    this.setState({disabled: false})
+    this.setState({ disabled: false })
   }
 
   checkMandatoryRepeatable = () => {
@@ -157,7 +166,7 @@ export class InputLiteral extends Component {
           type="button"
           onClick={this.handleItemClick}
           key={obj.id}
-          data-item={obj.id}
+          data-item={index}
           data-label={formInfo.uri}
         >X
         </button>

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -17,8 +17,8 @@ const resourceTemplateSelector = (state, props) => {
   if (props.propertyTemplate.propertyURI in resTemp) {
     items = resTemp[props.propertyTemplate.propertyURI]
   } else {
-    resTemp[props.propertyTemplate.propertyURI] = []
     items = []
+    resTemp[props.propertyTemplate.propertyURI] = items
   }
   return items
 }
@@ -44,6 +44,7 @@ export const setResourceTemplate = (state, action) => {
         // This items payload needs to vary if type is literal or lookup
         output[rtKey][property.propertyURI].items.push(
           {
+            id: output[rtKey][property.propertyURI].items.length,
             content: row.defaultLiteral,
             uri: row.defaultURI
           }

--- a/src/reducers/literal.js
+++ b/src/reducers/literal.js
@@ -1,80 +1,23 @@
-const formDataCollection = require('lodash/collection')
+// Copyright 2018, 2019 Stanford University see Apache2.txt for license
 
-const DEFAULT_STATE = {
-  formData: []
-}
-
-const removeAllContent = (state, action) => {
-  let newFormData = state.formData.slice(0)
-  const idToDelete = action.payload
-  let new_state = newFormData.filter(data => {
-    return data.id !== idToDelete
-  })
-  return {formData: new_state}
-}
-
-const deleteItem = (obj, itemToDelete) => {
-  const new_items = obj.items.filter(item => {
-    return item.id != itemToDelete.id
-  })
-  return new_items
-}
-
-export const removeMyItem = (state, action) => {
-  let newListItems = state.formData.slice(0)
-  const itemToDelete = action.payload
-  let new_state = newListItems.map(obj => {
-    if(obj.uri == itemToDelete.label){
-      const newItemArray = deleteItem(obj, itemToDelete)
-      return {id: obj.id, uri: obj.uri, items: newItemArray}
-    } else {
-      return obj
-    }
-  })
-  return {formData: new_state}
+export const removeAllContent = (state, action) => {
+  let newState = Object.assign({}, state)
+  newState[action.payload.rtId][action.payload.uri].items = []
+  return newState
 }
 
 export const setMyItems = (state, action) => {
-  let newFormData = state.formData.slice(0)
-
-  let exists
-  if (action.payload.items !== undefined && action.payload.items.length > 0) {
-    exists = formDataCollection.find(newFormData, {
-      id: action.payload.id,
-      rtId: action.payload.rtId,
-      items: [{
-        content: action.payload.items[0].content,
-        propPredicate: action.payload.items[0].propPredicate
-      }]
-    })
-  }
-
-  let needNewItemArray = true;
-  for (let field of newFormData) {
-    if (field.id == action.payload.id) {
-      if (exists === undefined) {
-        field.items = field.items.concat(action.payload.items)
-      }
-      needNewItemArray = false;
-      break;
-    }
-  }
-
-  if (needNewItemArray) {
-      newFormData.push(action.payload)
-  }
-  return {formData: newFormData}
+  let newState = Object.assign({}, state)
+  action.payload.items.map((row) => {
+    newState[action.payload.rtId][action.payload.uri].items.push(row)
+  })
+  return newState
 }
 
-export const literal = (state=DEFAULT_STATE, action) => {
-  switch(action.type) {
-    case 'SET_ITEMS':
-      return setMyItems(state,action)
-    case 'REMOVE_ITEM':
-      return removeMyItem(state,action)
-    case 'REMOVE_ALL_CONTENT':
-      return removeAllContent(state,action)
-    default:
-      return state
-  }
+export const removeMyItem = (state, action) => {
+  const newState = Object.assign({}, state)
+  const newItems = newState[action.payload.rtId][action.payload.uri].items.filter(
+    row => row.id != action.payload.id)
+  newState[action.payload.rtId][action.payload.uri].items = newItems
+  return newState
 }

--- a/static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/Barcode.json
+++ b/static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/Barcode.json
@@ -21,6 +21,19 @@
       },
       "propertyURI": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value",
       "propertyLabel": "Barcode"
+    },
+    {
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "resourceTemplates": [],
+      "valueConstraint": {
+        "valueTemplateRefs": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "propertyURI": "http://id.loc.gov/ontologies/bibframe/enumerationAndChronology",
+      "propertyLabel": "Enumeration and chronology"
     }
   ]
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,6 +24,9 @@ module.exports = {
       }
     ]
   },
+  node: {
+   fs: "empty"
+ },
   resolve: {
     extensions: ['*', '.js', '.jsx']
   },


### PR DESCRIPTION
On the way to finishing ticket #412, this PR uses Redux to set defaults based on Resource Template ID and URI of property using more generic reducers and a single `getProperty` selector to map the redux state to the InputLiteral's props. 

Fixes #390
Fixes #391
Fixes #428 