### PR TITLE
Resourcelabel 393

### DIFF
--- a/__tests__/components/editor/Editor.test.js
+++ b/__tests__/components/editor/Editor.test.js
@@ -28,10 +28,6 @@ describe('<Editor />', () => {
       expect(wrapper.find(Header).length).toBe(1)
     })
 
-    it('shows resource title', () => {
-      expect(wrapper.find('div#editor > div > section > h1').text()).toMatch('[Clone|Edit] Name of Resource')
-    })
-
     it('renders a Preview RDF button', () =>{
             expect(wrapper
               .find('div > div > section > button.btn-primary').length)

--- a/__tests__/components/editor/Editor.test.js
+++ b/__tests__/components/editor/Editor.test.js
@@ -28,12 +28,6 @@ describe('<Editor />', () => {
       expect(wrapper.find(Header).length).toBe(1)
     })
 
-    it('renders a Preview RDF button', () =>{
-            expect(wrapper
-              .find('div > div > section > button.btn-primary').length)
-              .toEqual(1)
-    })
-
     it('displays an login warning message', () => {
       expect(wrapper.find('div.alert-warning').text()).toMatch('Alert! No data can be saved unless you are logged in with group permissions.')
     })

--- a/__tests__/components/editor/ResourceTemplate.test.js
+++ b/__tests__/components/editor/ResourceTemplate.test.js
@@ -10,6 +10,9 @@ describe('<ResourceTemplate />', () => {
   const wrapper = shallow(<ResourceTemplate.WrappedComponent
     resourceTemplateId='resourceTemplate:bf2:Monograph:Instance'
     handleResourceTemplate={mockHandleResourceTemplate} />)
+	it('shows resource title', () => {
+	  expect(wrapper.find('section > h1').text()).toMatch('[Clone|Edit] BIBFRAME Instance')
+	})
 
   it('has div with class "ResourceTemplate"', () => {
     expect(wrapper.find('div.ResourceTemplate').length).toEqual(1)

--- a/__tests__/components/editor/ResourceTemplate.test.js
+++ b/__tests__/components/editor/ResourceTemplate.test.js
@@ -10,7 +10,14 @@ describe('<ResourceTemplate />', () => {
   const wrapper = shallow(<ResourceTemplate.WrappedComponent
     resourceTemplateId='resourceTemplate:bf2:Monograph:Instance'
     handleResourceTemplate={mockHandleResourceTemplate} />)
-	it('shows resource title', () => {
+	
+  it('renders a Preview RDF button', () =>{
+      expect(wrapper
+        .find('div > div > section > button.btn-primary').length)
+        .toEqual(1)
+  })
+
+  it('shows resource title', () => {
 	  expect(wrapper.find('section > h1').text()).toMatch('[Clone|Edit] BIBFRAME Instance')
 	})
 

--- a/src/components/editor/Editor.jsx
+++ b/src/components/editor/Editor.jsx
@@ -6,7 +6,6 @@ import { removeAllItems, logIn } from '../../actions/index'
 import { Link } from 'react-router-dom'
 import PropTypes from 'prop-types'
 import ResourceTemplate from './ResourceTemplate'
-import RDFModal from './RDFModal'
 import Header from './Header'
 import { loadState } from '../../localStorage'
 
@@ -49,17 +48,6 @@ class Editor extends Component {
       <div id="editor">
         <Header triggerEditorMenu={this.props.triggerHandleOffsetMenu}/>
         { authenticationMessage }
-        <div className="row">
-          <section className="col-md-3 pull-right">
-            <button type="button" className="btn btn-primary btn-sm">Preview RDF</button>
-          </section>
-        </div>
-        <div>
-            <RDFModal show={this.state.showRdf}
-                      close={this.rdfClose}
-                      rtId={this.props.rtId}
-                      linkedData={ JSON.stringify(this.props.generateLD) }/>
-        </div>
         <ResourceTemplate
           resourceTemplateId = {this.props.resourceTemplateId}
           resourceTemplateData = {this.state.resourceTemplateData}
@@ -71,7 +59,6 @@ class Editor extends Component {
 
 Editor.propTypes = {
   children: PropTypes.array,
-  generateLD: PropTypes.func,
   rtId: PropTypes.string,
   triggerHandleOffsetMenu: PropTypes.func,
   resetStore: PropTypes.func,

--- a/src/components/editor/Editor.jsx
+++ b/src/components/editor/Editor.jsx
@@ -15,8 +15,15 @@ class Editor extends Component {
     super(props)
     this.state = {
       tempRtState: true,
-      userAuthenticated: false
+      userAuthenticated: false,
+      resourceName: 'Default Name of Resource'
     }
+  }
+  
+  //Set state in response to changes to selection of resource template
+  
+  updateTemplateInfo = ( resourceName ) => {
+      this.setState({resourceName: resourceName});
   }
 
   render() {
@@ -52,7 +59,7 @@ class Editor extends Component {
         <div className="row">
           <section className="col-md-9">
             <h3>Resource Template Label</h3>
-            <h1>[Clone|Edit] <em>Name of Resource</em></h1>
+            <h1>[Clone|Edit] <em>{this.state.resourceName}</em></h1>
           </section>
           <section className="col-md-3">
             <button type="button" className="btn btn-primary btn-sm">Preview RDF</button>
@@ -67,6 +74,7 @@ class Editor extends Component {
         <ResourceTemplate
           resourceTemplateId = {this.props.resourceTemplateId}
           resourceTemplateData = {this.state.resourceTemplateData}
+          updateTemplateInfo ={this.updateTemplateInfo} 
         />
       </div>
     )

--- a/src/components/editor/Editor.jsx
+++ b/src/components/editor/Editor.jsx
@@ -15,16 +15,9 @@ class Editor extends Component {
     super(props)
     this.state = {
       tempRtState: true,
-      userAuthenticated: false,
-      resourceName: 'Default Name of Resource'
-    }
+      userAuthenticated: false
   }
-  
-  //Set state in response to changes to selection of resource template
-  
-  updateTemplateInfo = ( resourceName ) => {
-      this.setState({resourceName: resourceName});
-  }
+}
 
   render() {
     let authenticationMessage = <div className="alert alert-warning alert-dismissible">
@@ -57,11 +50,7 @@ class Editor extends Component {
         <Header triggerEditorMenu={this.props.triggerHandleOffsetMenu}/>
         { authenticationMessage }
         <div className="row">
-          <section className="col-md-9">
-            <h3>Resource Template Label</h3>
-            <h1>[Clone|Edit] <em>{this.state.resourceName}</em></h1>
-          </section>
-          <section className="col-md-3">
+          <section className="col-md-3 pull-right">
             <button type="button" className="btn btn-primary btn-sm">Preview RDF</button>
           </section>
         </div>
@@ -74,7 +63,6 @@ class Editor extends Component {
         <ResourceTemplate
           resourceTemplateId = {this.props.resourceTemplateId}
           resourceTemplateData = {this.state.resourceTemplateData}
-          updateTemplateInfo ={this.updateTemplateInfo} 
         />
       </div>
     )

--- a/src/components/editor/ResourceTemplate.jsx
+++ b/src/components/editor/ResourceTemplate.jsx
@@ -36,13 +36,19 @@ class ResourceTemplate extends Component {
 
     const rtData = resourceTemplateData(this.props.resourceTemplateData)
 
-
+    //TODO: Make rt not an array and just a single element.  You. Shall. Not. Pass.
     return (
       <div>
         {rtData.map((rt, index) => {
           this.props.handleResourceTemplate(rt)
-          this.props.updateTemplateInfo(rt["resourceLabel"])
-          return(
+          return(    
+            <div>
+              <div className='row'> 
+                  <section className='col-md-9'>
+                      <h3>{rt.resourceURI}</h3>
+                      <h1>[Clone|Edit] <em>{rt.resourceLabel}</em></h1>
+                  </section>
+            </div>   
             <div className='ResourceTemplate' key={index}>
               <div id="resourceTemplate">
                   <ResourceTemplateForm
@@ -52,6 +58,7 @@ class ResourceTemplate extends Component {
                     rtId = {rt.id}
                   />
               </div>
+            </div>
             </div>
           )
         })}

--- a/src/components/editor/ResourceTemplate.jsx
+++ b/src/components/editor/ResourceTemplate.jsx
@@ -64,7 +64,7 @@ class ResourceTemplate extends Component {
             <div>
                 <RDFModal show={this.state.showRdf}
                           close={this.rdfClose}
-                          rtId={this.props.rtId}
+                          rtId={rt.id}
                           linkedData={ JSON.stringify(this.props.generateLD) }/>
             </div>                       
             <div className='ResourceTemplate' key={index}>
@@ -89,8 +89,7 @@ ResourceTemplate.propTypes = {
   handleResourceTemplate: PropTypes.func,
   resourceTemplateId: PropTypes.string,
   resourceTemplateData: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
-  generateLD: PropTypes.func,
-  rtId: PropTypes.string
+  generateLD: PropTypes.func
 }
 
 const mapDispatchToProps = dispatch => ({

--- a/src/components/editor/ResourceTemplate.jsx
+++ b/src/components/editor/ResourceTemplate.jsx
@@ -41,6 +41,7 @@ class ResourceTemplate extends Component {
       <div>
         {rtData.map((rt, index) => {
           this.props.handleResourceTemplate(rt)
+          this.props.updateTemplateInfo(rt["resourceLabel"])
           return(
             <div className='ResourceTemplate' key={index}>
               <div id="resourceTemplate">

--- a/src/components/editor/ResourceTemplate.jsx
+++ b/src/components/editor/ResourceTemplate.jsx
@@ -89,7 +89,8 @@ ResourceTemplate.propTypes = {
   handleResourceTemplate: PropTypes.func,
   resourceTemplateId: PropTypes.string,
   resourceTemplateData: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
-  generateLD: PropTypes.func
+  generateLD: PropTypes.func,
+  rtId: PropTypes.string
 }
 
 const mapDispatchToProps = dispatch => ({

--- a/src/components/editor/ResourceTemplate.jsx
+++ b/src/components/editor/ResourceTemplate.jsx
@@ -40,9 +40,10 @@ class ResourceTemplate extends Component {
     return (
       <div>
         {rtData.map((rt, index) => {
-          this.props.handleResourceTemplate(rt)
+          this.props.handleResourceTemplate(rt);
+          let headingKey = "label-" + index;
           return(    
-            <div>
+            <div key={headingKey}>
               <div className='row'> 
                   <section className='col-md-9'>
                       <h3>{rt.resourceURI}</h3>

--- a/src/components/editor/ResourceTemplate.jsx
+++ b/src/components/editor/ResourceTemplate.jsx
@@ -6,9 +6,17 @@ import ResourceTemplateForm from './ResourceTemplateForm'
 import { setResourceTemplate } from '../../actions/index'
 import { getResourceTemplate } from '../../sinopiaServer'
 import PropTypes from 'prop-types'
+import RDFModal from './RDFModal'
 
 class ResourceTemplate extends Component {
 
+    constructor(props) {
+        super(props)
+        this.state = {
+            showRdf: false //this may not belong here but inserted constructor
+            //and variable to enable this.state.showRdf to exist
+      }
+    }
   render () {
 
     const resourceTemplateData = (rtd) => {
@@ -41,15 +49,24 @@ class ResourceTemplate extends Component {
       <div>
         {rtData.map((rt, index) => {
           this.props.handleResourceTemplate(rt);
-          let headingKey = "label-" + index;
+          let headingKey = "heading-" + index;
           return(    
-            <div key={headingKey}>
-              <div className='row'> 
-                  <section className='col-md-9'>
-                      <h3>{rt.resourceURI}</h3>
-                      <h1>[Clone|Edit] <em>{rt.resourceLabel}</em></h1>
-                  </section>
-            </div>   
+          <div key={headingKey}>
+            <div className="row">
+                <section className="col-md-9">
+                    <h3>{rt.resourceURI}</h3>
+                    <h1>[Clone|Edit] <em>{rt.resourceLabel}</em></h1>
+                </section>
+                <section className="col-md-3">
+                        <button type="button" className="btn btn-primary btn-sm">Preview RDF</button>
+                </section>
+            </div>
+            <div>
+                <RDFModal show={this.state.showRdf}
+                          close={this.rdfClose}
+                          rtId={this.props.rtId}
+                          linkedData={ JSON.stringify(this.props.generateLD) }/>
+            </div>                       
             <div className='ResourceTemplate' key={index}>
               <div id="resourceTemplate">
                   <ResourceTemplateForm
@@ -60,7 +77,7 @@ class ResourceTemplate extends Component {
                   />
               </div>
             </div>
-            </div>
+        </div>
           )
         })}
       </div>
@@ -71,7 +88,8 @@ class ResourceTemplate extends Component {
 ResourceTemplate.propTypes = {
   handleResourceTemplate: PropTypes.func,
   resourceTemplateId: PropTypes.string,
-  resourceTemplateData: PropTypes.oneOfType([PropTypes.string, PropTypes.object])
+  resourceTemplateData: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+  generateLD: PropTypes.func
 }
 
 const mapDispatchToProps = dispatch => ({


### PR DESCRIPTION
Shifted the code around that seemed specific to the resource template (i.e. the resource template ID/URI and label) to the resource template component.  At first, I had the preview RDF button still in the Editor component but moved the entire section with that and RDF Modal into ResourceTemplate.  Added a constructor to ResourceTemplate just so it can have state and showRDF (notice these are set in ResourceTemplateForm).  

The placement of preview rdf should match the original, but the label and URI are now being retrieved from the resource template data.

Tests have been updated to reflect shifting of content across components.  