### PR TITLE
Embedded resource template Redux support for UI

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -43,7 +43,8 @@ module.exports = {
     "jsx-a11y/anchor-is-valid": "warn", // see #172
     "jsx-a11y/label-has-for": "warn", // see #173
     "no-console": ["warn", { allow: ["info", "log"] }], //for development purposes
-    "no-extra-semi": "off"
+    "no-extra-semi": "off",
+    "security/detect-object-injection": "off"
   },
   overrides: [
     {

--- a/__tests__/actions/index.test.js
+++ b/__tests__/actions/index.test.js
@@ -57,3 +57,12 @@ describe('logOut action', () => {
     })
   })
 })
+
+describe('initializes the Redux State', () => {
+  it('should return Redux state based on SET_RESOURCE_TEMPLATE action', () => {
+    expect(actions.setResourceTemplate({}, { reduxPath: ['http://sinopia.io/example']})).toEqual({
+      type: 'SET_RESOURCE_TEMPLATE',
+      payload: {}
+    })
+  })
+})

--- a/__tests__/components/editor/InputLiteral.test.js
+++ b/__tests__/components/editor/InputLiteral.test.js
@@ -12,7 +12,8 @@ let plProps = {
       "type": "literal",
       "mandatory": "",
       "repeatable": ""
-    }
+    },
+    reduxPath: []
 }
 
 const valConstraintProps = {
@@ -88,7 +89,9 @@ describe('When the user enters input into field', ()=>{
     mock_wrapper.find('input').simulate('keypress', {key: 'Enter', preventDefault: () => {}})
     // test to see arguments used after its been submitted
     expect(mockFormDataFn.mock.calls[1][0]).toEqual(
-      {uri: "http://id.loc.gov/ontologies/bibframe/instanceOf", items:[{content: 'foo', id: 0}], "rtId": "resourceTemplate:bf2:Monograph:Instance"}
+      {uri: "http://id.loc.gov/ontologies/bibframe/instanceOf",
+      items:[{content: 'foo', id: 0}],
+      reduxPath: []}
     )
     mockFormDataFn.mock.calls = [] // reset the redux store to empty
   })
@@ -102,10 +105,16 @@ describe('When the user enters input into field', ()=>{
     mock_wrapper.find('input').simulate('keypress', {key: 'Enter', preventDefault: () => {}})
 
     expect(mockFormDataFn.mock.calls[0][0]).toEqual(
-      {uri: "http://id.loc.gov/ontologies/bibframe/instanceOf", items:[{content: 'fooby', id: 1}], "rtId": "resourceTemplate:bf2:Monograph:Instance"}
+      {uri: "http://id.loc.gov/ontologies/bibframe/instanceOf",
+       items:[{content: 'fooby', id: 1}],
+       reduxPath: []}
     )
     expect(mockFormDataFn.mock.calls[1][0]).toEqual(
-      {uri: "http://id.loc.gov/ontologies/bibframe/instanceOf", items:[{content: 'bar', id: 2}], "rtId": "resourceTemplate:bf2:Monograph:Instance"}
+      {
+       uri: "http://id.loc.gov/ontologies/bibframe/instanceOf",
+       items:[{content: 'bar', id: 2}],
+       reduxPath: []
+      }
     )
     mockFormDataFn.mock.calls = [] // reset the redux store to empty
   })
@@ -123,10 +132,15 @@ describe('When the user enters input into field', ()=>{
     mock_wrapper.find('input').simulate('keypress', {key: 'Enter', preventDefault: () => {}})
 
     expect(mockFormDataFn.mock.calls[0][0]).toEqual(
-      {uri: "http://id.loc.gov/ontologies/bibframe/instanceOf", items:[{content: 'fooby', id: 3}], "rtId": "resourceTemplate:bf2:Monograph:Instance"}
+      {uri: "http://id.loc.gov/ontologies/bibframe/instanceOf",
+       items:[{content: 'fooby', id: 3}],
+       reduxPath: []}
     )
     expect(mockFormDataFn.mock.calls[1][0]).toEqual(
-      {uri: "http://id.loc.gov/ontologies/bibframe/instanceOf", items:[], "rtId": "resourceTemplate:bf2:Monograph:Instance"}
+      { uri: "http://id.loc.gov/ontologies/bibframe/instanceOf",
+        items:[],
+        reduxPath: []
+      }
     )
     mockFormDataFn.mock.calls = [] // reset the redux store to empty
 

--- a/__tests__/components/editor/InputLiteral.test.js
+++ b/__tests__/components/editor/InputLiteral.test.js
@@ -2,6 +2,7 @@
 import 'jsdom-global/register'
 import React from 'react'
 import { shallow } from 'enzyme'
+import shortid from 'shortid'
 import { InputLiteral } from '../../../src/components/editor/InputLiteral'
 
 let plProps = {
@@ -66,10 +67,13 @@ describe('When the user enters input into field', ()=>{
   // our mock formData function to replace the one provided by mapDispatchToProps
   const mockFormDataFn = jest.fn()
   const removeMockDataFn = jest.fn()
+  const testId = jest.spyOn(shortid, 'generate').mockReturnValue(0)
   mock_wrapper = shallow(<InputLiteral {...plProps} id={11}
-                                       rtId={'resourceTemplate:bf2:Monograph:Instance'}
-                                       handleMyItemsChange={mockFormDataFn}
-                                       handleRemoveItem={removeMockDataFn}/>)
+                            rtId={'resourceTemplate:bf2:Monograph:Instance'}
+                            reduxPath={['resourceTemplate:bf2:Monograph:Instance',
+                                        'http://id.loc.gov/ontologies/bibframe/instanceOf']}
+                            handleMyItemsChange={mockFormDataFn}
+                            handleRemoveItem={removeMockDataFn}/>)
 
   it('has an id value as a unique property', () => {
     expect(mock_wrapper.find('input').prop('id')).toEqual("typeLiteral11")
@@ -91,7 +95,7 @@ describe('When the user enters input into field', ()=>{
     expect(mockFormDataFn.mock.calls[1][0]).toEqual(
       {uri: "http://id.loc.gov/ontologies/bibframe/instanceOf",
       items:[{content: 'foo', id: 0}],
-      reduxPath: []}
+      reduxPath: ['resourceTemplate:bf2:Monograph:Instance', 'http://id.loc.gov/ontologies/bibframe/instanceOf']}
     )
     mockFormDataFn.mock.calls = [] // reset the redux store to empty
   })
@@ -106,14 +110,15 @@ describe('When the user enters input into field', ()=>{
 
     expect(mockFormDataFn.mock.calls[0][0]).toEqual(
       {uri: "http://id.loc.gov/ontologies/bibframe/instanceOf",
-       items:[{content: 'fooby', id: 1}],
-       reduxPath: []}
+       items:[{content: 'fooby', id: 0}],
+       reduxPath: ['resourceTemplate:bf2:Monograph:Instance', 'http://id.loc.gov/ontologies/bibframe/instanceOf']}
     )
     expect(mockFormDataFn.mock.calls[1][0]).toEqual(
       {
        uri: "http://id.loc.gov/ontologies/bibframe/instanceOf",
        items:[{content: 'bar', id: 2}],
-       reduxPath: []
+       items: [{"content": "bar", "id": 0}],
+       reduxPath: ['resourceTemplate:bf2:Monograph:Instance', 'http://id.loc.gov/ontologies/bibframe/instanceOf']
       }
     )
     mockFormDataFn.mock.calls = [] // reset the redux store to empty
@@ -133,13 +138,13 @@ describe('When the user enters input into field', ()=>{
 
     expect(mockFormDataFn.mock.calls[0][0]).toEqual(
       {uri: "http://id.loc.gov/ontologies/bibframe/instanceOf",
-       items:[{content: 'fooby', id: 3}],
-       reduxPath: []}
+       items:[{content: 'fooby', id: 0}],
+       reduxPath: ['resourceTemplate:bf2:Monograph:Instance', 'http://id.loc.gov/ontologies/bibframe/instanceOf']}
     )
     expect(mockFormDataFn.mock.calls[1][0]).toEqual(
       { uri: "http://id.loc.gov/ontologies/bibframe/instanceOf",
         items:[],
-        reduxPath: []
+        reduxPath: ['resourceTemplate:bf2:Monograph:Instance', 'http://id.loc.gov/ontologies/bibframe/instanceOf']
       }
     )
     mockFormDataFn.mock.calls = [] // reset the redux store to empty

--- a/__tests__/components/editor/PropertyResourceTemplate.test.js
+++ b/__tests__/components/editor/PropertyResourceTemplate.test.js
@@ -2,7 +2,7 @@
 
 import React from 'react'
 import 'jsdom-global/register'
-import { shallow, mount } from 'enzyme'
+import { shallow } from 'enzyme'
 import PropertyActionButtons from '../../../src/components/editor/PropertyActionButtons'
 import PropertyResourceTemplate from '../../../src/components/editor/PropertyResourceTemplate'
 import PropertyTemplateOutline from '../../../src/components/editor/PropertyTemplateOutline'
@@ -17,7 +17,8 @@ describe('<PropertyResourceTemplate />', () => {
           propertyURI: "http://schema.org/"
         }
       ]
-    }
+    },
+    reduxPath: ''
   }
   const wrapper = shallow(<PropertyResourceTemplate {...propertyRtProps} />)
 
@@ -36,7 +37,7 @@ describe('<PropertyResourceTemplate />', () => {
 
   describe('<PropertyResourceTemplate /> has the "Add Click" and "Mint URI" buttons', () => {
 
-    const wrapper = mount(<PropertyResourceTemplate {...propertyRtProps} />)
+    const wrapper = shallow(<PropertyResourceTemplate {...propertyRtProps} />)
     const actionButtons = wrapper.find(PropertyActionButtons)
 
     it("Contains a PropertyActionButtons component", () => {

--- a/__tests__/components/editor/PropertyTemplateOutline.test.js
+++ b/__tests__/components/editor/PropertyTemplateOutline.test.js
@@ -39,6 +39,7 @@ describe('getLookupConfigItem module function', () => {
 })
 
 describe('<PropertyTemplateOutline />', () => {
+  const mockInitNewResourceTemplate = jest.fn()
   let propertyRtProps = {
     propertyTemplate:
         {
@@ -46,7 +47,8 @@ describe('<PropertyTemplateOutline />', () => {
           propertyURI: "http://schema.org/name"
         }
   }
-  const wrapper = shallow(<PropertyTemplateOutline {...propertyRtProps} />)
+  const wrapper = shallow(<PropertyTemplateOutline {...propertyRtProps}
+    initNewResourceTemplate={mockInitNewResourceTemplate} />)
   const childPropertyTemplateOutline = wrapper.find(PropertyTemplateOutline)
 
   it('Contains a <PropertyTypeRow />', () => {
@@ -134,6 +136,7 @@ describe('<PropertyTemplateOutline /> with propertyTemplate Refs', () => {
   const mockHandleCollapsed = jest.fn()
   const mockHandleAddClick = jest.fn()
   const mockHandleMintUri = jest.fn()
+  const mockInitNewResourceTemplate = jest.fn()
   const property = {
     propertyTemplate: {
         "propertyLabel": "Notes about the CreativeWork",
@@ -156,9 +159,11 @@ describe('<PropertyTemplateOutline /> with propertyTemplate Refs', () => {
   const wrapper = mount(<PropertyTemplateOutline {...property}
     handleCollapsed={mockHandleCollapsed}
     handleAddClick={mockHandleAddClick}
-    handleMintUri={mockHandleMintUri} />)
+    handleMintUri={mockHandleMintUri}
+    initNewResourceTemplate={mockInitNewResourceTemplate} />)
   const childOutlineHeader = wrapper.find(OutlineHeader)
   const actionButtons = wrapper.find(PropertyActionButtons)
+  console.log(actionButtons.debug())
 
   it('displays a collapsed OutlineHeader of the propertyTemplate label', () => {
     expect(childOutlineHeader.props().label).toEqual(property.propertyTemplate.propertyLabel)
@@ -171,13 +176,14 @@ describe('<PropertyTemplateOutline /> with propertyTemplate Refs', () => {
   })
 
   it('handles "Add" button click', () => {
-    const addButton = wrapper.find('.btn-default')
+    const addButton = wrapper.find('div > section > PropertyActionButtons > div > button.btn-default')
+    addButton.handleClick = mockHandleAddClick
     addButton.simulate('click')
     expect(mockHandleAddClick.mock.calls.length).toBe(1)
   })
 
   it('handles "Mint URI" button click', () => {
-    const mintButton = wrapper.find('.btn-success')
+    const mintButton = wrapper.find('div > section > PropertyActionButtons > div > button.btn-success')
     mintButton.simulate('click')
     expect(mockHandleMintUri.mock.calls.length).toBe(1)
   })

--- a/__tests__/components/editor/PropertyTemplateOutline.test.js
+++ b/__tests__/components/editor/PropertyTemplateOutline.test.js
@@ -163,7 +163,6 @@ describe('<PropertyTemplateOutline /> with propertyTemplate Refs', () => {
     initNewResourceTemplate={mockInitNewResourceTemplate} />)
   const childOutlineHeader = wrapper.find(OutlineHeader)
   const actionButtons = wrapper.find(PropertyActionButtons)
-  console.log(actionButtons.debug())
 
   it('displays a collapsed OutlineHeader of the propertyTemplate label', () => {
     expect(childOutlineHeader.props().label).toEqual(property.propertyTemplate.propertyLabel)

--- a/__tests__/reducers/index.test.js
+++ b/__tests__/reducers/index.test.js
@@ -1,0 +1,44 @@
+// Copyright 2019 Stanford University see Apache2.txt for license
+
+import { refreshResourceTemplate  } from '../../src/reducers/index'
+
+describe(`Takes a resource template ID and populates the global state`, () => {
+
+  it('passing a payload to an empty state', () => {
+    const emptyStateResult = refreshResourceTemplate({}, {
+      type:  'REFRESH_RESOURCE_TEMPLATE',
+      payload: {
+        reduxPath: ['http://sinopia.io/example']
+      }
+    })
+    expect(emptyStateResult).toEqual({
+      'http://sinopia.io/example': { items: { items: [] } }
+    })
+
+  })
+
+  it(`missing reduxPath in payload should return the state`, () => {
+    const missingPayload = refreshResourceTemplate({}, {
+      type:  'REFRESH_RESOURCE_TEMPLATE',
+      payload: {}
+    })
+    expect(missingPayload).toEqual({})
+  })
+
+  it('tests with a more realistic payload with defaults', () => {
+    const defaultStateResult = refreshResourceTemplate({}, {
+      type: 'REFRESH_RESOURCE_TEMPLATE',
+      payload: {
+        reduxPath: ['resourceTemplate:bf2:Item', 'http://schema.org/name'],
+        defaults: ['Sinopia Name']
+      }
+    })
+    expect(defaultStateResult).toEqual({
+      'resourceTemplate:bf2:Item': {
+        'http://schema.org/name':{
+          items: [ "Sinopia Name" ]
+        }
+      }
+    })
+  })
+})

--- a/__tests__/reducers/index.test.js
+++ b/__tests__/reducers/index.test.js
@@ -12,7 +12,7 @@ describe(`Takes a resource template ID and populates the global state`, () => {
       }
     })
     expect(emptyStateResult).toEqual({
-      'http://sinopia.io/example': { items: { items: [] } }
+      'http://sinopia.io/example': { items: [] }
     })
 
   })

--- a/__tests__/reducers/literal.test.js
+++ b/__tests__/reducers/literal.test.js
@@ -9,7 +9,8 @@ describe('literal reducer functions', () => {
       type: 'SET_ITEMS',
       payload: {
         rtId: 'resourceTemplate:Monograph:Instance',
-        uri:'http://schema.org/name',
+        uri: 'http://schema.org/name',
+        reduxPath: ['resourceTemplate:Monograph:Instance', 'http://schema.org/name'],
         items: [ { id: 0, content: 'Run the tests'} ]
       }
     })
@@ -26,9 +27,13 @@ describe('literal reducer functions', () => {
     expect(
       setMyItems({ "resourceTemplate:Monograph:Instance": {
         'http://schema.org/name': {
-          items: [{ id: 1, content: "Run the tests" }] },
+          items: [{ id: 1, content: "Run the tests" }],
+          reduxPath: ['resourceTemplate:Monograph:Instance', 'http://schema.org/name']
+        },
         'http://schema.org/description': {
-          items: []}
+          items: [],
+          reduxPath: ['resourceTemplate:Monograph:Instance', 'http://schema.org/description']
+        }
         }
       },
       {
@@ -36,16 +41,19 @@ describe('literal reducer functions', () => {
         payload: {
           rtId: "resourceTemplate:Monograph:Instance",
           uri: 'http://schema.org/description',
+          reduxPath: ['resourceTemplate:Monograph:Instance', 'http://schema.org/description'],
           items: [ { id: 2, content: "add this!"}]
         }
       })
     ).toEqual({
       "resourceTemplate:Monograph:Instance": {
         'http://schema.org/name': {
-          items: [{ id: 1, content: 'Run the tests'}]
+          items: [{ id: 1, content: 'Run the tests'}],
+          reduxPath: ['resourceTemplate:Monograph:Instance', 'http://schema.org/name']
         },
         'http://schema.org/description': {
-          items: [{ id: 2, content: "add this!"}]
+          items: [{ id: 2, content: "add this!"}],
+          reduxPath: ['resourceTemplate:Monograph:Instance', 'http://schema.org/description']
         }
       }
     })

--- a/__tests__/reducers/literal.test.js
+++ b/__tests__/reducers/literal.test.js
@@ -75,6 +75,7 @@ describe('literal reducer functions', () => {
       payload: {
         id: 0,
         rtId: "resourceTemplate:Monograph:Instance",
+        reduxPath: ["resourceTemplate:Monograph:Instance", "http://schema.org/name"],
         uri: "http://schema.org/name",
         content: "test content"
       }

--- a/__tests__/reducers/literal.test.js
+++ b/__tests__/reducers/literal.test.js
@@ -102,9 +102,9 @@ describe('literal reducer functions', () => {
       type: 'REMOVE_ITEM',
       payload: {
         id: 0,
-        rtId: "resourceTemplate:Monograph:Instance",
         uri: "http://schema.org/name",
-        content: "test content"
+        content: "test content",
+        reduxPath: ["resourceTemplate:Monograph:Instance", "http://schema.org/name"]
       }
     })
    ).toEqual({
@@ -134,8 +134,8 @@ describe('literal reducer functions', () => {
       {
         type: "REMOVE_ALL_CONTENT",
         payload:{
-          rtId: "resourceTemplate:Monograph:Instance",
-          uri: 'http://schema.org/name'
+          uri: 'http://schema.org/name',
+          reduxPath: ["resourceTemplate:Monograph:Instance", "http://schema.org/name"]
         }
       })
     ).toEqual({

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -3,6 +3,11 @@ export const setItems = item => ({
   payload: item
 })
 
+export const refreshResourceTemplate  = update => ({
+  type: 'REFRESH_RESOURCE_TEMPLATE',
+  payload: update
+})
+
 export const setResourceTemplate = resource_template => ({
   type: 'SET_RESOURCE_TEMPLATE',
   payload: resource_template

--- a/src/components/editor/InputLiteral.jsx
+++ b/src/components/editor/InputLiteral.jsx
@@ -39,6 +39,7 @@ export class InputLiteral extends Component {
 
   handleFocus = (event) => {
     document.getElementById(event.target.id).focus()
+    event.preventDefault()
   }
 
   handleChange = (event) => {

--- a/src/components/editor/InputLiteral.jsx
+++ b/src/components/editor/InputLiteral.jsx
@@ -79,7 +79,7 @@ export class InputLiteral extends Component {
       }
       const user_input = {
         uri: this.props.propertyTemplate.propertyURI,
-        rtId: this.props.rtId,
+        reduxPath: this.props.reduxPath,
         items: userInputArray
       }
       this.props.handleMyItemsChange(user_input)
@@ -204,7 +204,7 @@ export class InputLiteral extends Component {
 }
 
 InputLiteral.propTypes = {
-  id: PropTypes.number,
+  id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   propertyTemplate: PropTypes.shape({
     propertyLabel: PropTypes.string.isRequired,
     propertyURI: PropTypes.string.isRequired,
@@ -222,6 +222,7 @@ InputLiteral.propTypes = {
   }),
   handleMyItemsChange: PropTypes.func,
   handleRemoveItem: PropTypes.func,
+  reduxPath: PropTypes.string,
   rtId: PropTypes.string,
   blankNodeForLiteral: PropTypes.object,
   propPredicate: PropTypes.string,

--- a/src/components/editor/InputLiteral.jsx
+++ b/src/components/editor/InputLiteral.jsx
@@ -8,6 +8,7 @@ import { getProperty } from '../../reducers/index'
 import InputLang from './InputLang'
 import Modal from 'react-bootstrap/lib/Modal'
 import Button from 'react-bootstrap/lib/Button'
+import shortid from 'shortid'
 import store from '../../store.js'
 
 // Redux recommends exporting the unconnected component for unit tests.
@@ -15,17 +16,10 @@ export class InputLiteral extends Component {
 
   constructor(props) {
     super(props)
-    let lastId
-    try {
-      lastId =  Number(props.propertyTemplate.valueConstraint.defaults.length)-1
-    } catch (err) {
-      lastId = -1
-    }
     this.state = {
       show: false,
       content_add: "",
-      disabled: false,
-      lastId: lastId
+      disabled: false
     }
   }
 
@@ -55,12 +49,11 @@ export class InputLiteral extends Component {
   }
 
   addUserInput = (userInputArray, currentcontent) => {
-    const newId = this.state.lastId + 1
+    const newId = shortid.generate()
     userInputArray.push({
       content: currentcontent,
       id: newId
     })
-    this.setState( { lastId: newId } )
   }
 
   handleKeypress = (event) => {
@@ -92,13 +85,12 @@ export class InputLiteral extends Component {
 
   handleItemClick = (event) => {
     const labelToRemove = event.target.dataset["content"]
-    const idToRemove = Number(event.target.dataset["item"])
-
+    const idToRemove = event.target.dataset["item"]
     this.props.handleRemoveItem(
     {
       id: idToRemove,
       label: labelToRemove,
-      rtId: this.props.rtId,
+      reduxPath: this.props.reduxPath,
       uri: this.props.propertyTemplate.propertyURI
     })
     this.setState({ disabled: false })
@@ -159,15 +151,16 @@ export class InputLiteral extends Component {
     if (formInfo == undefined || formInfo.items == undefined) {
       return
     }
-    const elements = formInfo.items.map((obj, index) => {
-      return <div id="userInput" key = {index} >
+    const elements = formInfo.items.map((obj) => {
+      const itemId = obj.id || shortid.generate()
+      return <div id="userInput" key = {itemId} >
         {obj.content}
         <button
           id="displayedItem"
           type="button"
           onClick={this.handleItemClick}
           key={obj.id}
-          data-item={index}
+          data-item={itemId}
           data-label={formInfo.uri}
         >X
         </button>
@@ -216,13 +209,13 @@ InputLiteral.propTypes = {
     })
   }).isRequired,
   formData: PropTypes.shape({
-    id: PropTypes.number,
+    id: PropTypes.string,
     uri: PropTypes.string,
     items: PropTypes.array
   }),
   handleMyItemsChange: PropTypes.func,
   handleRemoveItem: PropTypes.func,
-  reduxPath: PropTypes.string,
+  reduxPath: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
   rtId: PropTypes.string,
   blankNodeForLiteral: PropTypes.object,
   propPredicate: PropTypes.string,

--- a/src/components/editor/PropertyPanel.jsx
+++ b/src/components/editor/PropertyPanel.jsx
@@ -41,9 +41,9 @@ export default class PropertyPanel extends Component {
   render() {
     return (
       <div className={this.getCssClasses()}>
-        <div className="panel-heading prop-heading">
-          {this.generateTitle()}
-        </div>
+      <div className="panel-heading prop-heading">
+        {this.generateTitle()}
+      </div>
         <div className="panel-body">
           {this.props.children}
         </div>

--- a/src/components/editor/PropertyResourceTemplate.jsx
+++ b/src/components/editor/PropertyResourceTemplate.jsx
@@ -38,7 +38,7 @@ class PropertyResourceTemplate extends Component {
       </div>
       <div>
       {
-        this.props.resourceTemplate.propertyTemplates.map((property, i) => {
+        this.props.resourceTemplate.propertyTemplates.map((property) => {
           let newReduxPath = Object.assign([], this.props.reduxPath)
           newReduxPath.push(property.propertyURI)
           return(<PropertyTemplateOutline
@@ -55,6 +55,7 @@ class PropertyResourceTemplate extends Component {
 }
 
 PropertyResourceTemplate.propTypes = {
+  reduxPath: PropTypes.string,
   resourceTemplate: PropTypes.object
 }
 

--- a/src/components/editor/PropertyResourceTemplate.jsx
+++ b/src/components/editor/PropertyResourceTemplate.jsx
@@ -55,7 +55,7 @@ class PropertyResourceTemplate extends Component {
 }
 
 PropertyResourceTemplate.propTypes = {
-  reduxPath: PropTypes.string,
+  reduxPath: PropTypes.array,
   resourceTemplate: PropTypes.object
 }
 

--- a/src/components/editor/PropertyResourceTemplate.jsx
+++ b/src/components/editor/PropertyResourceTemplate.jsx
@@ -18,6 +18,7 @@ class PropertyResourceTemplate extends Component {
 
   handleAddClick = (event) => {
      event.preventDefault()
+     console.log(`in handleAddClick PropertyResourceTemplate`)
   }
 
   handleMintUri = (event) => {
@@ -25,28 +26,30 @@ class PropertyResourceTemplate extends Component {
   }
 
   render() {
-    return (
-      <div>
-        <div className="row">
-          <section className="col-md-8">
-            <h4>{this.props.resourceTemplate.resourceLabel}</h4>
-          </section>
-          <section className="col-md-4">
-            <PropertyActionButtons handleAddClick={this.handleAddClick}
-              handleMintUri={this.handleMintUri} key={shortid.generate()} />
-          </section>
-        </div>
-        <div>
-        {
-          this.props.resourceTemplate.propertyTemplates.map((property, i) => {
-            return(<PropertyTemplateOutline
-                    propertyTemplate={property}
-                    key={shortid.generate()}
-                    count={i}  />)
-          })
-        }
-        </div>
+    return (<div>
+      <div className="row" key={shortid.generate()}>
+        <section className="col-md-8">
+          <h4>{this.props.resourceTemplate.resourceLabel}</h4>
+        </section>
+        <section className="col-md-4">
+          <PropertyActionButtons handleAddClick={this.handleAddClick}
+            handleMintUri={this.handleMintUri} key={shortid.generate()} />
+        </section>
       </div>
+      <div>
+      {
+        this.props.resourceTemplate.propertyTemplates.map((property, i) => {
+          let newReduxPath = Object.assign([], this.props.reduxPath)
+          newReduxPath.push(property.propertyURI)
+          return(<PropertyTemplateOutline
+                  propertyTemplate={property}
+                  rtId={this.props.resourceTemplate.id}
+                  reduxPath={newReduxPath}
+                  key={shortid.generate()} />)
+        })
+      }
+      </div>
+    </div>
     )
   }
 }

--- a/src/components/editor/PropertyResourceTemplate.jsx
+++ b/src/components/editor/PropertyResourceTemplate.jsx
@@ -18,7 +18,6 @@ class PropertyResourceTemplate extends Component {
 
   handleAddClick = (event) => {
      event.preventDefault()
-     console.log(`in handleAddClick PropertyResourceTemplate`)
   }
 
   handleMintUri = (event) => {

--- a/src/components/editor/PropertyTemplateOutline.jsx
+++ b/src/components/editor/PropertyTemplateOutline.jsx
@@ -60,7 +60,6 @@ export class PropertyTemplateOutline extends Component {
       collapsed: true,
       output: []
     }
-    // this.handleNewResourceTemplate = this.handleNewResourceTemplate.bind(this)
   }
 
   handleAddClick = (event) => {
@@ -79,9 +78,15 @@ export class PropertyTemplateOutline extends Component {
     let lookupConfigItem, lookupConfigItems
     switch (property.type) {
       case "literal":
+        let localReduxPath = Object.assign([], rtReduxPath)
+        if (!property.propertyURI in localReduxPath) {
+          localReduxPath.push(property.propertyURI)
+        }
+
         input = <InputLiteral id={this.props.count}
               propertyTemplate={property}
               key={shortid.generate()}
+              reduxPath={localReduxPath}
               rtId={property.rtId} />
         break;
 
@@ -121,14 +126,11 @@ export class PropertyTemplateOutline extends Component {
                   })
                 })
               }
-
-              this.props.handleNewResourceTemplate(payload)
-              console.log(`Current props`)
-              console.warn(this.props)
-
+              this.props.initNewResourceTemplate(payload)
               input.push(<PropertyTemplateOutline key={shortid.generate()}
                 propertyTemplate={rtProperty}
                 reduxPath={newReduxPath}
+                initNewResourceTemplate={this.props.initNewResourceTemplate}
                 resourceTemplate={getResourceTemplate(rtId)} />)
             })
           })
@@ -191,8 +193,6 @@ export class PropertyTemplateOutline extends Component {
 }
 
 PropertyTemplateOutline.propTypes = {
-  count: PropTypes.number,
-  depth: PropTypes.number,
   handleAddClick: PropTypes.func,
   handleMintUri: PropTypes.func,
   handleCollapsed: PropTypes.func,
@@ -202,7 +202,7 @@ PropertyTemplateOutline.propTypes = {
 }
 
 const mapDispatchToProps = dispatch => ({
-  handleNewResourceTemplate(rt_context) {
+  initNewResourceTemplate(rt_context) {
     dispatch(refreshResourceTemplate(rt_context))
   }
 })

--- a/src/components/editor/PropertyTemplateOutline.jsx
+++ b/src/components/editor/PropertyTemplateOutline.jsx
@@ -60,6 +60,7 @@ export class PropertyTemplateOutline extends Component {
       collapsed: true,
       output: []
     }
+    // this.handleNewResourceTemplate = this.handleNewResourceTemplate.bind(this)
   }
 
   handleAddClick = (event) => {
@@ -70,18 +71,10 @@ export class PropertyTemplateOutline extends Component {
     event.preventDefault()
   }
 
-  addDynamicResourceTemplate = (resourceTemplate, parentRt) => {
-    //!! Should check Redux state to if key exists
-
-    if (this.state.collapsed) {
-      console.log(`In addDynamicResourceTemplate ${resourceTemplate.resourceLabel} parent ${parentRt}`)
-      console.warn(this.props)
-    }
-  }
-
   handleClick = (property) => (event) => {
     event.preventDefault()
     let newOutput = this.state.output
+    let rtReduxPath = Object.assign([], this.props.reduxPath)
     let input
     let lookupConfigItem, lookupConfigItems
     switch (property.type) {
@@ -104,8 +97,6 @@ export class PropertyTemplateOutline extends Component {
           input = []
           property.valueConstraint.valueTemplateRefs.map((rtId) => {
             let resourceTemplate = getResourceTemplate(rtId)
-            let rtReduxPath = Object.assign([], this.props.reduxPath)
-            rtReduxPath.push(rtId)
             input.push(<div className="row" key={shortid.generate()}>
               <section className="col-sm-8">
                 <h5>{resourceTemplate.resourceLabel}</h5>
@@ -117,8 +108,24 @@ export class PropertyTemplateOutline extends Component {
             </div>)
             resourceTemplate.propertyTemplates.map((rtProperty) => {
               let newReduxPath = Object.assign([], rtReduxPath)
+              newReduxPath.push(rtId)
               newReduxPath.push(rtProperty.propertyURI)
-              this.props.handleNewResourceTemplate({ reduxPath: newReduxPath })
+              const payload = { reduxPath: newReduxPath }
+              if (rtProperty.valueConstraint.defaults && rtProperty.valueConstraint.defaults.length > 0) {
+                payload['defaults'] = []
+                rtProperty.valueConstraint.defaults.map((row, i) => {
+                  payload['defaults'].push({
+                    id: i,
+                    content: row.defaultLiteral,
+                    uri: row.defaultURI
+                  })
+                })
+              }
+
+              this.props.handleNewResourceTemplate(payload)
+              console.log(`Current props`)
+              console.warn(this.props)
+
               input.push(<PropertyTemplateOutline key={shortid.generate()}
                 propertyTemplate={rtProperty}
                 reduxPath={newReduxPath}

--- a/src/components/editor/PropertyTemplateOutline.jsx
+++ b/src/components/editor/PropertyTemplateOutline.jsx
@@ -84,7 +84,9 @@ export class PropertyTemplateOutline extends Component {
     let lookupConfigItem, lookupConfigItems
     switch (property.type) {
       case "literal":
-        rtReduxPath.push(property.propertyURI)
+        if (rtReduxPath[rtReduxPath.length - 1] !== property.propertyURI) {
+          rtReduxPath.push(property.propertyURI)
+        }
         key = shortid.generate()
         input = <InputLiteral id={key}
               propertyTemplate={property}

--- a/src/components/editor/PropertyTemplateOutline.jsx
+++ b/src/components/editor/PropertyTemplateOutline.jsx
@@ -9,7 +9,7 @@ import OutlineHeader from './OutlineHeader'
 import PropertyActionButtons from './PropertyActionButtons'
 import PropertyTypeRow from './PropertyTypeRow'
 import RequiredSuperscript from './RequiredSuperscript'
-import { setResourceTemplate } from '../../reducers/index'
+import { refreshResourceTemplate } from '../../actions/index'
 import { getResourceTemplate } from '../../sinopiaServer'
 import lookupConfig from '../../../static/spoofedFilesFromServer/fromSinopiaServer/lookupConfig.json'
 import PropTypes from 'prop-types'
@@ -115,11 +115,10 @@ export class PropertyTemplateOutline extends Component {
                   handleMintUri={this.handleMintUri} key={shortid.generate()} />
               </section>
             </div>)
-
             resourceTemplate.propertyTemplates.map((rtProperty) => {
               let newReduxPath = Object.assign([], rtReduxPath)
               newReduxPath.push(rtProperty.propertyURI)
-              console.warn(newReduxPath)
+              this.props.handleNewResourceTemplate({ reduxPath: newReduxPath })
               input.push(<PropertyTemplateOutline key={shortid.generate()}
                 propertyTemplate={rtProperty}
                 reduxPath={newReduxPath}
@@ -197,7 +196,7 @@ PropertyTemplateOutline.propTypes = {
 
 const mapDispatchToProps = dispatch => ({
   handleNewResourceTemplate(rt_context) {
-    dispatch(setResourceTemplate(rt_context))
+    dispatch(refreshResourceTemplate(rt_context))
   }
 })
 

--- a/src/components/editor/PropertyTemplateOutline.jsx
+++ b/src/components/editor/PropertyTemplateOutline.jsx
@@ -74,25 +74,22 @@ export class PropertyTemplateOutline extends Component {
     event.preventDefault()
     let newOutput = this.state.output
     let rtReduxPath = Object.assign([], this.props.reduxPath)
-    let input
+    let input, key
     let lookupConfigItem, lookupConfigItems
     switch (property.type) {
       case "literal":
-        let localReduxPath = Object.assign([], rtReduxPath)
-        if (!property.propertyURI in localReduxPath) {
-          localReduxPath.push(property.propertyURI)
-        }
-
-        input = <InputLiteral id={this.props.count}
+        rtReduxPath.push(property.propertyURI)
+        key = shortid.generate()
+        input = <InputLiteral id={key}
               propertyTemplate={property}
-              key={shortid.generate()}
-              reduxPath={localReduxPath}
+              key={key}
+              reduxPath={rtReduxPath}
               rtId={property.rtId} />
         break;
 
       case "lookup":
         lookupConfigItems = getLookupConfigItems(property);
-        input = <InputLookupQA propertyTemplate={property} 
+        input = <InputLookupQA propertyTemplate={property}
              lookupConfig={lookupConfigItems}
              rtId = {property.rtId} />
         break;
@@ -196,8 +193,10 @@ PropertyTemplateOutline.propTypes = {
   handleAddClick: PropTypes.func,
   handleMintUri: PropTypes.func,
   handleCollapsed: PropTypes.func,
+  initNewResourceTemplate: PropTypes.func,
   isRequired: PropTypes.func,
   propertyTemplate: PropTypes.object,
+  reduxPath: PropTypes.string,
   rtId: PropTypes.string
 }
 

--- a/src/components/editor/PropertyTemplateOutline.jsx
+++ b/src/components/editor/PropertyTemplateOutline.jsx
@@ -1,12 +1,15 @@
 // Copyright 2019 Stanford University see Apache2.txt for license
 
 import React, {Component} from 'react'
+import { connect } from 'react-redux'
 import InputLiteral from './InputLiteral'
 import InputListLOC from './InputListLOC'
 import InputLookupQA from './InputLookupQA'
 import OutlineHeader from './OutlineHeader'
+import PropertyActionButtons from './PropertyActionButtons'
 import PropertyTypeRow from './PropertyTypeRow'
 import RequiredSuperscript from './RequiredSuperscript'
+import { setResourceTemplate } from '../../reducers/index'
 import { getResourceTemplate } from '../../sinopiaServer'
 import lookupConfig from '../../../static/spoofedFilesFromServer/fromSinopiaServer/lookupConfig.json'
 import PropTypes from 'prop-types'
@@ -67,6 +70,15 @@ export class PropertyTemplateOutline extends Component {
     event.preventDefault()
   }
 
+  addDynamicResourceTemplate = (resourceTemplate, parentRt) => {
+    //!! Should check Redux state to if key exists
+
+    if (this.state.collapsed) {
+      console.log(`In addDynamicResourceTemplate ${resourceTemplate.resourceLabel} parent ${parentRt}`)
+      console.warn(this.props)
+    }
+  }
+
   handleClick = (property) => (event) => {
     event.preventDefault()
     let newOutput = this.state.output
@@ -92,9 +104,25 @@ export class PropertyTemplateOutline extends Component {
           input = []
           property.valueConstraint.valueTemplateRefs.map((rtId) => {
             let resourceTemplate = getResourceTemplate(rtId)
+            let rtReduxPath = Object.assign([], this.props.reduxPath)
+            rtReduxPath.push(rtId)
+            input.push(<div className="row" key={shortid.generate()}>
+              <section className="col-sm-8">
+                <h5>{resourceTemplate.resourceLabel}</h5>
+              </section>
+              <section className="col-sm-4">
+                <PropertyActionButtons handleAddClick={this.handleAddClick}
+                  handleMintUri={this.handleMintUri} key={shortid.generate()} />
+              </section>
+            </div>)
+
             resourceTemplate.propertyTemplates.map((rtProperty) => {
+              let newReduxPath = Object.assign([], rtReduxPath)
+              newReduxPath.push(rtProperty.propertyURI)
+              console.warn(newReduxPath)
               input.push(<PropertyTemplateOutline key={shortid.generate()}
                 propertyTemplate={rtProperty}
+                reduxPath={newReduxPath}
                 resourceTemplate={getResourceTemplate(rtId)} />)
             })
           })
@@ -167,4 +195,10 @@ PropertyTemplateOutline.propTypes = {
   rtId: PropTypes.string
 }
 
-export default PropertyTemplateOutline;
+const mapDispatchToProps = dispatch => ({
+  handleNewResourceTemplate(rt_context) {
+    dispatch(setResourceTemplate(rt_context))
+  }
+})
+
+export default connect(null, mapDispatchToProps)(PropertyTemplateOutline);

--- a/src/components/editor/PropertyTemplateOutline.jsx
+++ b/src/components/editor/PropertyTemplateOutline.jsx
@@ -64,10 +64,16 @@ export class PropertyTemplateOutline extends Component {
 
   handleAddClick = (event) => {
     event.preventDefault()
+    if (this.props.handleAddClick !== undefined) {
+      this.props.handleAddClick(event)
+    }
   }
 
   handleMintUri = (event) => {
     event.preventDefault()
+    if (this.props.handleMintUri !== undefined) {
+      this.props.handleMintUri(event)
+    }
   }
 
   handleClick = (property) => (event) => {
@@ -196,7 +202,7 @@ PropertyTemplateOutline.propTypes = {
   initNewResourceTemplate: PropTypes.func,
   isRequired: PropTypes.func,
   propertyTemplate: PropTypes.object,
-  reduxPath: PropTypes.string,
+  reduxPath: PropTypes.array,
   rtId: PropTypes.string
 }
 

--- a/src/components/editor/PropertyTypeRow.jsx
+++ b/src/components/editor/PropertyTypeRow.jsx
@@ -2,8 +2,6 @@
 
 import React, {Component} from 'react'
 import PropTypes from 'prop-types'
-import PropertyActionButtons from './PropertyActionButtons'
-import { valueTemplateRefTest } from './PropertyTemplateOutline'
 import shortid from 'shortid'
 
 export class PropertyTypeRow extends Component {
@@ -12,25 +10,12 @@ export class PropertyTypeRow extends Component {
     super(props)
   }
 
-  addButtons = () => {
-    if (valueTemplateRefTest(this.props.propertyTemplate)) {
-      return <PropertyActionButtons handleAddClick={this.props.handleAddClick}
-        handleMintUri={this.props.handleMintUri} key={shortid.generate()}/>
-    }
-  }
-
   render() {
-    return(<React.Fragment key={shortid.generate()}>
-      <div className="row">
-        <section className="col-sm-8">
-        {this.props.propertyTemplate.propertyLabel}
-        </section>
-        <section className="col-sm-4">
-          {this.addButtons()}
-        </section>
-      </div>
+    return(
+      <React.Fragment key={shortid.generate()}>
       { this.props.children }
-    </React.Fragment>)
+      </React.Fragment>
+    )
   }
 }
 

--- a/src/components/editor/ResourceTemplateForm.jsx
+++ b/src/components/editor/ResourceTemplateForm.jsx
@@ -156,7 +156,45 @@ class ResourceTemplateForm extends Component {
                                     pt.valueConstraint.useValuesFrom
                                 )
 
-                                let lookupConfigItem, templateUris, listComponent, lookupConfigItems
+                    if (listComponent === 'list'){
+                      return (
+                        <PropertyPanel pt={pt} key={index} rtId={this.props.rtId}>
+                          <InputListLOC propertyTemplate = {pt} lookupConfig = {lookupConfigItem} key = {index} rtId = {this.props.rtId} />
+                        </PropertyPanel>
+                      )
+                    }
+                    else if (listComponent ===  'lookup'){
+                      return(
+                        <PropertyPanel pt={pt} key={index} rtId={this.props.rtId}>
+                          <InputLookupQA propertyTemplate = {pt} lookupConfig = {lookupConfigItem} key = {index} rtId = {this.props.rtId} />
+                        </PropertyPanel>
+                      )
+                    }
+                    else if(pt.type == 'literal'){
+                      return(
+                        <PropertyPanel pt={pt} key={index} rtId={this.props.rtId}>
+                          <InputLiteral key={index} id={index}
+                                        propertyTemplate={pt}
+                                        rtId={this.props.rtId}
+                                        reduxPath={[this.props.rtId, pt.propertyURI]}
+                                       />
+                        </PropertyPanel>
+                      )
+                    }
+                    else if (this.isResourceWithValueTemplateRef(pt)) {
+                      let valueForButton
+                      return (
+                        <PropertyPanel pt={pt} key={index} rtId={this.props.rtId}>
+                            {this.resourceTemplateFields(pt.valueConstraint.valueTemplateRefs, pt.propertyURI)}
+                        </PropertyPanel>
+                        )
+                      }
+                      else if (pt.type == 'resource'){
+                        return (<p key={index}><b>{pt.propertyLabel}</b>: <i>NON-modal resource</i></p>)
+                      }
+                    }
+                  )
+                 }
 
                                 if ( isLookupWithConfig ) {
                                     templateUris = pt.valueConstraint.useValuesFrom;

--- a/src/components/editor/ResourceTemplateForm.jsx
+++ b/src/components/editor/ResourceTemplateForm.jsx
@@ -82,17 +82,21 @@ class ResourceTemplateForm extends Component {
         return content
     }
 
-    // Note: rtIds is expected to be an array of length at least one
-    resourceTemplateFields = ( rtIds ) => {
-        const rtProperties = []
-        rtIds.map(( rtId, i ) => {
-            rtProperties.push( <PropertyResourceTemplate key={shortid.generate()} resourceTemplate={getResourceTemplate( rtId )} /> )
-            if ( ( rtIds.length - i ) > 1 ) {
-                rtProperties.push( <hr key={i} /> )
-            }
-        } )
-        return rtProperties
-    }
+  // Note: rtIds is expected to be an array of length at least one
+  resourceTemplateFields = (rtIds, propUri) => {
+    const rtProperties = []
+    rtIds.map((rtId, i) => {
+      let resourceTemplate = getResourceTemplate(rtId)
+      rtProperties.push(<PropertyResourceTemplate
+        key={shortid.generate()}
+        resourceTemplate={resourceTemplate}
+        reduxPath={[this.props.rtId, propUri, rtId]} />)
+      if ((rtIds.length - i) > 1) {
+        rtProperties.push(<hr key={i} />)
+      }
+    })
+    return rtProperties
+  }
 
     defaultValues = () => {
         this.props.propertyTemplates.map(( pt ) => {

--- a/src/components/editor/ResourceTemplateForm.jsx
+++ b/src/components/editor/ResourceTemplateForm.jsx
@@ -182,7 +182,6 @@ class ResourceTemplateForm extends Component {
                       )
                     }
                     else if (this.isResourceWithValueTemplateRef(pt)) {
-                      let valueForButton
                       return (
                         <PropertyPanel pt={pt} key={index} rtId={this.props.rtId}>
                             {this.resourceTemplateFields(pt.valueConstraint.valueTemplateRefs, pt.propertyURI)}

--- a/src/components/editor/ResourceTemplateForm.jsx
+++ b/src/components/editor/ResourceTemplateForm.jsx
@@ -134,23 +134,7 @@ class ResourceTemplateForm extends Component {
         this.props.handleRemoveAllContent( buttonIndex )
     }
 
-    renderValueForButton( buttonValue, buttonIndex ) {
-        if ( buttonValue != undefined ) {
-            return (
-                <div className="btn-group btn-group-xs">
-                    <button type="button" className="btn btn-sm btn-default">{buttonValue}</button>
-                    <button disabled className="btn btn-warning" type="button">
-                        <span className="glyphicon glyphicon-pencil" />
-                    </button>
-                    <button className="btn btn-danger" type="button" onClick={() => this.handleTrashValue( buttonIndex )}>
-                        <span className="glyphicon glyphicon-trash" />
-                    </button>
-                </div>
-            )
-        }
-    }
-
-    render() {
+  render() {
 
         if ( this.props.propertyTemplates.length === 0 || this.props.propertyTemplates[0] === {} ) {
             return <h1>There are no propertyTemplates - probably an error.</h1>

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -31,8 +31,15 @@ export const getProperty = createSelector(
 )
 
 export const refreshResourceTemplate = (state, action) => {
-  let newState = Object.create(state)
+  let newState = Object.assign({}, state)
   const reduxPath = action.payload.reduxPath
+  console.warn(action.payload)
+  const items = action.payload.defaults || { items: [] }
+  const lastKey = reduxPath.pop()
+  const lastObject = reduxPath.reduce((newState, key) =>
+    newState[key] = newState[key] || {},
+    newState)
+  lastObject[lastKey] = items
   return newState
 }
 

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -9,6 +9,7 @@ import shortid from 'shortid'
 
 const inputPropertySelector = (state, props) => {
   const reduxPath = props.reduxPath
+  console.log(`${props.reduxPath}`)
   let items = reduxPath.reduce((obj, key) =>
     (obj && obj[key] !== 'undefined') ? obj[key] : undefined,
     state.selectorReducer)
@@ -28,18 +29,18 @@ export const getProperty = createSelector(
 export const refreshResourceTemplate = (state, action) => {
   let newState = Object.assign({}, state)
   const reduxPath = action.payload.reduxPath
-  let items
-  // const items = action.payload.defaults || { items: [] }
-  if (action.payload.defaults) {
-    items = action.payload.defaults
-  } else   {
-    items = { items: [] }
-  }
+  const items = action.payload.defaults || { items: [] }
+  // let items
+  // if (action.payload.defaults) {
+  //   items = action.payload.defaults
+  // } else   {
+  //   items = { items: [] }
+  // }
   const lastKey = reduxPath.pop()
   const lastObject = reduxPath.reduce((newState, key) =>
     newState[key] = newState[key] || {},
     newState)
-  lastObject[lastKey] = items
+  lastObject[lastKey] = { items: items }
   return newState
 }
 

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -28,13 +28,11 @@ export const getProperty = createSelector(
 export const refreshResourceTemplate = (state, action) => {
   let newState = Object.assign({}, state)
   const reduxPath = action.payload.reduxPath
+  if (reduxPath === undefined || reduxPath.length < 1) {
+      return newState
+  }
   const items = action.payload.defaults || { items: [] }
-  // let items
-  // if (action.payload.defaults) {
-  //   items = action.payload.defaults
-  // } else   {
-  //   items = { items: [] }
-  // }
+
   const lastKey = reduxPath.pop()
   const lastObject = reduxPath.reduce((newState, key) =>
     newState[key] = newState[key] || {},

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -5,7 +5,7 @@ import { generateLD } from './linkedData'
 import lang from './lang'
 import authenticate from './authenticate'
 import { removeAllContent, setMyItems, removeMyItem } from './literal'
-
+import shortid from 'shortid'
 
 const inputPropertySelector = (state, props) => {
   const reduxPath = props.reduxPath
@@ -28,12 +28,18 @@ export const getProperty = createSelector(
 export const refreshResourceTemplate = (state, action) => {
   let newState = Object.assign({}, state)
   const reduxPath = action.payload.reduxPath
-  const items = action.payload.defaults || { items: [] }
+  let items
+  // const items = action.payload.defaults || { items: [] }
+  if (action.payload.defaults) {
+    items = action.payload.defaults
+  } else   {
+    items = { items: [] }
+  }
   const lastKey = reduxPath.pop()
   const lastObject = reduxPath.reduce((newState, key) =>
     newState[key] = newState[key] || {},
     newState)
-  lastObject[lastKey] = { items: items }
+  lastObject[lastKey] = items
   return newState
 }
 
@@ -47,9 +53,10 @@ export const setResourceTemplate = (state, action) => {
     if (property.valueConstraint.defaults && property.valueConstraint.defaults.length > 0) {
       property.valueConstraint.defaults.forEach((row) => {
         // This items payload needs to vary if type is literal or lookup
+
         output[rtKey][property.propertyURI].items.push(
           {
-            id: output[rtKey][property.propertyURI].items.length,
+            id: shortid.generate(),
             content: row.defaultLiteral,
             uri: row.defaultURI
           }

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -37,7 +37,11 @@ export const refreshResourceTemplate = (state, action) => {
   const lastObject = reduxPath.reduce((newState, key) =>
     newState[key] = newState[key] || {},
     newState)
-  lastObject[lastKey] = { items: items }
+  if (Object.keys(items).includes('items')) {
+    lastObject[lastKey] = items
+  } else {
+    lastObject[lastKey] = { items: items }
+  }
   return newState
 }
 

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -30,7 +30,11 @@ export const getProperty = createSelector(
   }
 )
 
-
+export const refreshResourceTemplate = (state, action) => {
+  let newState = Object.create(state)
+  const reduxPath = action.payload.reduxPath
+  return newState
+}
 
 export const setResourceTemplate = (state, action) => {
   const rtKey = action.payload.id
@@ -67,6 +71,8 @@ const selectorReducer = (state={}, action) => {
       return setResourceTemplate(state, action)
     case 'SET_ITEMS':
       return setMyItems(state, action)
+    case 'REFRESH_RESOURCE_TEMPLATE':
+      return refreshResourceTemplate(state, action)
     case 'REMOVE_ITEM':
       return removeMyItem(state, action)
     case 'REMOVE_ALL_CONTENT':

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -7,14 +7,17 @@ import authenticate from './authenticate'
 import { removeAllContent, setMyItems, removeMyItem } from './literal'
 
 
-const resourceTemplateSelector = (state, props) => {
-
-  const resTemp = state.selectorReducer[props.rtId]
+const inputPropertySelector = (state, props) => {
+  console.log(`In resourceTemplateSelector`)
+  console.warn(props)
+  const reduxPath = props.reduxPath
+  const resTemp = state.selectorReducer[reduxPath[0]]
   if (resTemp == undefined) {
     return state
   }
   let items
   if (props.propertyTemplate.propertyURI in resTemp) {
+  // if (reduxPath[1] in resTemp) {
     items = resTemp[props.propertyTemplate.propertyURI]
   } else {
     items = []
@@ -24,7 +27,7 @@ const resourceTemplateSelector = (state, props) => {
 }
 
 export const getProperty = createSelector(
-  [ resourceTemplateSelector ],
+  [ inputPropertySelector ],
   (propertyURI) => {
     return propertyURI.items
   }
@@ -33,7 +36,6 @@ export const getProperty = createSelector(
 export const refreshResourceTemplate = (state, action) => {
   let newState = Object.assign({}, state)
   const reduxPath = action.payload.reduxPath
-  console.warn(action.payload)
   const items = action.payload.defaults || { items: [] }
   const lastKey = reduxPath.pop()
   const lastObject = reduxPath.reduce((newState, key) =>

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -9,7 +9,6 @@ import shortid from 'shortid'
 
 const inputPropertySelector = (state, props) => {
   const reduxPath = props.reduxPath
-  console.log(`${props.reduxPath}`)
   let items = reduxPath.reduce((obj, key) =>
     (obj && obj[key] !== 'undefined') ? obj[key] : undefined,
     state.selectorReducer)

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -8,20 +8,12 @@ import { removeAllContent, setMyItems, removeMyItem } from './literal'
 
 
 const inputPropertySelector = (state, props) => {
-  console.log(`In resourceTemplateSelector`)
-  console.warn(props)
   const reduxPath = props.reduxPath
-  const resTemp = state.selectorReducer[reduxPath[0]]
-  if (resTemp == undefined) {
-    return state
-  }
-  let items
-  if (props.propertyTemplate.propertyURI in resTemp) {
-  // if (reduxPath[1] in resTemp) {
-    items = resTemp[props.propertyTemplate.propertyURI]
-  } else {
+  let items = reduxPath.reduce((obj, key) =>
+    (obj && obj[key] !== 'undefined') ? obj[key] : undefined,
+    state.selectorReducer)
+  if (items === undefined) {
     items = []
-    resTemp[props.propertyTemplate.propertyURI] = items
   }
   return items
 }
@@ -41,7 +33,7 @@ export const refreshResourceTemplate = (state, action) => {
   const lastObject = reduxPath.reduce((newState, key) =>
     newState[key] = newState[key] || {},
     newState)
-  lastObject[lastKey] = items
+  lastObject[lastKey] = { items: items }
   return newState
 }
 

--- a/src/reducers/literal.js
+++ b/src/reducers/literal.js
@@ -13,6 +13,9 @@ export const setMyItems = (state, action) => {
   reduxPath.reduce((obj, key) => {
     level++
     if (level === reduxPath.length) {
+      if ((key in obj) != true) {
+        obj[key] = { items: [] }
+      }
       action.payload.items.map((row) => {
         obj[key].items.push(row)
       })
@@ -24,8 +27,17 @@ export const setMyItems = (state, action) => {
 
 export const removeMyItem = (state, action) => {
   const newState = Object.assign({}, state)
-  const newItems = newState[action.payload.rtId][action.payload.uri].items.filter(
-    row => row.id != action.payload.id)
-  newState[action.payload.rtId][action.payload.uri].items = newItems
+  const reduxPath = action.payload.reduxPath
+  let level = 0
+  reduxPath.reduce((obj, key) => {
+    level++
+    if (level === reduxPath.length) {
+      console.log(`remove items ${action.payload.id}`)
+      console.warn(obj[key].items)
+      obj[key].items = obj[key].items.filter(
+        row => row.id != action.payload.id)
+    }
+    return obj[key]
+  }, newState)
   return newState
 }

--- a/src/reducers/literal.js
+++ b/src/reducers/literal.js
@@ -8,9 +8,18 @@ export const removeAllContent = (state, action) => {
 
 export const setMyItems = (state, action) => {
   let newState = Object.assign({}, state)
-  action.payload.items.map((row) => {
-    newState[action.payload.rtId][action.payload.uri].items.push(row)
-  })
+  const reduxPath = action.payload.reduxPath
+  let level = 0
+  reduxPath.reduce((obj, key) => {
+    level++
+    console.warn(obj, key)
+    if (level === reduxPath.length) {
+      action.payload.items.map((row) => {
+        obj[key].items.push(row)
+      })
+    }
+    return obj[key]
+  }, newState)
   return newState
 }
 

--- a/src/reducers/literal.js
+++ b/src/reducers/literal.js
@@ -2,7 +2,15 @@
 
 export const removeAllContent = (state, action) => {
   let newState = Object.assign({}, state)
-  newState[action.payload.rtId][action.payload.uri].items = []
+  const reduxPath = action.payload.reduxPath
+  let level = 0
+  reduxPath.reduce((obj, key) => {
+    level++
+    if (level === reduxPath.length) {
+      obj[key].items = []
+    }
+    return obj[key]
+  }, newState)
   return newState
 }
 
@@ -32,8 +40,6 @@ export const removeMyItem = (state, action) => {
   reduxPath.reduce((obj, key) => {
     level++
     if (level === reduxPath.length) {
-      console.log(`remove items ${action.payload.id}`)
-      console.warn(obj[key].items)
       obj[key].items = obj[key].items.filter(
         row => row.id != action.payload.id)
     }

--- a/src/reducers/literal.js
+++ b/src/reducers/literal.js
@@ -12,7 +12,6 @@ export const setMyItems = (state, action) => {
   let level = 0
   reduxPath.reduce((obj, key) => {
     level++
-    console.warn(obj, key)
     if (level === reduxPath.length) {
       action.payload.items.map((row) => {
         obj[key].items.push(row)

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -88,11 +88,12 @@ body {
   border: 1px dotted;
   background-color: white;
   margin: .5em;
+  padding: .25em;
 }
 
-.rOutline-property div {
-  padding: .5em;
-}
+/* .rOutline-property div {
+  padding-left: .5em;
+} */
 
 .arrow-icon{
   color: white;


### PR DESCRIPTION
PR uses the structure of the Resource Template as a data-structure that stores the state of `InputLiteral` anywhere in the User Interface. This example shows the default value of _DLC_ in a multiple-layer deep embedded resource template:

<img width="522" alt="Screen Shot 2019-04-01 at 9 59 52 AM" src="https://user-images.githubusercontent.com/71847/55342011-a0064280-545c-11e9-99b4-6a8f42519caf.png">
 
Todos:
- [x] Add reduxPath reduce function to the Remove Item reducer
- [x] ~~Support Redux defaults for `InputLookupQA` and `InputListLOC` components~~ moving this out of this PR, this PR establishes the pattern to use Redux for both of these components.
- [x] ~~Start integration test for Milestone 3~~ Issue [421](https://github.com/LD4P/sinopia_editor/issues/421) should capture the start of integration testing for the Editor.