### PR TITLE
PropertyPanel Support for property.repeatable 

### DIFF
--- a/__tests__/components/editor/PropertyActionButtons.test.js
+++ b/__tests__/components/editor/PropertyActionButtons.test.js
@@ -3,17 +3,37 @@
 import React from 'react'
 import { shallow } from 'enzyme'
 
-import PropertyActionButtons from '../../../src/components/editor/PropertyActionButtons'
+import { AddButton, MintButton, PropertyActionButtons } from '../../../src/components/editor/PropertyActionButtons'
+
+describe('<AddButton />', () => {
+  const add_btn_wrapper = shallow(<AddButton />)
+
+  it('renders an active button with a label', () => {
+    expect(add_btn_wrapper.instance().state.disabled).toBeFalsy()
+  })
+})
+
+describe('<MintButton />', () => {
+
+  const mint_btn_wrapper = shallow(<MintButton />)
+
+  it('renders an disabled button with a label', () => {
+    console.log(mint_btn_wrapper.debug())
+    expect(mint_btn_wrapper.instance().state.disabled).toBeTruthy()
+  })
+
+})
 
 describe('<PropertyActionButtons />', () => {
 
   const wrapper = shallow(<PropertyActionButtons />)
-  const buttons = wrapper.find('button')
 
   it('has two buttons', () => {
-    expect(buttons.length).toEqual(2)
-    expect(buttons.find('.btn-default')).toBeTruthy()
-    expect(buttons.find('.btn-success')).toBeTruthy()
+    expect(wrapper.find(AddButton)).toBeTruthy()
+    expect(wrapper.find(MintButton)).toBeTruthy()
   })
 
+  describe('when propertyTemplate.repeatable is false', () => {
+      // const disabled_wrapper = shallow(<)
+  })
 })

--- a/__tests__/components/editor/PropertyTemplateOutline.test.js
+++ b/__tests__/components/editor/PropertyTemplateOutline.test.js
@@ -175,20 +175,21 @@ describe('<PropertyTemplateOutline /> with propertyTemplate Refs', () => {
   })
 
   it('handles "Add" button click', () => {
-    const addButton = wrapper.find('div > section > PropertyActionButtons > div > button.btn-default')
+    const addButton = wrapper.find('div > section > PropertyActionButtons > div > AddButton')
     addButton.handleClick = mockHandleAddClick
     addButton.simulate('click')
     expect(mockHandleAddClick.mock.calls.length).toBe(1)
   })
 
-  it('handles "Mint URI" button click', () => {
-    const mintButton = wrapper.find('div > section > PropertyActionButtons > div > button.btn-success')
-    mintButton.simulate('click')
-    expect(mockHandleMintUri.mock.calls.length).toBe(1)
+  it('the "Mint URI" button is disabled', () => {
+    const mintButton = wrapper.find('div > section > PropertyActionButtons > div > MintButton')
+    console.log(mintButton.debug())
+    // mintButton.simulate('click')
+    // expect(mockHandleMintUri.mock.calls.length).toBe(1)
   })
   //Adding tests for assessing new methods added
   describe('Multiple lookup configs can be retrieved and returned', () => {
-	const property = {   
+	const property = {
 		propertyTemplate : {
 			"mandatory": "true",
 			"repeatable": "true",
@@ -207,7 +208,7 @@ describe('<PropertyTemplateOutline /> with propertyTemplate Refs', () => {
 			},
 			"propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
 			"propertyLabel": "LOC Names: locnames_ld4l_cache/person",
-			"remark": "http://id.loc.gov/authorities/names.html" 
+			"remark": "http://id.loc.gov/authorities/names.html"
 		}
 	}
 
@@ -218,11 +219,11 @@ describe('<PropertyTemplateOutline /> with propertyTemplate Refs', () => {
   it('template uri for person returns appropriate config', () => {
 	  expect(getLookupConfigForTemplateUri(templateUri).value.uri).toBe(templateUri)
   })
-  
+
    it('multiple use values from should return the same number of configurations', () => {
 	  expect(getLookupConfigItems(property.propertyTemplate).length).toBe(2)
   })
-  
+
 })
 
 })

--- a/src/components/editor/PropertyActionButtons.jsx
+++ b/src/components/editor/PropertyActionButtons.jsx
@@ -3,6 +3,38 @@
 import React, {Component} from 'react'
 import PropTypes from 'prop-types'
 
+export class AddButton extends Component {
+
+  constructor(props) {
+    super(props)
+    this.state = {
+      disabled: false
+    }
+  }
+
+  render() {
+    return(<button className="btn btn-default btn-sm"
+            onClick={this.props.onClick}
+            disabled={this.state.disabled}>Add</button>)
+  }
+}
+
+export class MintButton extends Component {
+
+  constructor(props) {
+    super(props)
+    this.state = {
+      disabled: true
+    }
+  }
+
+  render() {
+    return(<button onClick={this.props.onClick}
+                   disabled={this.state.disabled}
+                   className="btn btn-success btn-sm">Mint URI</button>)
+  }
+}
+
 export class PropertyActionButtons extends Component {
 
   constructor(props) {
@@ -11,10 +43,18 @@ export class PropertyActionButtons extends Component {
 
   render() {
     return(<div className="btn-group" role="group" aria-label="...">
-      <button onClick={this.props.handleMintUri} className="btn btn-success btn-sm">Mint URI</button>
-      <button className="btn btn-default btn-sm" onClick={this.props.handleAddClick}>Add</button>
+      <MintButton onClick={this.props.handleMintUri} />
+      <AddButton onClick={this.props.handleAddClick} />
     </div>)
   }
+}
+
+AddButton.propTypes = {
+  onClick: PropTypes.func
+}
+
+MintButton.propTypes = {
+  onClick: PropTypes.func
 }
 
 PropertyActionButtons.propTypes = {


### PR DESCRIPTION
Draft PR for supporting repeatable property in the propertyTemplate for type=resource.

## Commits:
* 6ce7f7df5cd03797fa9033720b554ff70edbbd69 New `AddButton` and `MintButton` components with tests 

Would close these issues:
*  #387  
* #346 
