### PR TITLE
List of resource templates retrieved from sinopia_server

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,6 +4,7 @@
     "@babel/preset-react"
   ],
   "plugins": [
-    "@babel/plugin-proposal-class-properties"
+    "@babel/plugin-proposal-class-properties",
+    "@babel/plugin-transform-runtime"
   ]
 }

--- a/__tests__/components/editor/ImportResourceTemplate.test.js
+++ b/__tests__/components/editor/ImportResourceTemplate.test.js
@@ -4,6 +4,7 @@ import React from 'react'
 import { shallow } from 'enzyme'
 import ImportResourceTemplate from '../../../src/components/editor/ImportResourceTemplate'
 import ImportFileZone from '../../../src/components/editor/ImportFileZone'
+import SinopiaResourceTemplates from '../../../src/components/editor/SinopiaResourceTemplates'
 
 describe('<ImportResourceTemplate />', () => {
   const wrapper = shallow(<ImportResourceTemplate />)
@@ -14,6 +15,10 @@ describe('<ImportResourceTemplate />', () => {
 
   it('contains the place to import a file', () => {
     expect(wrapper.find(ImportFileZone).length).toBe(1)
+  })
+
+  it('contains a place to display the resource templates stored on the server', () => {
+    expect(wrapper.find(SinopiaResourceTemplates).length).toBe(1)
   })
 
 })

--- a/__tests__/components/editor/SinopiaResourceTemplates.test.js
+++ b/__tests__/components/editor/SinopiaResourceTemplates.test.js
@@ -21,35 +21,43 @@ describe('<SinopiaResourceTemplates />', () => {
     expect(wrapper.find(BootstrapTable).dive().length).toEqual(1)
   })
 
-  describe('gettiong data from the sinopia_server', () => {
+  describe('getting data from the sinopia_server', () => {
 
-    it('sets the state with group data (as Array) from sinopia_server', async() => {
+    const mockResponse = (status, statusText, response) => {
+      return new Response(response, {
+        status: status,
+        statusText: statusText,
+        headers: {
+          'Content-type': 'application/json'
+        }
+      }).body
+    }
 
-      const mockResponse = (status, statusText, response) => {
-        return new Response(response, {
-          status: status,
-          statusText: statusText,
-          headers: {
-            'Content-type': 'application/json'
-          }
-        }).body
-      }
-
-      const bodyContains = {
-        response: {
-          body: {
-            contains: [
-              'ld4p', 'pcc'
-            ]
-          }
+    const bodyContains = {
+      response: {
+        body: {
+          contains: [
+            'ld4p', 'pcc'
+          ]
         }
       }
+    }
+
+    it('sets the state with group data (as Array) from sinopia_server', async() => {
 
       const promise = Promise.resolve(mockResponse(200, null, bodyContains))
       const wrapper2 = shallow(<SinopiaResourceTemplates />)
       await wrapper2.instance().fulfillGroupPromise(promise)
       wrapper2.update()
       expect(wrapper2.state('groupData')).toEqual(['ld4p', 'pcc'])
+    })
+
+    it('sets a message if there is no server response', async() => {
+      const promise = Promise.resolve(mockResponse(200, null, undefined))
+      const wrapper2 = shallow(<SinopiaResourceTemplates />)
+      await wrapper2.instance().fulfillGroupPromise(promise)
+      await wrapper2.update()
+      expect(wrapper2.state('message')).toBeTruthy()
     })
 
     it('sets the state with a list of resource templates from the server', async() => {

--- a/__tests__/components/editor/SinopiaResourceTemplates.test.js
+++ b/__tests__/components/editor/SinopiaResourceTemplates.test.js
@@ -47,6 +47,7 @@ describe('<SinopiaResourceTemplates />', () => {
       const promise = Promise.resolve(mockResponse(200, null, bodyContains))
       const wrapper2 = shallow(<SinopiaResourceTemplates />)
       await wrapper2.instance().fulfillGroupPromise(promise)
+      wrapper2.update()
       expect(wrapper2.state('groupData')).toEqual(['ld4p'])
     })
 
@@ -69,6 +70,7 @@ describe('<SinopiaResourceTemplates />', () => {
       //TODO: figure out how to mock and test a nested promise...
       const spy = jest.spyOn(wrapper3.instance(), 'fulfillGroupDataPromise')
       await wrapper3.instance().fulfillGroupDataPromise(promise)
+      wrapper3.update()
       expect(spy).toHaveBeenCalled()
     })
 

--- a/__tests__/components/editor/SinopiaResourceTemplates.test.js
+++ b/__tests__/components/editor/SinopiaResourceTemplates.test.js
@@ -18,7 +18,7 @@ describe('<SinopiaResourceTemplates />', () => {
   })
 
   it('has a bootstrap table that displays the results from the calls to sinopia_server', () => {
-    expect(wrapper.find(BootstrapTable).dive().length).toEqual(1)
+    expect(wrapper.find('BootstrapTable').length).toEqual(1)
   })
 
   describe('getting data from the sinopia_server', () => {
@@ -83,6 +83,50 @@ describe('<SinopiaResourceTemplates />', () => {
       expect(spy).toHaveBeenCalled()
     })
 
+  })
+
+  describe('linking back to the Editor component', () => {
+
+    const cell = 'Note'
+    const row = {
+      name: "Note",
+      uri: "http://localhost:8080/repository/ld4p/Note",
+      id: "ld4p:resourceTemplate:bf2:Note",
+      group: "ld4p",
+      data: {
+        "id": "resourceTemplate:bf2:Title:Note",
+        "resourceURI": "http://id.loc.gov/ontologies/bibframe/Note",
+        "resourceLabel": "Title note",
+        "propertyTemplates": [
+          {
+            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+            "propertyLabel": "Note Text",
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "literal",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [],
+              "useValuesFrom": [],
+              "valueDataType": {},
+              "defaults": []
+            }
+          }
+        ]
+      }
+    }
+
+    const wrapper4 = shallow(<SinopiaResourceTemplates />)
+
+    it('has the header columns for the table of linked resource templates', async () => {
+      await expect(wrapper4.find('BootstrapTable').find('TableHeaderColumn').length).toEqual(3)
+    })
+
+    it('renders a link to the Editor with a payload of data', async () => {
+      const link = await wrapper4.instance().linkFormatter(cell, row)
+      await expect(link.props.to.pathname).toEqual('/editor')
+      await expect(link.props.to.state.resourceTemplateData).toEqual(row.data)
+    })
   })
 
 })

--- a/__tests__/components/editor/SinopiaResourceTemplates.test.js
+++ b/__tests__/components/editor/SinopiaResourceTemplates.test.js
@@ -1,0 +1,68 @@
+import 'jsdom-global/register'
+import React from 'react'
+import { shallow } from 'enzyme'
+import SinopiaResourceTemplates from '../../../src/components/editor/SinopiaResourceTemplates'
+import BootstrapTable from 'react-bootstrap-table-next'
+
+describe('<SinopiaResourceTemplates />', () => {
+
+  const wrapper = shallow(<SinopiaResourceTemplates />)
+
+  it('has a header for the area where the list of groups in sinopia_Server are displayed', () => {
+    expect(wrapper.find('div > h4').first().text()).toEqual('Groups in Sinopia')
+  })
+
+  it('has a header for the area where the table of resource templates for the groups are displayed', () => {
+    expect(wrapper.find('div > h4').last().text()).toEqual('Available Resource Templates in Sinopia')
+  })
+
+  it('has a bootstrap table that displays the results from the calls to sinopia_server', () => {
+    expect(wrapper.find(BootstrapTable).dive().length).toEqual(1)
+  })
+
+  describe('gettiong data from the sinopia_server', () => {
+
+    it('sets the state with group data from sinopia_server', () => {
+      const bodyContains = {
+        response: {
+          body: {
+            contains: [
+              "http://localhost:8080/repository/ld4p/Note",
+              "http://localhost:8080/repository/ld4p/Barcode",
+              "http://localhost:8080/repository/ld4p/Title",
+              "http://localhost:8080/repository/ld4p/Item"
+            ]
+          }
+        }
+      }
+
+      jest.fn(() => new Promise(resolve => resolve(JSON.stringify(bodyContains))))
+      const wrapper2 = shallow(<SinopiaResourceTemplates />)
+
+      wrapper2.instance().fulfillGroupPromise()
+      wrapper2.update()
+      wrapper2.setState({groupData: bodyContains.response.body.contains})
+      console.warn(wrapper2.state())
+      expect(wrapper2.state('groupData').length).toEqual(4)
+    })
+
+    it('sets the state with a list of resource templates from the server', () => {
+      const joined = [
+        {name: 'Note', uri: "http://localhost:8080/repository/ld4p/Note", id: 'resourceTemplate:bf2:Note', group: 'ld4p'},
+        {name: 'Barcode', uri: "http://localhost:8080/repository/ld4p/Barcode", id: 'resourceTemplate:bf2:Barcode', group: 'ld4p'},
+        {name: 'Title', uri: "http://localhost:8080/repository/ld4p/Title", id: 'resourceTemplate:bf2:Title', group: 'ld4p'},
+        {name: 'Item', uri: "http://localhost:8080/repository/ld4p/Item", id: 'resourceTemplate:bf2:Item', group: 'ld4p'}
+      ]
+      jest.fn(() => new Promise(resolve => resolve(JSON.stringify(joined))))
+      const wrapper3 = shallow(<SinopiaResourceTemplates />)
+      wrapper3.instance().fulfillGroupDataPromise()
+      wrapper3.update()
+
+      wrapper3.setState({templatesForGroup: joined})
+      console.warn(wrapper3.state())
+      expect(wrapper3.state('templatesForGroup').length).toEqual(4)
+    })
+
+  })
+
+})

--- a/__tests__/components/editor/SinopiaResourceTemplates.test.js
+++ b/__tests__/components/editor/SinopiaResourceTemplates.test.js
@@ -38,7 +38,7 @@ describe('<SinopiaResourceTemplates />', () => {
         response: {
           body: {
             contains: [
-              'ld4p'
+              'ld4p', 'pcc'
             ]
           }
         }
@@ -48,13 +48,14 @@ describe('<SinopiaResourceTemplates />', () => {
       const wrapper2 = shallow(<SinopiaResourceTemplates />)
       await wrapper2.instance().fulfillGroupPromise(promise)
       wrapper2.update()
-      expect(wrapper2.state('groupData')).toEqual(['ld4p'])
+      expect(wrapper2.state('groupData')).toEqual(['ld4p', 'pcc'])
     })
 
     it('sets the state with a list of resource templates from the server', async() => {
       const bodyContains = {
         response: {
           body: {
+            "@id": 'ld4p',
             contains: [
               "http://localhost:8080/repository/ld4p/Note",
               "http://localhost:8080/repository/ld4p/Barcode",
@@ -67,9 +68,9 @@ describe('<SinopiaResourceTemplates />', () => {
 
       const promise = Promise.resolve(mockResponse(200, null, bodyContains))
       const wrapper3 = shallow(<SinopiaResourceTemplates />)
-      //TODO: figure out how to mock and test a nested promise...
-      const spy = jest.spyOn(wrapper3.instance(), 'fulfillGroupDataPromise')
-      await wrapper3.instance().fulfillGroupDataPromise(promise)
+      // //TODO: figure out how to mock and test a nested promise...
+      const spy = jest.spyOn(wrapper3.instance(), 'fulfillGroupData')
+      await wrapper3.instance().fulfillGroupData(bodyContains)
       wrapper3.update()
       expect(spy).toHaveBeenCalled()
     })

--- a/__tests__/components/editor/SinopiaResourceTemplates.test.js
+++ b/__tests__/components/editor/SinopiaResourceTemplates.test.js
@@ -2,7 +2,7 @@ import 'jsdom-global/register'
 import React from 'react'
 import { shallow } from 'enzyme'
 import SinopiaResourceTemplates from '../../../src/components/editor/SinopiaResourceTemplates'
-import BootstrapTable from 'react-bootstrap-table-next'
+import BootstrapTable from 'react-bootstrap-table'
 import 'isomorphic-fetch'
 
 describe('<SinopiaResourceTemplates />', () => {

--- a/__tests__/components/editor/SinopiaResourceTemplates.test.js
+++ b/__tests__/components/editor/SinopiaResourceTemplates.test.js
@@ -23,17 +23,18 @@ describe('<SinopiaResourceTemplates />', () => {
 
   describe('gettiong data from the sinopia_server', () => {
 
-    const mockResponse = (status, statusText, response) => {
-      return new Response(response, {
-        status: status,
-        statusText: statusText,
-        headers: {
-          'Content-type': 'application/json'
-        }
-      }).body
-    }
-
     it('sets the state with group data (as Array) from sinopia_server', async() => {
+
+      const mockResponse = (status, statusText, response) => {
+        return new Response(response, {
+          status: status,
+          statusText: statusText,
+          headers: {
+            'Content-type': 'application/json'
+          }
+        }).body
+      }
+
       const bodyContains = {
         response: {
           body: {
@@ -66,9 +67,8 @@ describe('<SinopiaResourceTemplates />', () => {
         }
       }
 
-      const promise = Promise.resolve(mockResponse(200, null, bodyContains))
       const wrapper3 = shallow(<SinopiaResourceTemplates />)
-      // //TODO: figure out how to mock and test a nested promise...
+      //TODO: figure out how to mock and test a nested promise...
       const spy = jest.spyOn(wrapper3.instance(), 'fulfillGroupData')
       await wrapper3.instance().fulfillGroupData(bodyContains)
       wrapper3.update()

--- a/package-lock.json
+++ b/package-lock.json
@@ -11372,6 +11372,27 @@
         "warning": "^3.0.0"
       }
     },
+    "react-bootstrap-table-next": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/react-bootstrap-table-next/-/react-bootstrap-table-next-3.0.2.tgz",
+      "integrity": "sha512-0/Uhs0bjrmPNa3NxDrOlfez90dnJXPN6i7wHKW1YUoPMXiFFoWM60SJLvWXPOHwTc5UBk6PiYi1XLITs/iEk/w==",
+      "requires": {
+        "classnames": "2.2.5",
+        "underscore": "1.9.1"
+      },
+      "dependencies": {
+        "classnames": {
+          "version": "2.2.5",
+          "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.5.tgz",
+          "integrity": "sha1-+zgB1FNGdknvNgPH1hoCvRKb3m0="
+        },
+        "underscore": {
+          "version": "1.9.1",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
+          "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
+        }
+      }
+    },
     "react-bootstrap-typeahead": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/react-bootstrap-typeahead/-/react-bootstrap-typeahead-3.2.4.tgz",
@@ -12907,9 +12928,9 @@
       "dev": true
     },
     "sinopia_server": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/sinopia_server/-/sinopia_server-2.0.0.tgz",
-      "integrity": "sha512-PG9vQ/H2WXOKX+/DgqlrC9mfguC0b/84L6TQMYi3Hu1IOoL9/e1uzxOfSVs6DFFeL2S/EfH4IAOsYU0IB/vAgQ==",
+      "version": "3.0.0-beta2",
+      "resolved": "https://registry.npmjs.org/sinopia_server/-/sinopia_server-3.0.0-beta2.tgz",
+      "integrity": "sha512-ms4mrjTk5DrI4XCn+4TwubQZlOUiVhV/emfpIC0IhRAfIL9v4yE5g5gCaixjTyba+EF/SpOubVL50SwrckYk0A==",
       "requires": {
         "elasticsearch": "^15.3.1",
         "superagent": "^4.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -845,6 +845,35 @@
         "regenerator-transform": "^0.13.3"
       }
     },
+    "@babel/plugin-transform-runtime": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.4.0.tgz",
+      "integrity": "sha512-1uv2h9wnRj98XX3g0l4q+O3jFM6HfayKup7aIu4pnnlzGz0H+cYckGBC74FZIWJXJSXAmeJ9Yu5Gg2RQpS4hWg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "resolve": "^1.8.1",
+        "semver": "^5.5.1"
+      },
+      "dependencies": {
+        "resolve": {
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
+          "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        },
+        "semver": {
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+          "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+          "dev": true
+        }
+      }
+    },
     "@babel/plugin-transform-shorthand-properties": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.0.0.tgz",
@@ -966,17 +995,17 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.2.0.tgz",
-      "integrity": "sha512-oouEibCbHMVdZSDlJBO6bZmID/zA/G/Qx3H1d3rSNPTD+L8UNKvCat7aKWSJ74zYbm5zWGh0GQN0hKj8zYFTCg==",
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.2.tgz",
+      "integrity": "sha512-7Bl2rALb7HpvXFL7TETNzKSAeBVCPHELzc0C//9FCxN8nsiueWSJBqaF+2oIJScyILStASR/Cx5WMkXGYTiJFA==",
       "requires": {
-        "regenerator-runtime": "^0.12.0"
+        "regenerator-runtime": "^0.13.2"
       },
       "dependencies": {
         "regenerator-runtime": {
-          "version": "0.12.1",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
-          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
+          "version": "0.13.2",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+          "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -5422,6 +5422,11 @@
         }
       }
     },
+    "exenv": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
+      "integrity": "sha1-KueOhdmJQVhnCwPUe+wfA72Ru50="
+    },
     "exit": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
@@ -11401,25 +11406,15 @@
         "warning": "^3.0.0"
       }
     },
-    "react-bootstrap-table-next": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/react-bootstrap-table-next/-/react-bootstrap-table-next-3.0.2.tgz",
-      "integrity": "sha512-0/Uhs0bjrmPNa3NxDrOlfez90dnJXPN6i7wHKW1YUoPMXiFFoWM60SJLvWXPOHwTc5UBk6PiYi1XLITs/iEk/w==",
+    "react-bootstrap-table": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/react-bootstrap-table/-/react-bootstrap-table-4.3.1.tgz",
+      "integrity": "sha1-9wS+Vbf2vwVX0vxb7G0l/TB9DN4=",
       "requires": {
-        "classnames": "2.2.5",
-        "underscore": "1.9.1"
-      },
-      "dependencies": {
-        "classnames": {
-          "version": "2.2.5",
-          "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.5.tgz",
-          "integrity": "sha1-+zgB1FNGdknvNgPH1hoCvRKb3m0="
-        },
-        "underscore": {
-          "version": "1.9.1",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
-          "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
-        }
+        "classnames": "^2.1.2",
+        "prop-types": "^15.5.10",
+        "react-modal": "^3.1.7",
+        "react-s-alert": "^1.3.2"
       }
     },
     "react-bootstrap-typeahead": {
@@ -11500,6 +11495,17 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
+    "react-modal": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.8.1.tgz",
+      "integrity": "sha512-aLKeZM9pgXpIKVwopRHMuvqKWiBajkqisDA8UzocdCF6S4fyKVfLWmZR5G1Q0ODBxxxxf2XIwiCP8G/11GJAuw==",
+      "requires": {
+        "exenv": "^1.2.0",
+        "prop-types": "^15.5.10",
+        "react-lifecycles-compat": "^3.0.0",
+        "warning": "^3.0.0"
+      }
     },
     "react-offcanvas": {
       "version": "0.3.1",
@@ -11646,6 +11652,14 @@
             "loose-envify": "^1.0.0"
           }
         }
+      }
+    },
+    "react-s-alert": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/react-s-alert/-/react-s-alert-1.4.1.tgz",
+      "integrity": "sha512-+cSpVPe6YeGklhlo7zbVlB0Z6jdiU9HPmEVzp5nIhNm9lvdL7rVO2Jx09pCwT99GmODyoN0iNhbQku6r7six8A==",
+      "requires": {
+        "babel-runtime": "^6.23.0"
       }
     },
     "react-test-renderer": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1391,6 +1391,14 @@
         "es6-promisify": "^5.0.0"
       }
     },
+    "agentkeepalive": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-3.5.2.tgz",
+      "integrity": "sha512-e0L/HNe6qkQ7H19kTlRRqUibEAwDK5AFk6y3PtMsuut2VAH6+Q4xZml1tNDJD7kSAyqmbG/K08K5WEJYtUrSlQ==",
+      "requires": {
+        "humanize-ms": "^1.2.1"
+      }
+    },
     "ajv": {
       "version": "6.6.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.2.tgz",
@@ -1446,8 +1454,7 @@
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "dev": true
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -1981,8 +1988,7 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "atob": {
       "version": "2.1.2",
@@ -3313,8 +3319,7 @@
     "component-emitter": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
-      "dev": true
+      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
     },
     "compressible": {
       "version": "2.0.15",
@@ -3412,6 +3417,11 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+    },
+    "cookiejar": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
+      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA=="
     },
     "copy-concurrently": {
       "version": "1.0.5",
@@ -4174,6 +4184,40 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+    },
+    "elasticsearch": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/elasticsearch/-/elasticsearch-15.4.1.tgz",
+      "integrity": "sha512-IL46Sv9krCKtpvlI37/vQVQrWx6QeT1OJhfWW6L3fIXzR1Vv5utO+DHYz8AosUI6vlkxShoq+y6sUIBhTF1OIg==",
+      "requires": {
+        "agentkeepalive": "^3.4.1",
+        "chalk": "^1.0.0",
+        "lodash": "^4.17.10"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+        }
+      }
     },
     "electron-to-chromium": {
       "version": "1.3.84",
@@ -6153,6 +6197,11 @@
         }
       }
     },
+    "formidable": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.1.tgz",
+      "integrity": "sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg=="
+    },
     "forwarded": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
@@ -6244,8 +6293,7 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6269,15 +6317,13 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6294,22 +6340,19 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6440,8 +6483,7 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6455,7 +6497,6 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6472,7 +6513,6 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6481,15 +6521,13 @@
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
           "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -6510,7 +6548,6 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6599,8 +6636,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6614,7 +6650,6 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6710,8 +6745,7 @@
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
           "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6753,7 +6787,6 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6775,7 +6808,6 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6824,15 +6856,13 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
           "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -7142,7 +7172,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true,
       "requires": {
         "ansi-regex": "^2.0.0"
       }
@@ -7813,6 +7842,14 @@
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true
         }
+      }
+    },
+    "humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
+      "requires": {
+        "ms": "^2.0.0"
       }
     },
     "humps": {
@@ -12869,6 +12906,15 @@
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
     },
+    "sinopia_server": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/sinopia_server/-/sinopia_server-2.0.0.tgz",
+      "integrity": "sha512-PG9vQ/H2WXOKX+/DgqlrC9mfguC0b/84L6TQMYi3Hu1IOoL9/e1uzxOfSVs6DFFeL2S/EfH4IAOsYU0IB/vAgQ==",
+      "requires": {
+        "elasticsearch": "^15.3.1",
+        "superagent": "^4.1.0"
+      }
+    },
     "sisteransi": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-0.1.1.tgz",
@@ -13437,7 +13483,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }
@@ -13446,7 +13491,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true,
       "requires": {
         "ansi-regex": "^2.0.0"
       }
@@ -13491,6 +13535,67 @@
             "ajv": "^6.1.0",
             "ajv-errors": "^1.0.0",
             "ajv-keywords": "^3.1.0"
+          }
+        }
+      }
+    },
+    "superagent": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-4.1.0.tgz",
+      "integrity": "sha512-FT3QLMasz0YyCd4uIi5HNe+3t/onxMyEho7C3PSqmti3Twgy2rXT4fmkTz6wRL6bTF4uzPcfkUCa8u4JWHw8Ag==",
+      "requires": {
+        "component-emitter": "^1.2.0",
+        "cookiejar": "^2.1.2",
+        "debug": "^4.1.0",
+        "form-data": "^2.3.3",
+        "formidable": "^1.2.0",
+        "methods": "^1.1.1",
+        "mime": "^2.4.0",
+        "qs": "^6.6.0",
+        "readable-stream": "^3.0.6"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "form-data": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+          "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "mime": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.0.tgz",
+          "integrity": "sha512-ikBcWwyqXQSHKtciCcctu9YfPbFYZ4+gbHEmE0Q8jzcTYQg5dHCr3g2wwAZjPoJfQVXZq6KXAjpXOTf5/cjT7w=="
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        },
+        "qs": {
+          "version": "6.6.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.6.0.tgz",
+          "integrity": "sha512-KIJqT9jQJDQx5h5uAVPimw6yVg2SekOKu959OCtktD3FjzbpvaPr8i4zzg07DOMz+igA4W/aNM7OV8H37pFYfA=="
+        },
+        "readable-stream": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.2.0.tgz",
+          "integrity": "sha512-RV20kLjdmpZuTF1INEb9IA3L68Nmi+Ri7ppZqo78wj//Pn62fCoJyV9zalccNzDD/OuJpMG4f+pfMl8+L6QdGw==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
           }
         }
       }
@@ -14262,8 +14367,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "util.promisify": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "query-string": "^6.2.0",
     "react": "^16.6.3",
     "react-bootstrap": "^0.32.4",
-    "react-bootstrap-table-next": "^3.0.2",
+    "react-bootstrap-table": "^4.3.1",
     "react-bootstrap-typeahead": "^3.2.4",
     "react-dom": "^16.6.3",
     "react-dropzone": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "query-string": "^6.2.0",
     "react": "^16.6.3",
     "react-bootstrap": "^0.32.4",
+    "react-bootstrap-table-next": "^3.0.2",
     "react-bootstrap-typeahead": "^3.2.4",
     "react-dom": "^16.6.3",
     "react-dropzone": "^7.0.1",
@@ -107,7 +108,7 @@
     "redux": "^4.0.1",
     "reselect": "^4.0.0",
     "shortid": "^2.2.14",
-    "sinopia_server": "^2.0.0",
+    "sinopia_server": "^3.0.0-beta2",
     "swagger-client": "^3.8.22",
     "x2js": "^3.2.3"
   },

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "@babel/core": "^7.1.6",
     "@babel/plugin-proposal-class-properties": "^7.1.0",
+    "@babel/plugin-transform-runtime": "^7.4.0",
     "@babel/preset-env": "^7.1.6",
     "@babel/preset-react": "^7.0.0",
     "babel-eslint": "^10.0.1",
@@ -83,6 +84,7 @@
   },
   "license": "ISC",
   "dependencies": {
+    "@babel/runtime": "^7.4.2",
     "@fortawesome/fontawesome-svg-core": "^1.2.8",
     "@fortawesome/free-solid-svg-icons": "^5.5.0",
     "@fortawesome/react-fontawesome": "^0.1.3",

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "redux": "^4.0.1",
     "reselect": "^4.0.0",
     "shortid": "^2.2.14",
+    "sinopia_server": "^2.0.0",
     "swagger-client": "^3.8.22",
     "x2js": "^3.2.3"
   },

--- a/src/components/editor/ImportResourceTemplate.jsx
+++ b/src/components/editor/ImportResourceTemplate.jsx
@@ -5,6 +5,7 @@ import { Redirect } from 'react-router-dom'
 import PropTypes from 'prop-types'
 import Header from './Header'
 import ImportFileZone from './ImportFileZone'
+import SinopiaResourceTemplates from './SinopiaResourceTemplates'
 
 class ImportResourceTemplate extends Component {
   constructor(props) {
@@ -31,6 +32,7 @@ class ImportResourceTemplate extends Component {
         <div id="importResourceTemplate">
           <Header triggerEditorMenu={this.props.triggerHandleOffsetMenu}/>
           <ImportFileZone setResourceTemplateCallback={this.setResourceTemplates} />
+          <SinopiaResourceTemplates/>
         </div>
       )
     } else {

--- a/src/components/editor/ImportResourceTemplate.jsx
+++ b/src/components/editor/ImportResourceTemplate.jsx
@@ -32,7 +32,7 @@ class ImportResourceTemplate extends Component {
         <div id="importResourceTemplate">
           <Header triggerEditorMenu={this.props.triggerHandleOffsetMenu}/>
           <ImportFileZone setResourceTemplateCallback={this.setResourceTemplates} />
-          <SinopiaResourceTemplates/>
+          <SinopiaResourceTemplates />
         </div>
       )
     } else {

--- a/src/components/editor/SinopiaResourceTemplates.jsx
+++ b/src/components/editor/SinopiaResourceTemplates.jsx
@@ -6,14 +6,6 @@ const SinopiaServer = require('sinopia_server')
 const instance = new SinopiaServer.LDPApi()
 instance.apiClient.basePath = 'http://localhost:8080'
 
-const groupPromise = new Promise((resolve) => {
-  resolve(instance.getBaseWithHttpInfo())
-})
-
-const ld4pGroupDataPromise = new Promise((resolve) => {
-  resolve(instance.getGroupWithHttpInfo('ld4p'))
-})
-
 class SinopiaResourceTemplates extends Component {
   constructor(props) {
     super(props)
@@ -24,9 +16,20 @@ class SinopiaResourceTemplates extends Component {
     }
   }
 
-  componentDidMount() {
-    this.fulfillGroupPromise(groupPromise)
-    this.fulfillGroupDataPromise(ld4pGroupDataPromise)
+  async componentDidMount() {
+    const groupPromise = new Promise((resolve) => {
+      resolve(instance.getBaseWithHttpInfo())
+    })
+
+    await this.fulfillGroupPromise(groupPromise).then(async () => {
+      const ld4pGroupDataPromise = new Promise((resolve) => {
+        this.state.groupData.map((group) => {
+          const name = this.resourceToName(group)
+          resolve(instance.getGroupWithHttpInfo(name))
+        })
+      })
+      await this.fulfillGroupDataPromise(ld4pGroupDataPromise)
+    })
   }
 
 

--- a/src/components/editor/SinopiaResourceTemplates.jsx
+++ b/src/components/editor/SinopiaResourceTemplates.jsx
@@ -10,9 +10,8 @@ class SinopiaResourceTemplates extends Component {
   constructor(props) {
     super(props)
     this.state = {
-      isLoading: false,
+      message: '',
       groupData: [],
-      joined: [],
       templatesForGroup: []
     }
   }

--- a/src/components/editor/SinopiaResourceTemplates.jsx
+++ b/src/components/editor/SinopiaResourceTemplates.jsx
@@ -1,7 +1,7 @@
 // Copyright 2019 Stanford University see Apache2.txt for license
 
 import React, {Component} from 'react'
-import PropTypes from 'prop-types'
+// import PropTypes from 'prop-types'
 const SinopiaServer = require('sinopia_server')
 const instance = new SinopiaServer.LDPApi()
 instance.apiClient.basePath = 'http://localhost:8080'
@@ -25,19 +25,20 @@ class SinopiaResourceTemplates extends Component {
 
   componentDidMount() {
     groupPromise.then((data) => {
-      if(typeof data.response.body.contains === 'Array') {
+      const contains = data.response.body.contains
+      if(typeof contains.constructor === Array) {
         this.setState({groupData: data.response.body.contains})
       } else {
         this.setState({groupData: [data.response.body.contains]})
       }
     }, function(error) {
-      console.error(error)
+      alert(error)
     })
 
     ld4pGroupDataPromise.then((data) => {
       this.setState({ld4pGroupData: data.response.body.contains})
     }, function(error) {
-      console.error(error)
+      alert(error)
     })
 
     // this.state.ld4pGroupData.map((resource, index) => {
@@ -92,8 +93,8 @@ class SinopiaResourceTemplates extends Component {
   }
 }
 
-SinopiaResourceTemplates.propTypes = {
-
-}
+// SinopiaResourceTemplates.propTypes = {
+//
+// }
 
 export default (SinopiaResourceTemplates)

--- a/src/components/editor/SinopiaResourceTemplates.jsx
+++ b/src/components/editor/SinopiaResourceTemplates.jsx
@@ -19,7 +19,7 @@ class SinopiaResourceTemplates extends Component {
   async componentDidMount() {
     const groupPromise = new Promise((resolve) => {
       resolve(instance.getBaseWithHttpInfo())
-    })
+    }).then((data) => data).catch(() => {})
 
     await this.fulfillGroupPromise(groupPromise).then(async () => {
       const ld4pGroupDataPromise = new Promise((resolve) => {
@@ -27,7 +27,7 @@ class SinopiaResourceTemplates extends Component {
           const name = this.resourceToName(group)
           resolve(instance.getGroupWithHttpInfo(name))
         })
-      })
+      }).then((data) => data).catch(() => {})
       await this.fulfillGroupDataPromise(ld4pGroupDataPromise)
     })
   }
@@ -49,6 +49,7 @@ class SinopiaResourceTemplates extends Component {
       let joined = []
       data.response.body.contains.map((c) => {
         const name = this.resourceToName(c)
+
 
         const promise = new Promise((resolve) => {
           resolve(instance.getResourceWithHttpInfo('ld4p', name, { acceptEncoding: 'application/json' }))

--- a/src/components/editor/SinopiaResourceTemplates.jsx
+++ b/src/components/editor/SinopiaResourceTemplates.jsx
@@ -25,26 +25,24 @@ class SinopiaResourceTemplates extends Component {
   }
 
   componentDidMount() {
-    this.fulfillGroupPromise()
-    this.fulfillGroupDataPromise()
+    this.fulfillGroupPromise(groupPromise)
+    this.fulfillGroupDataPromise(ld4pGroupDataPromise)
   }
 
-  fulfillGroupPromise = () => {
-    groupPromise.then((data) => {
-      const contains = data.response.body.contains
-      if(typeof contains.constructor === Array) {
-        this.setState({groupData: data.response.body.contains})
-      } else {
-        this.setState({groupData: [data.response.body.contains]})
-      }
+
+  fulfillGroupPromise = (promise) => {
+    promise.then((data) => {
+      const contains = [].concat(data.response.body.contains)
+      this.setState({groupData: contains})
     }).catch((error) => {
       this.setState({message: error})
     })
+    return promise
   }
 
   //TODO: get resource templates for other groups
-  fulfillGroupDataPromise = () => {
-    ld4pGroupDataPromise.then((data) => {
+  fulfillGroupDataPromise = (promise) => {
+    promise.then((data) => {
       let joined = []
       data.response.body.contains.map((c) => {
         const name = this.resourceToName(c)
@@ -62,6 +60,7 @@ class SinopiaResourceTemplates extends Component {
     }).catch((error) => {
       this.setState({message: error})
     })
+    return promise
   }
 
   resourceToName = (resource) => {

--- a/src/components/editor/SinopiaResourceTemplates.jsx
+++ b/src/components/editor/SinopiaResourceTemplates.jsx
@@ -71,6 +71,11 @@ class SinopiaResourceTemplates extends Component {
     return resource.substring(idx+1)
   }
 
+  //TODO: replace this with a link to the Editor component, passing in the resource template ID
+  handleRowSelect = (key) => {
+    alert(key)
+  }
+
   render(){
     const columns = [{
       dataField: 'id',
@@ -85,6 +90,13 @@ class SinopiaResourceTemplates extends Component {
       text: 'Group',
       sort: true
     }];
+
+    //TODO: select a row and get the RtId from it to link to Editor tab.
+    //TODO: this may help: https://github.com/AllenFang/react-bootstrap-table/blob/master/examples/js/selection/custom-multi-select-table.js
+    const selectRow = {
+      mode: 'radio',
+      onSelect: this.handleRowSelect
+    }
 
     if (this.state.message) {
       return (
@@ -106,7 +118,7 @@ class SinopiaResourceTemplates extends Component {
           })}
         </ul>
         <h4>Available Resource Templates in Sinopia</h4>
-        <BootstrapTable keyField='id' data={ this.state.templatesForGroup } columns={ columns } />
+        <BootstrapTable keyField='id' data={ this.state.templatesForGroup } columns={ columns } selectRow={ selectRow } />
       </div>
     )
   }

--- a/src/components/editor/SinopiaResourceTemplates.jsx
+++ b/src/components/editor/SinopiaResourceTemplates.jsx
@@ -1,0 +1,99 @@
+// Copyright 2019 Stanford University see Apache2.txt for license
+
+import React, {Component} from 'react'
+import PropTypes from 'prop-types'
+const SinopiaServer = require('sinopia_server')
+const instance = new SinopiaServer.LDPApi()
+instance.apiClient.basePath = 'http://localhost:8080'
+
+const groupPromise = new Promise((resolve) => {
+  resolve(instance.getBaseWithHttpInfo())
+})
+const ld4pGroupDataPromise = new Promise((resolve) => {
+  resolve(instance.getGroupWithHttpInfo('ld4p'))
+})
+
+class SinopiaResourceTemplates extends Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      isLoading: false,
+      groupData: [],
+      ld4pGroupData: []
+    }
+  }
+
+  componentDidMount() {
+    groupPromise.then((data) => {
+      if(typeof data.response.body.contains === 'Array') {
+        this.setState({groupData: data.response.body.contains})
+      } else {
+        this.setState({groupData: [data.response.body.contains]})
+      }
+    }, function(error) {
+      console.error(error)
+    })
+
+    ld4pGroupDataPromise.then((data) => {
+      this.setState({ld4pGroupData: data.response.body.contains})
+    }, function(error) {
+      console.error(error)
+    })
+
+    // this.state.ld4pGroupData.map((resource, index) => {
+    //   const name = this.resourceToName(resource)
+    //
+    //   const promise = new Promise((resolve) => {
+    //     resolve(instance.getResourceWithHttpInfo('ld4p', name))
+    //   })
+    //
+    //   promise.then((data) => {
+    //     console.log(data)
+    //   })
+    // })
+  }
+
+  resourceToName = (resource) => {
+    const idx = resource.lastIndexOf('/')
+    return resource.substring(idx+1)
+  }
+
+  render(){
+    return(
+      <div>
+        <h4>Groups in Sinopia</h4>
+        <ul>
+          { this.state.groupData.map((container, index) => {
+            return(
+              <li key={index}>{container}</li>
+            )
+          })}
+        </ul>
+        <h4>Available Resource Templates in Sinopia</h4>
+        <ul>
+          { this.state.ld4pGroupData.map((resource, index) => {
+            const name = this.resourceToName(resource)
+
+            const promise = new Promise((resolve) => {
+              resolve(instance.getResourceWithHttpInfo('ld4p', name))
+            })
+
+            promise.then((response_and_data) => {
+              console.log(response_and_data.response)
+            })
+
+            return(
+              <li key={index}>{resource}</li>
+            )
+          })}
+        </ul>
+      </div>
+    )
+  }
+}
+
+SinopiaResourceTemplates.propTypes = {
+
+}
+
+export default (SinopiaResourceTemplates)

--- a/src/components/editor/SinopiaResourceTemplates.jsx
+++ b/src/components/editor/SinopiaResourceTemplates.jsx
@@ -6,11 +6,11 @@ const SinopiaServer = require('sinopia_server')
 const instance = new SinopiaServer.LDPApi()
 instance.apiClient.basePath = 'http://localhost:8080'
 
-const groupPromise = new Promise((resolve, reject) => {
+const groupPromise = new Promise((resolve) => {
   resolve(instance.getBaseWithHttpInfo())
 })
 
-const ld4pGroupDataPromise = new Promise((resolve, reject) => {
+const ld4pGroupDataPromise = new Promise((resolve) => {
   resolve(instance.getGroupWithHttpInfo('ld4p'))
 })
 
@@ -25,6 +25,11 @@ class SinopiaResourceTemplates extends Component {
   }
 
   componentDidMount() {
+    this.fulfillGroupPromise()
+    this.fulfillGroupDataPromise()
+  }
+
+  fulfillGroupPromise = () => {
     groupPromise.then((data) => {
       const contains = data.response.body.contains
       if(typeof contains.constructor === Array) {
@@ -35,8 +40,10 @@ class SinopiaResourceTemplates extends Component {
     }).catch((error) => {
       this.setState({message: error})
     })
+  }
 
-    //TODO: get resource templates for other groups
+  //TODO: get resource templates for other groups
+  fulfillGroupDataPromise = () => {
     ld4pGroupDataPromise.then((data) => {
       let joined = []
       data.response.body.contains.map((c) => {

--- a/src/components/editor/SinopiaResourceTemplates.jsx
+++ b/src/components/editor/SinopiaResourceTemplates.jsx
@@ -1,7 +1,8 @@
 // Copyright 2019 Stanford University see Apache2.txt for license
 
 import React, {Component} from 'react'
-import BootstrapTable from 'react-bootstrap-table-next'
+import { Link } from 'react-router-dom'
+import {BootstrapTable, TableHeaderColumn} from 'react-bootstrap-table'
 const SinopiaServer = require('sinopia_server')
 const instance = new SinopiaServer.LDPApi()
 instance.apiClient.basePath = 'http://localhost:8080'
@@ -57,7 +58,8 @@ class SinopiaResourceTemplates extends Component {
       })
 
       promise.then((response_and_data) => {
-        this.setState({tempState: {name: name, uri: c, id: `${groupName}:${response_and_data.response.body.id}`, group: groupName}})
+        const data = response_and_data.response.body
+        this.setState({tempState: {name: name, uri: c, id: `${groupName}:${data.id}`, group: groupName, data: data}})
         const joined = this.state.templatesForGroup.slice(0)
         joined.push(this.state.tempState)
         this.setState({templatesForGroup: joined})
@@ -71,33 +73,13 @@ class SinopiaResourceTemplates extends Component {
     return resource.substring(idx+1)
   }
 
-  //TODO: replace this with a link to the Editor component, passing in the resource template ID
-  handleRowSelect = (key) => {
-    alert(key)
+  linkFormatter = (cell, row) => {
+    return(
+      <Link to={{pathname: '/editor', state: { resourceTemplateData: row.data }}}>{cell}</Link>
+    )
   }
 
   render(){
-    const columns = [{
-      dataField: 'id',
-      text: 'Template name',
-      sort: true
-    }, {
-      dataField: 'name',
-      text: 'ID',
-      sort: true
-    }, {
-      dataField: 'group',
-      text: 'Group',
-      sort: true
-    }];
-
-    //TODO: select a row and get the RtId from it to link to Editor tab.
-    //TODO: this may help: https://github.com/AllenFang/react-bootstrap-table/blob/master/examples/js/selection/custom-multi-select-table.js
-    const selectRow = {
-      mode: 'radio',
-      onSelect: this.handleRowSelect
-    }
-
     if (this.state.message) {
       return (
         <div className="alert alert-warning alert-dismissible">
@@ -106,6 +88,13 @@ class SinopiaResourceTemplates extends Component {
         </div>
       )
     }
+
+    const thIDClass = { backgroundColor: '#F8F6EF', width: '50%' }
+    const thNameClass = { backgroundColor: '#F8F6EF', width: '25%' }
+    const thGroupClass = { backgroundColor: '#F8F6EF', width: '25%' }
+    const tdIDClass = { width: '50%' }
+    const tdNameClass = { width: '25%' }
+    const tdGroupClass = { width: '25%' }
 
     return(
       <div>
@@ -118,7 +107,11 @@ class SinopiaResourceTemplates extends Component {
           })}
         </ul>
         <h4>Available Resource Templates in Sinopia</h4>
-        <BootstrapTable keyField='id' data={ this.state.templatesForGroup } columns={ columns } selectRow={ selectRow } />
+        <BootstrapTable keyField='id' data={ this.state.templatesForGroup } >
+          <TableHeaderColumn thStyle={ thNameClass } tdStyle={ tdNameClass } dataFormat={ this.linkFormatter } dataField='name' dataSort={true} >Template name</TableHeaderColumn>
+          <TableHeaderColumn thStyle={ thIDClass } tdStyle={ tdIDClass } dataField='id' dataSort={true} >ID</TableHeaderColumn>
+          <TableHeaderColumn thStyle={ thGroupClass } tdStyle={ tdGroupClass } dataField='group' dataSort={true} >Group</TableHeaderColumn>
+        </BootstrapTable>
       </div>
     )
   }

--- a/src/components/editor/SinopiaResourceTemplates.jsx
+++ b/src/components/editor/SinopiaResourceTemplates.jsx
@@ -22,13 +22,13 @@ class SinopiaResourceTemplates extends Component {
     }).then((data) => data).catch(() => {})
 
     await this.fulfillGroupPromise(groupPromise).then(async () => {
-      const ld4pGroupDataPromise = new Promise((resolve) => {
+      const groupDataPromise = new Promise((resolve) => {
         this.state.groupData.map((group) => {
           const name = this.resourceToName(group)
           resolve(instance.getGroupWithHttpInfo(name))
         })
       }).then((data) => data).catch(() => {})
-      await this.fulfillGroupDataPromise(ld4pGroupDataPromise)
+      await this.fulfillGroupDataPromise(groupDataPromise)
     })
   }
 
@@ -47,12 +47,12 @@ class SinopiaResourceTemplates extends Component {
   fulfillGroupDataPromise = (promise) => {
     promise.then((data) => {
       let joined = []
+      const groupName = this.resourceToName(data.response.body['@id'])
+
       data.response.body.contains.map((c) => {
         const name = this.resourceToName(c)
-
-
         const promise = new Promise((resolve) => {
-          resolve(instance.getResourceWithHttpInfo('ld4p', name, { acceptEncoding: 'application/json' }))
+          resolve(instance.getResourceWithHttpInfo(groupName, name, { acceptEncoding: 'application/json' }))
         })
 
         promise.then((response_and_data) => {

--- a/src/components/editor/SinopiaResourceTemplates.jsx
+++ b/src/components/editor/SinopiaResourceTemplates.jsx
@@ -1,15 +1,16 @@
 // Copyright 2019 Stanford University see Apache2.txt for license
 
 import React, {Component} from 'react'
-// import PropTypes from 'prop-types'
+import BootstrapTable from 'react-bootstrap-table-next'
 const SinopiaServer = require('sinopia_server')
 const instance = new SinopiaServer.LDPApi()
 instance.apiClient.basePath = 'http://localhost:8080'
 
-const groupPromise = new Promise((resolve) => {
+const groupPromise = new Promise((resolve, reject) => {
   resolve(instance.getBaseWithHttpInfo())
 })
-const ld4pGroupDataPromise = new Promise((resolve) => {
+
+const ld4pGroupDataPromise = new Promise((resolve, reject) => {
   resolve(instance.getGroupWithHttpInfo('ld4p'))
 })
 
@@ -19,7 +20,7 @@ class SinopiaResourceTemplates extends Component {
     this.state = {
       isLoading: false,
       groupData: [],
-      ld4pGroupData: []
+      templatesForGroup: []
     }
   }
 
@@ -31,27 +32,29 @@ class SinopiaResourceTemplates extends Component {
       } else {
         this.setState({groupData: [data.response.body.contains]})
       }
-    }, function(error) {
-      alert(error)
+    }).catch((error) => {
+      this.setState({message: error})
     })
 
+    //TODO: get resource templates for other groups
     ld4pGroupDataPromise.then((data) => {
-      this.setState({ld4pGroupData: data.response.body.contains})
-    }, function(error) {
-      alert(error)
-    })
+      let joined = []
+      data.response.body.contains.map((c) => {
+        const name = this.resourceToName(c)
 
-    // this.state.ld4pGroupData.map((resource, index) => {
-    //   const name = this.resourceToName(resource)
-    //
-    //   const promise = new Promise((resolve) => {
-    //     resolve(instance.getResourceWithHttpInfo('ld4p', name))
-    //   })
-    //
-    //   promise.then((data) => {
-    //     console.log(data)
-    //   })
-    // })
+        const promise = new Promise((resolve) => {
+          resolve(instance.getResourceWithHttpInfo('ld4p', name, { acceptEncoding: 'application/json' }))
+        })
+
+        promise.then((response_and_data) => {
+          joined.push({name: name, uri: c, id: response_and_data.response.body.id, group: 'ld4p'})
+          this.setState({templatesForGroup: joined})
+        })
+
+      })
+    }).catch((error) => {
+      this.setState({message: error})
+    })
   }
 
   resourceToName = (resource) => {
@@ -60,41 +63,43 @@ class SinopiaResourceTemplates extends Component {
   }
 
   render(){
+    const columns = [{
+      dataField: 'id',
+      text: 'Template name',
+      sort: true
+    }, {
+      dataField: 'name',
+      text: 'ID',
+      sort: true
+    }, {
+      dataField: 'group',
+      text: 'Group'
+    }];
+
+    if (this.state.message) {
+      return (
+        <div className="alert alert-warning alert-dismissible">
+          <button className="close" data-dismiss="alert" aria-label="close">&times;</button>
+          No connection to the Sinopia Server is available, or there are no resources for any group
+        </div>
+      )
+    }
+
     return(
       <div>
         <h4>Groups in Sinopia</h4>
         <ul>
           { this.state.groupData.map((container, index) => {
             return(
-              <li key={index}>{container}</li>
+              <li key={index}>{this.resourceToName(container)}</li>
             )
           })}
         </ul>
         <h4>Available Resource Templates in Sinopia</h4>
-        <ul>
-          { this.state.ld4pGroupData.map((resource, index) => {
-            const name = this.resourceToName(resource)
-
-            const promise = new Promise((resolve) => {
-              resolve(instance.getResourceWithHttpInfo('ld4p', name))
-            })
-
-            promise.then((response_and_data) => {
-              console.log(response_and_data.response)
-            })
-
-            return(
-              <li key={index}>{resource}</li>
-            )
-          })}
-        </ul>
+        <BootstrapTable keyField='id' data={ this.state.templatesForGroup } columns={ columns } />
       </div>
     )
   }
 }
-
-// SinopiaResourceTemplates.propTypes = {
-//
-// }
 
 export default (SinopiaResourceTemplates)

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -171,3 +171,7 @@ input.rbt-input-main {
 .editor-navtabs a {
     color: #2F2424;
 }
+
+.react-bootstrap-table thead {
+  background-color: #F8F6EF;
+}

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -171,7 +171,3 @@ input.rbt-input-main {
 .editor-navtabs a {
     color: #2F2424;
 }
-
-.react-bootstrap-table thead {
-  background-color: #F8F6EF;
-}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,6 +21,11 @@ module.exports = {
         use: [
           'file-loader'
         ]
+      },
+      {
+        parser: {
+          amd: false
+        }
       }
     ]
   },


### PR DESCRIPTION
Fixes #418 
Make calls to sinopia_server using the swagger generated API code. If the calls come back with an error message, display on the page, otherwise display the returned data in a bootstrap table:

**No connection to sinopia_server, or no data retrieved from calls:**

![Screen Shot 2019-03-21 at 4 34 58 PM](https://user-images.githubusercontent.com/3093850/54791475-4b123300-4bf7-11e9-9006-523b88be1de2.png)

**sinopia_server is connected and returns the expected data from `repository/ld4p`:**

<img width="807" alt="Screen Shot 2019-03-28 at 3 29 02 PM" src="https://user-images.githubusercontent.com/3093850/55197047-8f10b500-516e-11e9-8cc7-38dee074ea1f.png">

