### PR TITLE
Update resources and warn users

### DIFF
--- a/__tests__/components/editor/SinopiaResourceTemplates.test.js
+++ b/__tests__/components/editor/SinopiaResourceTemplates.test.js
@@ -49,17 +49,19 @@ describe('<SinopiaResourceTemplates />', () => {
     it('sets the state with group data (as Array) from sinopia_server', async() => {
 
       const promise = Promise.resolve(mockResponse(200, null, bodyContains))
-      const wrapper2 = shallow(<SinopiaResourceTemplates message={message}/>)
+      const wrapper2 = shallow(<SinopiaResourceTemplates message={message} />)
       await wrapper2.instance().fulfillGroupPromise(promise).then(() => wrapper2.update()).then(() => {
         expect(wrapper2.state('groupData')).toEqual(['ld4p', 'pcc'])
+        expect(resourceToName).toHaveBeenCalled()
       }).catch(e => {})
     })
 
     it('sets a message if there is no server response', async() => {
       const promise = Promise.resolve(mockResponse(200, null, undefined))
-      const wrapper2 = shallow(<SinopiaResourceTemplates message={message}/>)
+      const wrapper2 = shallow(<SinopiaResourceTemplates message={message} />)
       await wrapper2.instance().fulfillGroupPromise(promise).then(() => wrapper2.update()).then(() => {
         expect(wrapper2.state('message')).toBeTruthy()
+        expect(resourceToName).toHaveBeenCalled()
       }).catch(e => {})
     })
 

--- a/__tests__/components/editor/UpdateResourceModal.test.js
+++ b/__tests__/components/editor/UpdateResourceModal.test.js
@@ -1,0 +1,89 @@
+import 'jsdom-global/register'
+import React from 'react'
+import { shallow } from 'enzyme'
+import Modal from 'react-bootstrap/lib/Modal'
+import Button from 'react-bootstrap/lib/Button'
+import UpdateResourceModal from '../../../src/components/editor/UpdateResourceModal'
+
+describe('<UpdateResourceModal> with conflict message', () => {
+
+  const messages = [{
+    "req": {
+      "method":"POST",
+      "url":"http://localhost:8080/repository/ld4p",
+      "_data": {
+        "propertyTemplates":[
+          { "mandatory":"true",
+            "repeatable":"false",
+            "type":"literal",
+            "propertyURI":"http://id.loc.gov/ontologies/bibframe/classificationPortion",
+            "propertyLabel":"LC Classification Number 2"
+          }
+        ],
+        "id":"sinopia:resourceTemplate:bf2:LCC",
+        "resourceLabel":"Library of Congress Classification 2",
+        "resourceURI":"http://id.loc.gov/ontologies/bibframe/ClassificationLcc",
+        "date":"2019-04-19",
+        "author":"NDMSO",
+        "schema":"https://ld4p.github.io/sinopia/schemas/0.1.0/resource-template.json"
+      },
+    },
+    "statusText":"Conflict",
+    "statusCode":409,
+    "status":409
+  }]
+
+  const mockUpdate = jest.fn()
+  const mockClose = jest.fn()
+  const wrapper = shallow(<UpdateResourceModal show={true} close={mockClose} message={messages} update={mockUpdate} />)
+  wrapper.update()
+
+  it('renders the component as a Modal', () => {
+    expect(wrapper.find(Modal).length).toBe(1)
+  })
+
+  it('has a modal title with the status text and template id', () => {
+    expect(wrapper.find(Modal.Title).dive().text()).toEqual('sinopia:resourceTemplate:bf2:LCC already exisits')
+  })
+
+  it('has a modal body with a question', () => {
+    expect(wrapper.find(Modal.Body).dive().text()).toEqual('Do you want to overwrite these resource templates?')
+  })
+
+  it('has a Yes button, when clicked will call the update function', () => {
+    const button = wrapper.find(Button).first()
+    expect(button.dive().text()).toEqual('Yes, overwite')
+    button.simulate('click')
+    expect(mockUpdate).toHaveBeenCalled()
+  })
+
+  it('has a No button, when clicked will call the modal close function', () => {
+    const button = wrapper.find(Button).last()
+    expect(button.dive().text()).toEqual('No, get me out of here!')
+    button.simulate('click')
+    expect(mockClose).toHaveBeenCalled()
+  })
+
+})
+
+describe('message with no data (or id)', () => {
+  const messages = [{
+    "req": {
+      "method":"POST",
+      "url":"http://localhost:8080/repository/ld4p",
+      "_data": {},
+    },
+    "statusText":"Conflict",
+    "statusCode":409,
+    "status":409
+  }]
+
+  const mockUpdate = jest.fn()
+  const mockClose = jest.fn()
+  const wrapper = shallow(<UpdateResourceModal show={true} close={mockClose} message={messages} update={mockUpdate} />)
+  wrapper.update()
+
+  expect(wrapper.state().titleMessage).toEqual("")
+  expect(wrapper.state().group).toEqual("")
+  expect(wrapper.state().rts).toEqual([])
+})

--- a/src/components/Login.jsx
+++ b/src/components/Login.jsx
@@ -16,7 +16,7 @@ class Login extends React.Component {
     if(!this.props.test) {
       setTimeout(function(){
         window.location.assign(url)
-      }, 3000);
+      }, 1000);
     }
   }
 

--- a/src/components/editor/ImportResourceTemplate.jsx
+++ b/src/components/editor/ImportResourceTemplate.jsx
@@ -5,11 +5,13 @@ import PropTypes from 'prop-types'
 import Header from './Header'
 import ImportFileZone from './ImportFileZone'
 import SinopiaResourceTemplates from './SinopiaResourceTemplates'
+import UpdateResourceModal from './UpdateResourceModal'
 import { loadState } from '../../localStorage'
 import Config from '../../../src/Config'
 const SinopiaServer = require('sinopia_server')
 const instance = new SinopiaServer.LDPApi()
 const curJwt = loadState('jwtAuth')
+const _ = require('lodash')
 instance.apiClient.basePath = Config.sinopiaServerBase
 if (curJwt !== undefined) {
   instance.apiClient.authentications['CognitoUser'].accessToken = curJwt.id_token
@@ -22,7 +24,10 @@ class ImportResourceTemplate extends Component {
       redirect: false,
       group: '',
       message: [],
-      updateKey: 0
+      createResourceError: [],
+      updateResourceError: '',
+      updateKey: 0,
+      modalShow: false
     }
   }
 
@@ -31,38 +36,104 @@ class ImportResourceTemplate extends Component {
     this.setState({updateKey: incrementedKey})
   }
 
+  modalClose = () => {
+    this.setState( { modalShow: false } )
+  }
+
   //resource templates are set via ImportFileZone and passed to ResourceTemplate via redirect to Editor
   setResourceTemplates = (content, group) => {
+    const profileCount = content.Profile.resourceTemplates.length
     content.Profile.resourceTemplates.map(rt => {
-      this.fulfillCreateResourcePromise(this.createResourcePromise(rt, group))
+      this.fulfillCreateResourcePromise(this.createResourcePromise(rt, group, profileCount))
       const incrementedKey = this.state.updateKey + 1
       this.setState({updateKey: incrementedKey})
     })
   }
 
-  createResourcePromise = (content, group) => new Promise(async (resolve) => {
-    resolve(await instance.createResourceWithHttpInfo(group, content, { slug: content.id, contentType: 'application/json' }))
+  createResourcePromise = (content, group, profileCount) => new Promise(async (resolve) => {
+    resolve(
+      await instance.createResourceWithHttpInfo(group, content, { slug: content.id, contentType: 'application/json' }).catch((error) => {
+        this.updateStateForResourceError(error)
+      })
+    )
   }).then(response => {
+    if(this.state.createResourceError.length === profileCount) {
+      this.setState({modalShow: true})
+    }
     return response
   }).catch(() => {})
 
-  fulfillCreateResourcePromise = (promise) => {
-    promise.then(result => {
+  updateResourcePromise = (content, group) => new Promise(async (resolve) => {
+    resolve(
+      await instance.updateResourceWithHttpInfo(group, content.id, content, { contentType: 'application/json' }).catch((error) => {
+        this.setState({
+          updateResourceError: error
+        })
+      })
+    )
+  }).then(response => {
+
+    return response
+  }).catch(() => {})
+
+  fulfillCreateResourcePromise = async (promise) => {
+    await promise.then(result => {
       const joinedMessages = this.state.message.slice(0)
-      this.setState({tempState: `${result.response.statusText} ${result.response.headers.location}`})
-      joinedMessages.push(this.state.tempState)
-      this.setState({message: joinedMessages})
+
+      if(result.response.statusText !== 'No Content') {
+        this.setState({tempState: `${result.response.statusText} ${result.response.headers.location}`})
+        joinedMessages.push(this.state.tempState)
+        this.setState({message: joinedMessages})
+      }
+
     }).catch(() => {
-      this.setState({message: ['Cannot create resource. It is likely that the sinopia server is either not running or accepting requests.']})
+      if (this.state.createResourceError[0].statusText !== 'Conflict') {
+        const msg = 'The sinopia server is not accepting the request for this resource.'
+        this.state.updateResourceError ? this.setState({message: [`${msg}: ${this.state.updateResourceError}`]}) : this.setState({message: [msg]})
+      }
+    })
+  }
+
+  updateStateForResourceError = (error) => {
+    if(_.get(error, 'response.statusText') === 'Conflict') {
+      const response = error.response
+      const joinedConflicts = this.state.createResourceError.slice(0)
+      this.setState({tempConflictError: response})
+      joinedConflicts.push(this.state.tempConflictError)
+      this.setState({createResourceError: joinedConflicts})
+    }
+  }
+
+  updateAllResources = (rts, group) => {
+    return Promise.all(rts.map(async rt =>
+      await this.fulfillCreateResourcePromise(this.updateResourcePromise(rt, group))
+    ))
+  }
+
+  handleUpdateResource = async (rts, group) => {
+    await this.updateAllResources(rts, group).then(() => {
+      const incrementedKey = this.state.updateKey + 1
+      this.setState({updateKey: incrementedKey})
+      this.modalClose()
+      window.location.reload()
     })
   }
 
   render() {
     return(
       <div id="importResourceTemplate">
+        <div>
+        { (this.state.modalShow) ? (
+          <UpdateResourceModal show={this.state.modalShow}
+                               close={this.modalClose}
+                               message={this.state.createResourceError}
+                               update={this.handleUpdateResource} /> ) :
+          ( <div/> ) }
+        </div>
         <Header triggerEditorMenu={this.props.triggerHandleOffsetMenu}/>
         <ImportFileZone setResourceTemplateCallback={this.setResourceTemplates} />
-        <SinopiaResourceTemplates updateKey={this.state.updateKey} message={this.state.message}/>
+        <SinopiaResourceTemplates updateKey={this.state.updateKey}
+                                  message={this.state.message} />
       </div>
     )
   }

--- a/src/components/editor/UpdateResourceModal.jsx
+++ b/src/components/editor/UpdateResourceModal.jsx
@@ -1,0 +1,73 @@
+// Copyright 2019 Stanford University see Apache2.txt for license
+
+import React, {Component} from 'react'
+import PropTypes from 'prop-types'
+import Button from 'react-bootstrap/lib/Button'
+import Modal from 'react-bootstrap/lib/Modal'
+const _ = require('lodash')
+
+class UpdateResourceModal extends Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      titleMessage: [],
+      rts: []
+    }
+  }
+
+  resourceToName = (resource) => {
+    const idx = resource.lastIndexOf('/')
+    return resource.substring(idx+1)
+  }
+
+  componentDidMount() {
+    let group = ''
+    let rts = []
+    let titleMessages = []
+    const messages = this.props.message
+
+    messages.map(message => {
+      if(_.get(message, 'req._data.id')) {
+        const req = message.req
+        group = this.resourceToName(req.url)
+        const rt = req._data
+        rts.push(rt)
+        titleMessages.push(`${rt.id} already exisits`)
+      }
+    })
+
+    this.setState({
+      titleMessage: titleMessages.join(', '),
+      rts: rts,
+      group: group
+    })
+  }
+
+  render() {
+    return (
+      <div>
+        <Modal show={this.props.show}>
+          <Modal.Header>
+            <Modal.Title>{this.state.titleMessage}</Modal.Title>
+          </Modal.Header>
+          <Modal.Body>
+            Do you want to overwrite these resource templates?
+          </Modal.Body>
+          <Modal.Footer>
+            <Button onClick={() => {this.props.update(this.state.rts, this.state.group)}}>Yes, overwite</Button>
+            <Button onClick={this.props.close}>No, get me out of here!</Button>
+          </Modal.Footer>
+        </Modal>
+      </div>
+    )
+  }
+}
+
+UpdateResourceModal.propTypes = {
+  close: PropTypes.func,
+  show: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+  message: PropTypes.array,
+  update: PropTypes.func,
+}
+
+export default (UpdateResourceModal)


### PR DESCRIPTION
Update resources when a trellis response indicates a conflict and warn user in rendered modal.

Fixes #454

This PR includes:
 
- Creates `UpdateResourceModal` that appears when a 409/Conflict error is caught from a POST call to trellis with an existing resource ID. The modal captures the 409 response and renders some details about it, and then returns the conflicting template data to a callback function that handles the update (PUT) call instead.
- `ImportResourceTemplate` provides the callback function to the modal and handles the trellis call to do the updates, setting the component state and props as needed
- `SinopiaResourceTemplates` should handle an array of contents as well as a single content as a string. Refactors promise for better testing
- (minor change) Decrease the timeout before being sent to Cognito to login (this will be obviated by forthcoming PR #460) 
- Test changes, additions, and refactoring of components to maintain coverage