### PR TITLE
sending multiple lookup config items array to input qa

### DIFF
--- a/__tests__/components/editor/PropertyTemplateOutline.test.js
+++ b/__tests__/components/editor/PropertyTemplateOutline.test.js
@@ -8,7 +8,7 @@ import InputListLOC from '../../../src/components/editor/InputListLOC'
 import InputLookupQA from '../../../src/components/editor/InputLookupQA'
 import OutlineHeader from '../../../src/components/editor/OutlineHeader'
 import PropertyActionButtons from '../../../src/components/editor/PropertyActionButtons'
-import { getLookupConfigItem, PropertyTemplateOutline } from '../../../src/components/editor/PropertyTemplateOutline'
+import { getLookupConfigItem, getLookupConfigItems, getLookupConfigForTemplateUri, PropertyTemplateOutline } from '../../../src/components/editor/PropertyTemplateOutline'
 import PropertyTypeRow from '../../../src/components/editor/PropertyTypeRow'
 
 describe('getLookupConfigItem module function', () => {
@@ -181,5 +181,43 @@ describe('<PropertyTemplateOutline /> with propertyTemplate Refs', () => {
     mintButton.simulate('click')
     expect(mockHandleMintUri.mock.calls.length).toBe(1)
   })
+  //Adding tests for assessing new methods added
+  describe('Multiple lookup configs can be retrieved and returned', () => {
+const property = {   
+	propertyTemplate : {
+		"mandatory": "true",
+		"repeatable": "true",
+		"type": "lookup",
+		"resourceTemplates": [],
+		"valueConstraint": {
+		  "valueTemplateRefs": [],
+		  "useValuesFrom": [
+		"urn:ld4p:qa:names:person",
+		"urn:ld4p:qa:subjects:person"
+		  ],
+		  "valueDataType": {
+		"dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Agent"
+		  },
+		  "defaults": []
+		},
+		"propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
+		"propertyLabel": "LOC Names: locnames_ld4l_cache/person",
+		"remark": "http://id.loc.gov/authorities/names.html" 
+	}
+}
+
+  const wrapper = shallow(<PropertyTemplateOutline {...property} />)
+  const childPropertyTemplateOutline = wrapper.find(PropertyTemplateOutline)
+  //For specific template uri, should return the configuration matching
+  const templateUri = "urn:ld4p:qa:names:person";
+  it('template uri for person returns appropriate config', () => {
+	  expect(getLookupConfigForTemplateUri(templateUri).value.uri).toBe(templateUri)
+  })
+  
+   it('multiple use values from should return the same number of configurations', () => {
+	  expect(getLookupConfigItems(property.propertyTemplate).length).toBe(2)
+  })
+  
+})
 
 })

--- a/__tests__/components/editor/PropertyTemplateOutline.test.js
+++ b/__tests__/components/editor/PropertyTemplateOutline.test.js
@@ -183,28 +183,28 @@ describe('<PropertyTemplateOutline /> with propertyTemplate Refs', () => {
   })
   //Adding tests for assessing new methods added
   describe('Multiple lookup configs can be retrieved and returned', () => {
-const property = {   
-	propertyTemplate : {
-		"mandatory": "true",
-		"repeatable": "true",
-		"type": "lookup",
-		"resourceTemplates": [],
-		"valueConstraint": {
-		  "valueTemplateRefs": [],
-		  "useValuesFrom": [
-		"urn:ld4p:qa:names:person",
-		"urn:ld4p:qa:subjects:person"
-		  ],
-		  "valueDataType": {
-		"dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Agent"
-		  },
-		  "defaults": []
-		},
-		"propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
-		"propertyLabel": "LOC Names: locnames_ld4l_cache/person",
-		"remark": "http://id.loc.gov/authorities/names.html" 
+	const property = {   
+		propertyTemplate : {
+			"mandatory": "true",
+			"repeatable": "true",
+			"type": "lookup",
+			"resourceTemplates": [],
+			"valueConstraint": {
+			  "valueTemplateRefs": [],
+			  "useValuesFrom": [
+			"urn:ld4p:qa:names:person",
+			"urn:ld4p:qa:subjects:person"
+			  ],
+			  "valueDataType": {
+			"dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Agent"
+			  },
+			  "defaults": []
+			},
+			"propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
+			"propertyLabel": "LOC Names: locnames_ld4l_cache/person",
+			"remark": "http://id.loc.gov/authorities/names.html" 
+		}
 	}
-}
 
   const wrapper = shallow(<PropertyTemplateOutline {...property} />)
   const childPropertyTemplateOutline = wrapper.find(PropertyTemplateOutline)

--- a/src/components/editor/PropertyTemplateOutline.jsx
+++ b/src/components/editor/PropertyTemplateOutline.jsx
@@ -43,8 +43,8 @@ export const getLookupConfigItems = (property) => {
     let templateConfigItems = [];
     templateUris.forEach(templateUri => {
         let configItem = getLookupConfigForTemplateUri(templateUri);
-        if(configItem != null)         
-            templateConfigItems.push(configItem);
+        //TODO: Handle when this is undefined?
+        templateConfigItems.push(configItem);
     });
     return templateConfigItems;
 }

--- a/src/components/editor/PropertyTemplateOutline.jsx
+++ b/src/components/editor/PropertyTemplateOutline.jsx
@@ -18,15 +18,35 @@ export const valueTemplateRefTest = (property) => {
    property.valueConstraint.valueTemplateRefs.length > 0)
 }
 
+
+export const getLookupConfigForTemplateUri = (templateUri) => {
+    let returnConfigItem
+    lookupConfig.forEach((configItem) => {
+        if (configItem.uri === templateUri) {
+            returnConfigItem = configItem;
+        }
+    })
+    return {value: returnConfigItem};
+}
+
+//This method is used for input list loc below, with just one lookup config passed back
+// in {value : configItem } format
 export const getLookupConfigItem = (property) => {
-  let templateUri = property.valueConstraint.useValuesFrom[0]
-  let templateConfigItem
-  lookupConfig.forEach((configItem) => {
-    if (configItem.uri === templateUri) {
-      templateConfigItem = { value: configItem }
-    }
-  })
-  return templateConfigItem
+  let templateUri = property.valueConstraint.useValuesFrom[0];
+  let configItem = getLookupConfigForTemplateUri(templateUri);
+  return configItem
+}
+
+export const getLookupConfigItems = (property) => {
+    //More than one value possible so this returns all the lookup configs associated with property
+    let templateUris = property.valueConstraint.useValuesFrom;
+    let templateConfigItems = [];
+    templateUris.forEach(templateUri => {
+        let configItem = getLookupConfigForTemplateUri(templateUri);
+        if(configItem != null)         
+            templateConfigItems.push(configItem);
+    });
+    return templateConfigItems;
 }
 
 export class PropertyTemplateOutline extends Component {
@@ -51,7 +71,7 @@ export class PropertyTemplateOutline extends Component {
     event.preventDefault()
     let newOutput = this.state.output
     let input
-    let lookupConfigItem
+    let lookupConfigItem, lookupConfigItems
     switch (property.type) {
       case "literal":
         input = <InputLiteral id={this.props.count}
@@ -61,9 +81,9 @@ export class PropertyTemplateOutline extends Component {
         break;
 
       case "lookup":
-        lookupConfigItem = getLookupConfigItem(property)
-        input = <InputLookupQA propertyTemplate={property}
-             lookupConfig={lookupConfigItem}
+        lookupConfigItems = getLookupConfigItems(property);
+        input = <InputLookupQA propertyTemplate={property} 
+             lookupConfig={lookupConfigItems}
              rtId = {property.rtId} />
         break;
 


### PR DESCRIPTION
Updating PropertyTemplateOutline to retrieve and send array of lookup config items (instead of just the first one) to the input lookup qa component as expected.  Function for getting just the first lookup (for input list loc) and all lookup configs both employ shared code for retrieving lookup configuration based on a template uri. 