### PR TITLE
Update schema version info message when importing a new RT/profile

### DIFF
--- a/__tests__/integration/schemaValidation.test.js
+++ b/__tests__/integration/schemaValidation.test.js
@@ -58,7 +58,7 @@ describe('Editor', () => {
           // const dialog = await pupExpect(page).toDisplayDialog(async () => {
           //   await fileInput.uploadFile("__tests__/__fixtures__/lcc_v0.0.2.json")
           // })
-          const exp_msg = "No schema url found in template. Using https://ld4p.github.io/sinopia/schemas/0.0.1/resource-template.json"
+          const exp_msg = `No schema url found in template. Using https://ld4p.github.io/sinopia/schemas/${Config.defaultProfileSchemaVersion}/resource-template.json`
           // await expect(dialog.message()).toMatch(exp_msg)
           // await dialog.dismiss()
           // await pupExpect(page).toMatch('LC Classification Number')
@@ -74,7 +74,7 @@ describe('Editor', () => {
           // const dialog = await pupExpect(page).toDisplayDialog(async () => {
           //   await fileInput.uploadFile("__tests__/__fixtures__/place_profile_v0.0.2.json")
           // })
-          const exp_msg = "No schema url found in template. Using https://ld4p.github.io/sinopia/schemas/0.0.1/profile.json"
+          const exp_msg = `No schema url found in template. Using https://ld4p.github.io/sinopia/schemas/${Config.defaultProfileSchemaVersion}/profile.json`
           // await expect(dialog.message()).toMatch(exp_msg)
           // await dialog.dismiss()
           // await pupExpect(page).toMatch('Place Associated with a Work')

--- a/src/Config.js
+++ b/src/Config.js
@@ -1,4 +1,8 @@
 class Config {
+  static get defaultProfileSchemaVersion() {
+    return process.env.DEFAULT_PROFILE_SCHEMA_VERSION || '0.0.9'
+  }
+
   static get sinopiaDomainName() {
     return process.env.SINOPIA_URI || 'sinopia.io'
   }

--- a/src/components/editor/ImportFileZone.jsx
+++ b/src/components/editor/ImportFileZone.jsx
@@ -1,5 +1,6 @@
 // Copyright 2018 Stanford University see Apache2.txt for license
 
+import Config from '../../Config'
 import React, { Component }  from 'react'
 import Dropzone from 'react-dropzone'
 import PropTypes from 'prop-types'
@@ -34,9 +35,9 @@ class ImportFileZone extends Component {
         var schemaUrl = template.schema || (template.Profile && template.Profile.schema)
         if (schemaUrl == undefined) {
           if (template.Profile) {
-            schemaUrl = "https://ld4p.github.io/sinopia/schemas/0.0.1/profile.json"
+            schemaUrl = `https://ld4p.github.io/sinopia/schemas/${Config.defaultProfileSchemaVersion}/profile.json`
           } else {
-            schemaUrl = "https://ld4p.github.io/sinopia/schemas/0.0.1/resource-template.json"
+            schemaUrl = `https://ld4p.github.io/sinopia/schemas/${Config.defaultProfileSchemaVersion}/resource-template.json`
           }
           alert(`No schema url found in template. Using ${schemaUrl}`)
         }


### PR DESCRIPTION
Fixes #396

This introduces a new env-overrideable config variable setting the default RT/Profile schema version. 

~~Note that I was unable to determine whether 0.0.9 is the right default for now. #396 specifies 0.0.9 so that is what I went with, but 0.1.0 seems to be the newest version available~~ I... *think* I confirmed on Slack this morning that 0.0.9 is the right default for the time being.

~~FWIW, I attempted to upload a few seemingly valid 0.1.0 and 0.0.9 profiles and I was unable to get *any* to validate. I am not sure whether that should be in scope for this issue but I would at least like to understand why this is the case.~~ Confirmed with @michelleif that https://github.com/LD4P/sinopia_sample_profiles/blob/master/configuration_demo/SinopiaConfigurationDemo.json is the most reliable profile to test, and I can confirm it validates in this branch.