### PR TITLE
Allow environment variable injection from containerland into application

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,10 @@ jobs:
       - restore_cache:
           key: dependencies-ci-{{ checksum "package.json" }}
       - run: npm run eslint
-      - run: npm run build
+      - run:
+          command: npm run build
+          environment:
+            SPOOF_SINOPIA_SERVER: "false"
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,10 +36,7 @@ jobs:
       - restore_cache:
           key: dependencies-ci-{{ checksum "package.json" }}
       - run: npm run eslint
-      - run:
-          command: npm run build
-          environment:
-            SPOOF_SINOPIA_SERVER: "false"
+      - run: npm run build
       - persist_to_workspace:
           root: .
           paths:

--- a/.dockerignore
+++ b/.dockerignore
@@ -14,3 +14,4 @@ junit.xml
 npm-debug.log
 static-analysis
 setupEnzyme.js
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,30 @@
 FROM circleci/node:10.11
 
-WORKDIR /opt/sinopia_editor/
+# Allow build-time arguments (for, e.g., docker-compose)
+ARG SPOOF_SINOPIA_SERVER
+ARG TRELLIS_BASE_URL
+ARG DEFAULT_PROFILE_SCHEMA_VERSION
+ARG SINOPIA_GROUP
+ARG SINOPIA_URI
+ARG AWS_COGNITO_DOMAIN
+ARG COGNITO_CLIENT_ID
+
+# This is the directory the user in the circleci/node image can write to
+WORKDIR /home/circleci
 
 # Everything that isn't in .dockerignore ships
 COPY . .
+
+# Allow circleci user to run npm build
+USER root
+RUN /bin/bash -c 'chown -R circleci dist'
+
+# Run app using non-privileged account
+USER circleci
+
+# Build the app *within* the container because environment variables are fixed at build-time
+RUN npm install
+RUN npm run build
 
 # docker daemon maps app's port
 EXPOSE 8000

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Tests are written in jest, also utilizing puppeteer for end-to-end tests.
 To run them `npm test`.
 
 #### Test coverage
-To get coverage data, `npm run test-cov`.  Use a web browser to open `coverage/lcov-report/index.html`.  There is a project view and also a view of each file.  You can also check [coveralls](https://coveralls.io/repos/github/LD4P/sinopia_editor).
+To get coverage data, `npm run jest-cov`.  Use a web browser to open `coverage/lcov-report/index.html`.  There is a project view and also a view of each file.  You can also check [coveralls](https://coveralls.io/repos/github/LD4P/sinopia_editor).
 
 ### Static Analysis
 

--- a/__tests__/Config.test.js
+++ b/__tests__/Config.test.js
@@ -4,17 +4,24 @@ const OLD_ENV = process.env
 
 describe('Config', () => {
   describe('static default values', () => {
-
     it('sinopia has a default schema version', () => {
       expect(Config.defaultProfileSchemaVersion).toEqual('0.0.2')
     })
 
-    it('sinopia uri has static value', () => {
+    it('sinopia domain name has static value', () => {
       expect(Config.sinopiaDomainName).toEqual('sinopia.io')
+    })
+
+    it('default sinopia group id has static value', () => {
+      expect(Config.defaultSinopiaGroupId).toEqual('ld4p')
     })
 
     it('sinopia url has static value', () => {
       expect(Config.sinopiaUrl).toEqual('https://sinopia.io')
+    })
+
+    it('spoof sinopia server has static value', () => {
+      expect(Config.spoofSinopiaServer).toEqual(true)
     })
 
     it('aws client ID has static value', () => {
@@ -74,7 +81,9 @@ describe('Config', () => {
     beforeAll(() => {
       process.env = {
         DEFAULT_PROFILE_SCHEMA_VERSION: '0.1.0',
+        SPOOF_SINOPIA_SERVER: 'false',
         SINOPIA_URI: 'sinopia.foo',
+        SINOPIA_GROUP: 'foobar',
         TRELLIS_BASE_URL: 'https://sinopia_server.foo',
         COGNITO_CLIENT_ID: '1a2b3c',
         AWS_COGNITO_DOMAIN: 'sinopia-foo.amazoncognito.com'
@@ -86,6 +95,10 @@ describe('Config', () => {
       expect(Config.defaultProfileSchemaVersion).toEqual('0.1.0')
     })
 
+    it('default sinopia group id overrides static value', () => {
+      expect(Config.defaultSinopiaGroupId).toEqual('foobar')
+    })
+
     it('sinopia url overrides static value', () => {
       expect(Config.sinopiaUrl).toEqual('https://sinopia.foo')
     })
@@ -94,6 +107,10 @@ describe('Config', () => {
       expect(Config.sinopiaServerBase).toEqual('https://sinopia_server.foo')
     })
 
+    it('spoof sinopia server overrides static value', () => {
+      expect(Config.spoofSinopiaServer).toEqual(false)
+    }
+)
     it('aws client ID overrides static value', () => {
       expect(Config.awsClientID).toEqual('1a2b3c')
     })
@@ -132,5 +149,4 @@ describe('Config', () => {
       process.env = OLD_ENV
     })
   })
-
 })

--- a/__tests__/components/App.test.js
+++ b/__tests__/components/App.test.js
@@ -6,10 +6,10 @@ import { mount, shallow } from "enzyme"
 import { MemoryRouter } from "react-router"
 import RootContainer from '../../src/components/RootContainer'
 import App from '../../src/components/App'
+import Config from '../../src/Config'
 import HomePage from '../../src/components/HomePage'
 import Editor from '../../src/components/editor/Editor'
 import Browse from '../../src/components/editor/Browse'
-import ImportResourceTemplate from "../../src/components/editor/ImportResourceTemplate";
 import Login from '../../src/components/Login'
 import Footer from '../../src/components/Footer'
 
@@ -42,6 +42,8 @@ describe("#routes", () => {
     })
 
     it('/editor renders Editor component', () => {
+      // Stub `Config.spoofSinopiaServer` static getter to force RT to come from server
+      jest.spyOn(Config, 'spoofSinopiaServer', 'get').mockReturnValue(false)
       const component = renderRoutes("/editor")
       expect(component.find(Editor).length).toEqual(1)
     })

--- a/__tests__/components/editor/PropertyTemplateOutline.test.js
+++ b/__tests__/components/editor/PropertyTemplateOutline.test.js
@@ -285,7 +285,6 @@ describe('<PropertyTemplateOutline /> with propertyTemplate Refs', () => {
                                                  initNewResourceTemplate={mockInitNewResourceTemplate} />)
 
   const childOutlineHeader = wrapper.find(OutlineHeader)
-  const actionButtons = wrapper.find(PropertyActionButtons)
   const event = { preventDefault() {} }
 
   it('displays a collapsed OutlineHeader of the propertyTemplate label', () => {
@@ -297,7 +296,7 @@ describe('<PropertyTemplateOutline /> with propertyTemplate Refs', () => {
     await wrapper.instance().fullfillRTPromises(promises).then(() => wrapper.update()).then(() => {
       childOutlineHeader.find('a').simulate('click')
       expect(wrapper.state().collapsed).toBeFalsy()
-    }).catch(e => {})
+    }).catch(() => {})
   })
 
   it('handles "Add" button click', async () => {
@@ -306,7 +305,7 @@ describe('<PropertyTemplateOutline /> with propertyTemplate Refs', () => {
       addButton.handleClick = mockHandleAddClick
       addButton.simulate('click')
       expect(mockHandleAddClick.mock.calls.length).toBe(1)
-    }).catch(e => {})
+    }).catch(() => {})
 
   })
 
@@ -320,7 +319,7 @@ describe('<PropertyTemplateOutline /> with propertyTemplate Refs', () => {
       const mintButton = wrapper.find('div > section > PropertyActionButtons > div > button.btn-success')
       mintButton.simulate('click')
       expect(mockHandleMintUri.mock.calls.length).toBe(1)
-    }).catch(e => {})
+    }).catch(() => {})
   })
 
   it('handles the mintUri method callback call', () => {

--- a/__tests__/components/editor/PropertyTemplateOutline.test.js
+++ b/__tests__/components/editor/PropertyTemplateOutline.test.js
@@ -7,7 +7,7 @@ import InputLiteral from '../../../src/components/editor/InputLiteral'
 import InputListLOC from '../../../src/components/editor/InputListLOC'
 import InputLookupQA from '../../../src/components/editor/InputLookupQA'
 import OutlineHeader from '../../../src/components/editor/OutlineHeader'
-import PropertyActionButtons from '../../../src/components/editor/PropertyActionButtons'
+import Config from '../../../src/Config'
 import { getLookupConfigItem, PropertyTemplateOutline, valueTemplateRefTest, getLookupConfigItems } from '../../../src/components/editor/PropertyTemplateOutline'
 import PropertyTypeRow from '../../../src/components/editor/PropertyTypeRow'
 
@@ -286,6 +286,9 @@ describe('<PropertyTemplateOutline /> with propertyTemplate Refs', () => {
 
   const childOutlineHeader = wrapper.find(OutlineHeader)
   const event = { preventDefault() {} }
+
+  // Stub `Config.spoofSinopiaServer` static getter to force RT to come from server
+  jest.spyOn(Config, 'spoofSinopiaServer', 'get').mockReturnValue(false)
 
   it('displays a collapsed OutlineHeader of the propertyTemplate label', () => {
     expect(childOutlineHeader.props().label).toEqual(property.propertyTemplate.propertyLabel)

--- a/__tests__/components/editor/ResourceTemplate.test.js
+++ b/__tests__/components/editor/ResourceTemplate.test.js
@@ -47,7 +47,7 @@ describe('<ResourceTemplate />', () => {
 
   const wrapper = shallow(<ResourceTemplate.WrappedComponent resourceTemplateId='resourceTemplate:bf2:Note' />)
   const promise = Promise.resolve(mockResponse(200, null, responseBody))
-  wrapper.instance().getResourceTemplate(promise)
+  wrapper.instance().getResourceTemplatePromise(promise)
 
   it('has div with class "ResourceTemplate"', () => {
     expect(wrapper.find('div.ResourceTemplate').length).toEqual(1)

--- a/__tests__/components/editor/ResourceTemplate.test.js
+++ b/__tests__/components/editor/ResourceTemplate.test.js
@@ -47,7 +47,7 @@ describe('<ResourceTemplate />', () => {
 
   const wrapper = shallow(<ResourceTemplate.WrappedComponent resourceTemplateId='resourceTemplate:bf2:Note' />)
   const promise = Promise.resolve(mockResponse(200, null, responseBody))
-  wrapper.instance().getResourceTemplatePromise(promise)
+  wrapper.instance().getResourceTemplate(promise)
 
   it('has div with class "ResourceTemplate"', () => {
     expect(wrapper.find('div.ResourceTemplate').length).toEqual(1)

--- a/__tests__/components/editor/ResourceTemplate.test.js
+++ b/__tests__/components/editor/ResourceTemplate.test.js
@@ -2,11 +2,11 @@
 
 import React from 'react'
 import { shallow } from 'enzyme'
+import Config from '../../../src/Config'
 import ResourceTemplate from '../../../src/components/editor/ResourceTemplate'
 import ResourceTemplateForm from '../../../src/components/editor/ResourceTemplateForm'
 
 describe('<ResourceTemplate />', () => {
-
   const mockResponse = (status, statusText, response) => {
     return new Response(response, {
       status: status,
@@ -45,9 +45,11 @@ describe('<ResourceTemplate />', () => {
     }
   }
 
+  // Stub `Config.spoofSinopiaServer` static getter to force RT to come from server
+  jest.spyOn(Config, 'spoofSinopiaServer', 'get').mockReturnValue(false)
   const wrapper = shallow(<ResourceTemplate.WrappedComponent resourceTemplateId='resourceTemplate:bf2:Note' />)
   const promise = Promise.resolve(mockResponse(200, null, responseBody))
-  wrapper.instance().getResourceTemplate(promise)
+  wrapper.instance().getResourceTemplatePromise(promise)
 
   it('has div with class "ResourceTemplate"', () => {
     expect(wrapper.find('div.ResourceTemplate').length).toEqual(1)

--- a/__tests__/reducers/linkedData.test.js
+++ b/__tests__/reducers/linkedData.test.js
@@ -266,4 +266,3 @@ describe('should handle initial state', () => {
     expect(emptyGraph).toEqual(JSON.parse(jsonld))
   }
 })
-

--- a/__tests__/sinopiaServer.test.js
+++ b/__tests__/sinopiaServer.test.js
@@ -27,30 +27,31 @@ describe('sinopiaServerSpoof', () => {
   })
 
   describe('getResourceTemplate', () => {
-    it('known id: returns JSON for resource template', () => {
-      expect(sinopiaServer.getResourceTemplate('resourceTemplate:bf2:Title').id).toEqual('resourceTemplate:bf2:Title')
-      expect(sinopiaServer.getResourceTemplate('resourceTemplate:bf2:Title').resourceLabel).toEqual('Instance Title')
+    it('known id: returns JSON for resource template', async () => {
+      const template = await sinopiaServer.getResourceTemplate('resourceTemplate:bf2:Title')
+      expect(template.id).toEqual('resourceTemplate:bf2:Title')
+      expect(template.resourceLabel).toEqual('Instance Title')
     })
-    it('unknown id: returns empty resource template and logs error', () => {
+    it('unknown id: returns empty resource template and logs error', async () => {
       let output = ''
       let storeErr = inputs => (output += inputs)
       console["log"] = jest.fn(storeErr)
-      expect(sinopiaServer.getResourceTemplate('not:there')).toEqual({"propertyTemplates": [{}]})
+      expect(await sinopiaServer.getResourceTemplate('not:there')).toEqual({"propertyTemplates": [{}]})
       expect(output).toEqual('ERROR: un-spoofed resourceTemplate: not:there')
     })
-    it('null id: returns empty resource template and logs error', () => {
+    it('null id: returns empty resource template and logs error', async () => {
       let output = ''
       let storeErr = inputs => (output += inputs)
       console["log"] = jest.fn(storeErr)
-      expect(sinopiaServer.getResourceTemplate()).toEqual({"propertyTemplates": [{}]})
+      expect(await sinopiaServer.getResourceTemplate()).toEqual({"propertyTemplates": [{}]})
       expect(output).toEqual('ERROR: asked for resourceTemplate with null/undefined id')
       output = ''
-      expect(sinopiaServer.getResourceTemplate(null)).toEqual({"propertyTemplates": [{}]})
+      expect(await sinopiaServer.getResourceTemplate(null)).toEqual({"propertyTemplates": [{}]})
       expect(output).toEqual('ERROR: asked for resourceTemplate with null/undefined id')
       output = ''
-      expect(sinopiaServer.getResourceTemplate(undefined)).toEqual({"propertyTemplates": [{}]})
+      expect(await sinopiaServer.getResourceTemplate(undefined)).toEqual({"propertyTemplates": [{}]})
       expect(output).toEqual('ERROR: asked for resourceTemplate with null/undefined id')
-      expect(sinopiaServer.getResourceTemplate('')).toEqual({"propertyTemplates": [{}]})
+      expect(await sinopiaServer.getResourceTemplate('')).toEqual({"propertyTemplates": [{}]})
     })
 
   })

--- a/__tests__/sinopiaServer.test.js
+++ b/__tests__/sinopiaServer.test.js
@@ -27,7 +27,10 @@ describe('sinopiaServerSpoof', () => {
   })
 
   describe('getResourceTemplate', () => {
-    it('known id: returns JSON for resource template', () => {
+    it('known id: returns JSON for resource template', async () => {
+      // TODO: This only works with spoofed resource templates. prefix w/
+      // `await` when `sinopiaServer.getSpoofedResourceTemplate()` returns a
+      // promise.
       const template = sinopiaServer.getResourceTemplate('resourceTemplate:bf2:Title')
       expect(template.id).toEqual('resourceTemplate:bf2:Title')
       expect(template.resourceLabel).toEqual('Instance Title')

--- a/__tests__/sinopiaServer.test.js
+++ b/__tests__/sinopiaServer.test.js
@@ -27,31 +27,31 @@ describe('sinopiaServerSpoof', () => {
   })
 
   describe('getResourceTemplate', () => {
-    it('known id: returns JSON for resource template', async () => {
-      const template = await sinopiaServer.getResourceTemplate('resourceTemplate:bf2:Title')
+    it('known id: returns JSON for resource template', () => {
+      const template = sinopiaServer.getResourceTemplate('resourceTemplate:bf2:Title')
       expect(template.id).toEqual('resourceTemplate:bf2:Title')
       expect(template.resourceLabel).toEqual('Instance Title')
     })
-    it('unknown id: returns empty resource template and logs error', async () => {
+    it('unknown id: returns empty resource template and logs error', () => {
       let output = ''
       let storeErr = inputs => (output += inputs)
       console["log"] = jest.fn(storeErr)
-      expect(await sinopiaServer.getResourceTemplate('not:there')).toEqual({"propertyTemplates": [{}]})
+      expect(sinopiaServer.getResourceTemplate('not:there')).toEqual({"propertyTemplates": [{}]})
       expect(output).toEqual('ERROR: un-spoofed resourceTemplate: not:there')
     })
-    it('null id: returns empty resource template and logs error', async () => {
+    it('null id: returns empty resource template and logs error', () => {
       let output = ''
       let storeErr = inputs => (output += inputs)
       console["log"] = jest.fn(storeErr)
-      expect(await sinopiaServer.getResourceTemplate()).toEqual({"propertyTemplates": [{}]})
+      expect(sinopiaServer.getResourceTemplate()).toEqual({"propertyTemplates": [{}]})
       expect(output).toEqual('ERROR: asked for resourceTemplate with null/undefined id')
       output = ''
-      expect(await sinopiaServer.getResourceTemplate(null)).toEqual({"propertyTemplates": [{}]})
+      expect(sinopiaServer.getResourceTemplate(null)).toEqual({"propertyTemplates": [{}]})
       expect(output).toEqual('ERROR: asked for resourceTemplate with null/undefined id')
       output = ''
-      expect(await sinopiaServer.getResourceTemplate(undefined)).toEqual({"propertyTemplates": [{}]})
+      expect(sinopiaServer.getResourceTemplate(undefined)).toEqual({"propertyTemplates": [{}]})
       expect(output).toEqual('ERROR: asked for resourceTemplate with null/undefined id')
-      expect(await sinopiaServer.getResourceTemplate('')).toEqual({"propertyTemplates": [{}]})
+      expect(sinopiaServer.getResourceTemplate('')).toEqual({"propertyTemplates": [{}]})
     })
 
   })

--- a/__tests__/sinopiaServer.test.js
+++ b/__tests__/sinopiaServer.test.js
@@ -31,6 +31,8 @@ describe('sinopiaServerSpoof', () => {
       // TODO: This only works with spoofed resource templates. prefix w/
       // `await` when `sinopiaServer.getSpoofedResourceTemplate()` returns a
       // promise.
+      //
+      // See https://github.com/LD4P/sinopia_editor/issues/473
       const template = sinopiaServer.getResourceTemplate('resourceTemplate:bf2:Title')
       expect(template.id).toEqual('resourceTemplate:bf2:Title')
       expect(template.resourceLabel).toEqual('Instance Title')

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,19 +3,12 @@ services:
   editor:
     build:
       context: .
+      args:
+        SPOOF_SINOPIA_SERVER: 'false'
+        TRELLIS_BASE_URL: http://platform:8080
     ports:
       - 8000:8000
     depends_on:
-      - pipeline
-  pipeline:
-    image: ld4p/sinopia_indexing_pipeline:latest
-    environment:
-      INDEX_HOST: search
-      BROKER_HOST: broker
-    command: dockerize -wait tcp://broker:61613 -wait tcp://search:9200 -timeout 3m npm start
-    depends_on:
-      - broker
-      - search
       - platform
   broker:
     image: rmohr/activemq
@@ -41,9 +34,13 @@ services:
       - 8080:8080
       - 8081:8081
     depends_on:
-      - database
       - broker
+      - database
       - migration
+  broker:
+    image: rmohr/activemq
+    ports:
+      - 61613:61613
   database:
     image: postgres:latest
     environment:
@@ -53,27 +50,6 @@ services:
       PGDATA: /var/lib/postgresql/data/pgdata/mydata
     ports:
       - 5432:5432
-  search:
-    image: docker.elastic.co/elasticsearch/elasticsearch:6.3.2
-    entrypoint:
-      - elasticsearch
-      - -Ehttp.port=9200
-      - -Ehttp.cors.enabled=true
-      - -Ehttp.cors.allow-origin=http://searchui:1358,http://localhost:1358,http://127.0.0.1:1358
-      - -Ehttp.cors.allow-headers=X-Requested-With,X-Auth-Token,Content-Type,Content-Length,Authorization
-      - -Ehttp.cors.allow-credentials=true
-      - -Etransport.host=localhost
-      - -Ebootstrap.system_call_filter=false
-    user: elasticsearch
-    ports:
-      - 9200:9200
-      - 9300:9300
-  searchui:
-    image: appbaseio/dejavu:latest
-    ports:
-      - 1358:1358
-    depends_on:
-      - search
   migration:
     image: ld4p/trellis-ext-db:latest
     command: ["/opt/trellis/bin/trellis-db", "db", "migrate", "/opt/trellis/etc/config.yml"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -6570,7 +6570,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6591,12 +6592,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6611,17 +6614,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6738,7 +6744,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6750,6 +6757,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6764,6 +6772,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6771,12 +6780,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6795,6 +6806,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6875,7 +6887,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6887,6 +6900,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6972,7 +6986,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7008,6 +7023,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7027,6 +7043,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7070,12 +7087,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -8799,7 +8818,8 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -8820,12 +8840,14 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -8840,17 +8862,20 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -8967,7 +8992,8 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -8979,6 +9005,7 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -8993,6 +9020,7 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -9000,12 +9028,14 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -9024,6 +9054,7 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -9104,7 +9135,8 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -9116,6 +9148,7 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -9201,7 +9234,8 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -9237,6 +9271,7 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -9256,6 +9291,7 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -9299,12 +9335,14 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "dev-build": "webpack --progress --mode development",
     "dev-build-test": "npm run dev-build && npm run test",
     "dev-start": "webpack-dev-server --config ./webpack.config.js --mode development",
-    "eslint": "eslint --max-warnings 34 --color -c .eslintrc.js --ext js,jsx ./src",
+    "eslint": "eslint --max-warnings 15 --color -c .eslintrc.js --ext js,jsx ./src",
     "jest-cov": "jest --coverage --colors --silent --runInBand",
     "jest-ci": "jest  --colors --silent --ci --runInBand --coverage --reporters=default --reporters=jest-junit && cat ./coverage/lcov.info | coveralls",
     "test": "jest --colors --silent --runInBand --detectOpenHandles",

--- a/src/Config.js
+++ b/src/Config.js
@@ -20,6 +20,17 @@ class Config {
     return process.env.AWS_COGNITO_DOMAIN || 'sinopia-development.auth.us-west-2.amazoncognito.com'
   }
 
+  static get spoofSinopiaServer() {
+    // There are two value types of `process.env` variables:
+    //   1. When undefined, `if` condition it not satisfied and default `true` is returned
+    //   2. When defined, will always be a string.
+    //     a. When set to 'true' return `true` (use spoof)
+    //     b. When set to 'false' or any other string, return `false` (don't use spoof)
+    if (process.env.SPOOF_SINOPIA_SERVER)
+      return process.env.SPOOF_SINOPIA_SERVER === 'true'
+    return true
+  }
+
   static get awsClientID() {
     return process.env.COGNITO_CLIENT_ID || '2u6s7pqkc1grq1qs464fsi82at'
   }

--- a/src/components/editor/PropertyTemplateOutline.jsx
+++ b/src/components/editor/PropertyTemplateOutline.jsx
@@ -10,7 +10,7 @@ import PropertyActionButtons from './PropertyActionButtons'
 import PropertyTypeRow from './PropertyTypeRow'
 import RequiredSuperscript from './RequiredSuperscript'
 import { refreshResourceTemplate } from '../../actions/index'
-import { getResourceTemplateFromServer } from '../../sinopiaServer'
+import { getResourceTemplate } from '../../sinopiaServer'
 import lookupConfig from '../../../static/spoofedFilesFromServer/fromSinopiaServer/lookupConfig.json'
 import PropTypes from 'prop-types'
 import shortid from 'shortid'
@@ -75,7 +75,7 @@ export class PropertyTemplateOutline extends Component {
 
   resourceTemplatePromises = (templateRefs) => {
     return Promise.all(templateRefs.map(rtId =>
-      getResourceTemplateFromServer(rtId)
+      getResourceTemplate(rtId)
     ))
   }
 

--- a/src/components/editor/PropertyTemplateOutline.jsx
+++ b/src/components/editor/PropertyTemplateOutline.jsx
@@ -75,7 +75,7 @@ export class PropertyTemplateOutline extends Component {
 
   resourceTemplatePromises = (templateRefs) => {
     return Promise.all(templateRefs.map(rtId =>
-      getResourceTemplate('ld4p', rtId)
+      getResourceTemplate(rtId)
     ))
   }
 

--- a/src/components/editor/PropertyTemplateOutline.jsx
+++ b/src/components/editor/PropertyTemplateOutline.jsx
@@ -10,7 +10,7 @@ import PropertyActionButtons from './PropertyActionButtons'
 import PropertyTypeRow from './PropertyTypeRow'
 import RequiredSuperscript from './RequiredSuperscript'
 import { refreshResourceTemplate } from '../../actions/index'
-import { getResourceTemplateFromServer } from '../../sinopiaServer'
+import { getResourceTemplate } from '../../sinopiaServer'
 import lookupConfig from '../../../static/spoofedFilesFromServer/fromSinopiaServer/lookupConfig.json'
 import PropTypes from 'prop-types'
 import shortid from 'shortid'
@@ -75,7 +75,7 @@ export class PropertyTemplateOutline extends Component {
 
   resourceTemplatePromises = (templateRefs) => {
     return Promise.all(templateRefs.map(rtId =>
-      getResourceTemplateFromServer('ld4p', rtId)
+      getResourceTemplate('ld4p', rtId)
     ))
   }
 

--- a/src/components/editor/PropertyTemplateOutline.jsx
+++ b/src/components/editor/PropertyTemplateOutline.jsx
@@ -10,7 +10,7 @@ import PropertyActionButtons from './PropertyActionButtons'
 import PropertyTypeRow from './PropertyTypeRow'
 import RequiredSuperscript from './RequiredSuperscript'
 import { refreshResourceTemplate } from '../../actions/index'
-import { getResourceTemplate } from '../../sinopiaServer'
+import { getResourceTemplateFromServer } from '../../sinopiaServer'
 import lookupConfig from '../../../static/spoofedFilesFromServer/fromSinopiaServer/lookupConfig.json'
 import PropTypes from 'prop-types'
 import shortid from 'shortid'
@@ -75,7 +75,7 @@ export class PropertyTemplateOutline extends Component {
 
   resourceTemplatePromises = (templateRefs) => {
     return Promise.all(templateRefs.map(rtId =>
-      getResourceTemplate(rtId)
+      getResourceTemplateFromServer(rtId)
     ))
   }
 

--- a/src/components/editor/ResourceTemplate.jsx
+++ b/src/components/editor/ResourceTemplate.jsx
@@ -4,7 +4,7 @@ import React, { Component }  from 'react'
 import { connect } from 'react-redux'
 import ResourceTemplateForm from './ResourceTemplateForm'
 import { setResourceTemplate } from '../../actions/index'
-import { getResourceTemplate } from '../../sinopiaServer'
+import { getResourceTemplateFromServer } from '../../sinopiaServer'
 import PropTypes from 'prop-types'
 const _ = require('lodash')
 
@@ -17,10 +17,10 @@ class ResourceTemplate extends Component {
   }
 
   componentDidMount() {
-    this.getResourceTemplatePromise(this.resourceTemplatePromise())
+    this.getResourceTemplate(this.resourceTemplatePromise())
   }
 
-  getResourceTemplatePromise = (promise) => {
+  getResourceTemplate = (promise) => {
     promise.then(response_and_body => {
       this.setState({rtData: response_and_body.response.body})
       this.props.handleResourceTemplate(this.state.rtData)
@@ -30,7 +30,7 @@ class ResourceTemplate extends Component {
   }
 
   resourceTemplatePromise = () => {
-    return getResourceTemplate(this.props.resourceTemplateId)
+    return getResourceTemplateFromServer(this.props.resourceTemplateId)
   }
 
   renderRtData = () => {

--- a/src/components/editor/ResourceTemplate.jsx
+++ b/src/components/editor/ResourceTemplate.jsx
@@ -4,7 +4,7 @@ import React, { Component }  from 'react'
 import { connect } from 'react-redux'
 import ResourceTemplateForm from './ResourceTemplateForm'
 import { setResourceTemplate } from '../../actions/index'
-import { getResourceTemplateFromServer } from '../../sinopiaServer'
+import { getResourceTemplate } from '../../sinopiaServer'
 import PropTypes from 'prop-types'
 const _ = require('lodash')
 
@@ -17,10 +17,10 @@ class ResourceTemplate extends Component {
   }
 
   componentDidMount() {
-    this.getResourceTemplate(this.resourceTemplatePromise())
+    this.getResourceTemplatePromise(this.resourceTemplatePromise())
   }
 
-  getResourceTemplate = (promise) => {
+  getResourceTemplatePromise = (promise) => {
     promise.then(response_and_body => {
       this.setState({rtData: response_and_body.response.body})
       this.props.handleResourceTemplate(this.state.rtData)
@@ -30,7 +30,7 @@ class ResourceTemplate extends Component {
   }
 
   resourceTemplatePromise = () => {
-    return getResourceTemplateFromServer(this.props.resourceTemplateId)
+    return getResourceTemplate(this.props.resourceTemplateId)
   }
 
   renderRtData = () => {

--- a/src/components/editor/ResourceTemplate.jsx
+++ b/src/components/editor/ResourceTemplate.jsx
@@ -6,7 +6,6 @@ import ResourceTemplateForm from './ResourceTemplateForm'
 import { setResourceTemplate } from '../../actions/index'
 import { getResourceTemplate } from '../../sinopiaServer'
 import PropTypes from 'prop-types'
-import Config from '../../Config'
 const _ = require('lodash')
 
 class ResourceTemplate extends Component {
@@ -31,7 +30,7 @@ class ResourceTemplate extends Component {
   }
 
   resourceTemplatePromise = () => {
-    return getResourceTemplate(Config.defaultSinopiaGroupId, this.props.resourceTemplateId)
+    return getResourceTemplate(this.props.resourceTemplateId)
   }
 
   renderRtData = () => {

--- a/src/components/editor/ResourceTemplate.jsx
+++ b/src/components/editor/ResourceTemplate.jsx
@@ -4,7 +4,7 @@ import React, { Component }  from 'react'
 import { connect } from 'react-redux'
 import ResourceTemplateForm from './ResourceTemplateForm'
 import { setResourceTemplate } from '../../actions/index'
-import { getResourceTemplateFromServer } from '../../sinopiaServer'
+import { getResourceTemplate } from '../../sinopiaServer'
 import PropTypes from 'prop-types'
 import Config from '../../Config'
 const _ = require('lodash')
@@ -18,10 +18,10 @@ class ResourceTemplate extends Component {
   }
 
   componentDidMount() {
-    this.getResourceTemplate(this.resourceTemplatePromise())
+    this.getResourceTemplatePromise(this.resourceTemplatePromise())
   }
 
-  getResourceTemplate = (promise) => {
+  getResourceTemplatePromise = (promise) => {
     promise.then(response_and_body => {
       this.setState({rtData: response_and_body.response.body})
       this.props.handleResourceTemplate(this.state.rtData)
@@ -31,7 +31,7 @@ class ResourceTemplate extends Component {
   }
 
   resourceTemplatePromise = () => {
-    return getResourceTemplateFromServer(Config.defaultSinopiaGroupId, this.props.resourceTemplateId)
+    return getResourceTemplate(Config.defaultSinopiaGroupId, this.props.resourceTemplateId)
   }
 
   renderRtData = () => {

--- a/src/components/editor/ResourceTemplateForm.jsx
+++ b/src/components/editor/ResourceTemplateForm.jsx
@@ -11,7 +11,7 @@ import PropertyPanel from './PropertyPanel'
 import PropertyResourceTemplate from './PropertyResourceTemplate'
 import lookupConfig from '../../../static/spoofedFilesFromServer/fromSinopiaServer/lookupConfig.json'
 import { getLD, setItems, removeAllContent } from '../../actions/index'
-import { getResourceTemplateFromServer } from '../../sinopiaServer'
+import { getResourceTemplate } from '../../sinopiaServer'
 const N3 = require('n3')
 const { DataFactory } = N3
 const { blankNode } = DataFactory
@@ -58,7 +58,7 @@ export class ResourceTemplateForm extends Component {
 
   resourceTemplatePromises = async (templateRefs) => {
     return Promise.all(templateRefs.map(rtId =>
-      getResourceTemplateFromServer('ld4p', rtId)
+      getResourceTemplate('ld4p', rtId)
     ))
   }
 

--- a/src/components/editor/ResourceTemplateForm.jsx
+++ b/src/components/editor/ResourceTemplateForm.jsx
@@ -11,7 +11,7 @@ import PropertyPanel from './PropertyPanel'
 import PropertyResourceTemplate from './PropertyResourceTemplate'
 import lookupConfig from '../../../static/spoofedFilesFromServer/fromSinopiaServer/lookupConfig.json'
 import { getLD, setItems, removeAllContent } from '../../actions/index'
-import { getResourceTemplateFromServer } from '../../sinopiaServer'
+import { getResourceTemplate } from '../../sinopiaServer'
 const N3 = require('n3')
 const { DataFactory } = N3
 const { blankNode } = DataFactory
@@ -58,7 +58,7 @@ export class ResourceTemplateForm extends Component {
 
   resourceTemplatePromises = async (templateRefs) => {
     return Promise.all(templateRefs.map(rtId =>
-      getResourceTemplateFromServer(rtId)
+      getResourceTemplate(rtId)
     ))
   }
 

--- a/src/components/editor/ResourceTemplateForm.jsx
+++ b/src/components/editor/ResourceTemplateForm.jsx
@@ -11,7 +11,7 @@ import PropertyPanel from './PropertyPanel'
 import PropertyResourceTemplate from './PropertyResourceTemplate'
 import lookupConfig from '../../../static/spoofedFilesFromServer/fromSinopiaServer/lookupConfig.json'
 import { getLD, setItems, removeAllContent } from '../../actions/index'
-import { getResourceTemplate } from '../../sinopiaServer'
+import { getResourceTemplateFromServer } from '../../sinopiaServer'
 const N3 = require('n3')
 const { DataFactory } = N3
 const { blankNode } = DataFactory
@@ -58,7 +58,7 @@ export class ResourceTemplateForm extends Component {
 
   resourceTemplatePromises = async (templateRefs) => {
     return Promise.all(templateRefs.map(rtId =>
-      getResourceTemplate(rtId)
+      getResourceTemplateFromServer(rtId)
     ))
   }
 

--- a/src/components/editor/ResourceTemplateForm.jsx
+++ b/src/components/editor/ResourceTemplateForm.jsx
@@ -58,7 +58,7 @@ export class ResourceTemplateForm extends Component {
 
   resourceTemplatePromises = async (templateRefs) => {
     return Promise.all(templateRefs.map(rtId =>
-      getResourceTemplate('ld4p', rtId)
+      getResourceTemplate(rtId)
     ))
   }
 

--- a/src/reducers/linkedData.js
+++ b/src/reducers/linkedData.js
@@ -35,7 +35,6 @@ const clearLinkedData = () => {
 }
 
 const generateLinkedData = (state, action) => {
-
   let subject, predicate, object, resourceUri, label
   subject = action.payload.linkedNode.value
   resourceUri = action.payload.resourceURI
@@ -67,7 +66,7 @@ const generateLinkedData = (state, action) => {
   return { jsonld: jsonLD }
 }
 
-function createRDFLinks(p, o, resourceUri, label) {
+const createRDFLinks = (p, o, resourceUri, label) => {
   const entity = jsonLD['@graph'].some(thing => thing["@type"] === resourceUri)
   if(entity){
     jsonLD['@graph'][0][p] =  { "@id": o }
@@ -84,7 +83,7 @@ function createRDFLinks(p, o, resourceUri, label) {
   }
 }
 
-function createRDFLiterals(p, o, rtId, bnode, propPredicate) {
+const createRDFLiterals = (p, o, rtId, bnode, propPredicate) => {
   let resourceTemplateForEntity = getResourceTemplate(rtId)
   let entityResourceUri = resourceTemplateForEntity.resourceURI
   let literalItems = createLiteralArray(o)

--- a/src/reducers/linkedData.js
+++ b/src/reducers/linkedData.js
@@ -84,7 +84,10 @@ const createRDFLinks = (p, o, resourceUri, label) => {
 }
 
 const createRDFLiterals = (p, o, rtId, bnode, propPredicate) => {
-  // TODO: This only works for spoofed resource templates! Needs to be reworked to deal with promises.
+  // TODO: This only works for spoofed resource templates! Needs to be reworked
+  // to deal with promises.
+  //
+  // See https://github.com/LD4P/sinopia_editor/issues/473
   let resourceTemplateForEntity = getResourceTemplate(rtId)
   let entityResourceUri = resourceTemplateForEntity.resourceURI
   let literalItems = createLiteralArray(o)

--- a/src/reducers/linkedData.js
+++ b/src/reducers/linkedData.js
@@ -84,13 +84,14 @@ const createRDFLinks = (p, o, resourceUri, label) => {
 }
 
 const createRDFLiterals = (p, o, rtId, bnode, propPredicate) => {
+  // TODO: This only works for spoofed resource templates! Needs to be reworked to deal with promises.
   let resourceTemplateForEntity = getResourceTemplate(rtId)
   let entityResourceUri = resourceTemplateForEntity.resourceURI
   let literalItems = createLiteralArray(o)
   let literalValue = ''
   const entity = jsonLD['@graph'].some(thing => thing["@type"] === entityResourceUri)
 
-  if(literalItems.length === 1) {
+  if (literalItems.length === 1) {
     literalValue = literalItems[0]
   } else {
     literalValue = literalItems

--- a/src/sinopiaServer.js
+++ b/src/sinopiaServer.js
@@ -55,7 +55,7 @@ export const resourceTemplateId2Json = [
 const emptyTemplate = { propertyTemplates : [{}] }
 export const resourceTemplateIds = resourceTemplateId2Json.map(template => template.id)
 
-export const getResourceTemplate = (templateId) => {
+const getSpoofedResourceTemplate = (templateId) => {
   if (!templateId) {
     console.log(`ERROR: asked for resourceTemplate with null/undefined id`)
     return emptyTemplate
@@ -66,12 +66,20 @@ export const getResourceTemplate = (templateId) => {
     return emptyTemplate
   }
 
+  // TODO: Replace the current return value with a promise, so both functions
+  // called by getResourceTemplate() have a uniform interface, like so:
+  //
+  // return new Promise(resolve => {
+  //   resolve(resourceTemplateId2Json.find((template) => {
+  //     return template.id == templateId
+  //   }).json)
+  // })
   return resourceTemplateId2Json.find((template) => {
     return template.id == templateId
   }).json
 }
 
-export const getResourceTemplateFromServer = async (templateId, group) => {
+const getResourceTemplateFromServer = (templateId, group) => {
   // Allow function to be called without second arg
   if (!group)
     group = Config.defaultSinopiaGroupId
@@ -81,18 +89,14 @@ export const getResourceTemplateFromServer = async (templateId, group) => {
     return emptyTemplate
   }
 
-  return await getResourcePromise(group, templateId)
-}
-
-const getResourcePromise = (group, id) => {
   return new Promise(resolve => {
-    resolve(instance.getResourceWithHttpInfo(group, id, { acceptEncoding: 'application/json' }))
+    resolve(instance.getResourceWithHttpInfo(group, templateId, { acceptEncoding: 'application/json' }))
   })
 }
 
-// export const getResourceTemplate = async (templateId, group) => {
-//   if (Config.spoofSinopiaServer)
-//     return getSpoofedResourceTemplate(templateId)
+export const getResourceTemplate = (templateId, group) => {
+  if (Config.spoofSinopiaServer)
+    return getSpoofedResourceTemplate(templateId)
 
-//   return await getResourceTemplateFromServer(templateId, group)
-// }
+  return getResourceTemplateFromServer(templateId, group)
+}

--- a/src/sinopiaServer.js
+++ b/src/sinopiaServer.js
@@ -87,9 +87,12 @@ const getResourcePromise = (group, id) => {
   })
 }
 
-export const getResourceTemplate = async (group, templateId) => {
+export const getResourceTemplate = async (templateId, group) => {
   if (Config.spoofSinopiaServer)
     return getSpoofedResourceTemplate(templateId)
+
+  if (!group)
+    group = Config.defaultSinopiaGroupId
 
   return await getResourceTemplateFromServer(group, templateId)
 }

--- a/src/sinopiaServer.js
+++ b/src/sinopiaServer.js
@@ -74,6 +74,8 @@ const getSpoofedResourceTemplate = (templateId) => {
   //     return template.id == templateId
   //   }).json)
   // })
+  //
+  // See https://github.com/LD4P/sinopia_editor/issues/473
   return resourceTemplateId2Json.find((template) => {
     return template.id == templateId
   }).json

--- a/src/sinopiaServer.js
+++ b/src/sinopiaServer.js
@@ -91,6 +91,7 @@ export const getResourceTemplate = async (templateId, group) => {
   if (Config.spoofSinopiaServer)
     return getSpoofedResourceTemplate(templateId)
 
+  // Allow function to be called without second arg
   if (!group)
     group = Config.defaultSinopiaGroupId
 

--- a/src/sinopiaServer.js
+++ b/src/sinopiaServer.js
@@ -55,7 +55,7 @@ export const resourceTemplateId2Json = [
 const emptyTemplate = { propertyTemplates : [{}] }
 export const resourceTemplateIds = resourceTemplateId2Json.map(template => template.id)
 
-const getSpoofedResourceTemplate = (templateId) => {
+export const getResourceTemplate = (templateId) => {
   if (!templateId) {
     console.log(`ERROR: asked for resourceTemplate with null/undefined id`)
     return emptyTemplate
@@ -66,19 +66,22 @@ const getSpoofedResourceTemplate = (templateId) => {
     return emptyTemplate
   }
 
-  console.log(`returning template ${templateId} from spoof`)
   return resourceTemplateId2Json.find((template) => {
     return template.id == templateId
   }).json
 }
 
-const getResourceTemplateFromServer = async (group, id) => {
-  if (!id) {
+export const getResourceTemplateFromServer = async (templateId, group) => {
+  // Allow function to be called without second arg
+  if (!group)
+    group = Config.defaultSinopiaGroupId
+
+  if (!templateId) {
     console.log(`ERROR: asked for resourceTemplate with null/undefined id`)
     return emptyTemplate
   }
 
-  return getResourcePromise(group, id)
+  return await getResourcePromise(group, templateId)
 }
 
 const getResourcePromise = (group, id) => {
@@ -87,13 +90,9 @@ const getResourcePromise = (group, id) => {
   })
 }
 
-export const getResourceTemplate = async (templateId, group) => {
-  if (Config.spoofSinopiaServer)
-    return getSpoofedResourceTemplate(templateId)
+// export const getResourceTemplate = async (templateId, group) => {
+//   if (Config.spoofSinopiaServer)
+//     return getSpoofedResourceTemplate(templateId)
 
-  // Allow function to be called without second arg
-  if (!group)
-    group = Config.defaultSinopiaGroupId
-
-  return await getResourceTemplateFromServer(group, templateId)
-}
+//   return await getResourceTemplateFromServer(templateId, group)
+// }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,7 @@
 // Copyright 2018 Stanford University see Apache2.txt for license
-const path = require('path');
-const webpack = require('webpack');
-const HtmlWebpackPlugin = require('html-webpack-plugin');
+const path = require('path')
+const webpack = require('webpack')
+const HtmlWebpackPlugin = require('html-webpack-plugin')
 
 module.exports = {
   entry: './src/index.js',
@@ -46,11 +46,22 @@ module.exports = {
       template: path.resolve('./', 'index.html'),
       filename: 'index.html',
       hash: true
-    })
+    }),
+    new webpack.EnvironmentPlugin(
+      [
+        'SPOOF_SINOPIA_SERVER',
+        'TRELLIS_BASE_URL',
+        'DEFAULT_PROFILE_SCHEMA_VERSION',
+        'SINOPIA_GROUP',
+        'SINOPIA_URI',
+        'AWS_COGNITO_DOMAIN',
+        'COGNITO_CLIENT_ID'
+      ]
+    )
   ],
   devServer: {
     historyApiFallback: true,
     hot: true,
     port: 8888
   }
-};
+}


### PR DESCRIPTION
Fixes #459 

Includes:
* Add configuration for disabling/enabling spoofing
  * Set default value to enable spoofing and explicitly set this value in the editor service in docker-compose to retain current behavior
* Inject environment variables the editor can see and use via Docker in order to disable/enable spoofing and set the Sinopia server URL
* Favor `getResourceTemplate()` over `getResourceTemplateFromServer()` to allow switching behavior (namely where the RTs are coming from) via env vars.
* Reduce number of max warnings for eslint failures
