### PR TITLE
Test spaceless ids (refactor the schema validation tests)

### DIFF
--- a/__tests__/Config.test.js
+++ b/__tests__/Config.test.js
@@ -4,6 +4,11 @@ const OLD_ENV = process.env
 
 describe('Config', () => {
   describe('static default values', () => {
+
+    it('sinopia has a default schema version', () => {
+      expect(Config.defaultProfileSchemaVersion).toEqual('0.0.2')
+    })
+
     it('sinopia uri has static value', () => {
       expect(Config.sinopiaDomainName).toEqual('sinopia.io')
     })
@@ -68,11 +73,17 @@ describe('Config', () => {
 
     beforeAll(() => {
       process.env = {
+        DEFAULT_PROFILE_SCHEMA_VERSION: '0.1.0',
         SINOPIA_URI: 'sinopia.foo',
         TRELLIS_BASE_URL: 'https://sinopia_server.foo',
         COGNITO_CLIENT_ID: '1a2b3c',
         AWS_COGNITO_DOMAIN: 'sinopia-foo.amazoncognito.com'
       }
+    })
+
+
+    it('sinopia has a default schema version', () => {
+      expect(Config.defaultProfileSchemaVersion).toEqual('0.1.0')
     })
 
     it('sinopia url overrides static value', () => {

--- a/__tests__/__fixtures__/lcc_v0.0.9.json
+++ b/__tests__/__fixtures__/lcc_v0.0.9.json
@@ -1,0 +1,17 @@
+{
+  "id": "sinopia:resourceTemplate:bf2:LCC",
+  "resourceLabel": "Library of Congress Classification",
+  "resourceURI": "http://id.loc.gov/ontologies/bibframe/ClassificationLcc",
+  "date": "2017-05-13",
+  "author": "NDMSO",
+  "schema": "https://ld4p.github.io/sinopia/schemas/0.0.9/resource-template.json",
+  "propertyTemplates": [
+    {
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "propertyURI": "http://id.loc.gov/ontologies/bibframe/classificationPortion",
+      "propertyLabel": "LC Classification Number"
+    }
+  ]
+}

--- a/__tests__/__fixtures__/lcc_v0.1.0_bad_id.json
+++ b/__tests__/__fixtures__/lcc_v0.1.0_bad_id.json
@@ -1,0 +1,17 @@
+{
+  "id": "sinopia resourceTemplate:bf2:LCC",
+  "resourceLabel": "Library of Congress Classification",
+  "resourceURI": "http://id.loc.gov/ontologies/bibframe/ClassificationLcc",
+  "date": "2017-05-13",
+  "author": "NDMSO",
+  "schema": "https://ld4p.github.io/sinopia/schemas/0.1.0/resource-template.json",
+  "propertyTemplates": [
+    {
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "propertyURI": "http://id.loc.gov/ontologies/bibframe/classificationPortion",
+      "propertyLabel": "LC Classification Number"
+    }
+  ]
+}

--- a/__tests__/__fixtures__/place_profile_v0.0.9.json
+++ b/__tests__/__fixtures__/place_profile_v0.0.9.json
@@ -1,0 +1,43 @@
+{
+  "Profile": {
+    "resourceTemplates": [
+      {
+        "propertyTemplates": [
+          {
+            "mandatory": "false",
+            "repeatable": "false",
+            "type": "lookup",
+            "valueConstraint": {
+              "useValuesFrom": [
+                "http://id.loc.gov/authorities/names",
+                "http://id.loc.gov/authorities/subjects"
+              ]
+            },
+            "propertyLabel": "Search LCNAF/LCSH",
+            "propertyURI": "http://id.loc.gov/ontologies/bflc/target"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "false",
+            "type": "literal",
+            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+            "propertyLabel": "Record Place (if it does not appear above)",
+            "remark": "http://access.rdatoolkit.org/6.5.html"
+          }
+        ],
+        "id": "sinopia:resourceTemplate:bf2:Place",
+        "resourceURI": "http://id.loc.gov/ontologies/bibframe/Place",
+        "resourceLabel": "Place Associated with a Work",
+        "author": "NDMSO",
+        "date": "2017-05-13",
+        "schema": "https://ld4p.github.io/sinopia/schemas/0.0.9/resource-template.json"
+      }
+    ],
+    "id": "sinopia:profile:bf2:Place",
+    "title": "BIBFRAME 2.0 Place",
+    "date": "2017-05-13",
+    "description": "Place Associated with a Resource",
+    "author": "NDMSO",
+    "schema": "https://ld4p.github.io/sinopia/schemas/0.0.9/profile.json"
+  }
+}

--- a/__tests__/components/RootComponent.test.js
+++ b/__tests__/components/RootComponent.test.js
@@ -1,3 +1,4 @@
+import 'jsdom-global/register'
 import React from 'react'
 import { shallow } from "enzyme"
 import { MemoryRouter } from "react-router"

--- a/__tests__/components/editor/ImportFileZone.test.js
+++ b/__tests__/components/editor/ImportFileZone.test.js
@@ -6,17 +6,125 @@ import { shallow, mount } from 'enzyme'
 import ImportFileZone from '../../../src/components/editor/ImportFileZone'
 import DropZone from '../../../src/components/editor/ImportFileZone'
 import { MemoryRouter } from 'react-router-dom'
-import { Link } from 'react-router-dom'
+import Config from '../../../src/Config'
 require('isomorphic-fetch')
 
 describe('<ImportFileZone />', () => {
-  const reloadEditor = jest.fn()
-  let wrapper = shallow(<ImportFileZone reloadEditor={reloadEditor}/>)
-
   it('has an upload button', () => {
+    const wrapper = shallow(<ImportFileZone />)
     expect(wrapper.find('button#ImportProfile').exists()).toBeTruthy()
     expect(wrapper.find('button#ImportProfile').text()).toEqual('Import New or Revised Resource Template')
   })
+
+  describe('schema valid', () => {
+    describe('schema url in JSON', () => {
+      const wrapper = shallow(<ImportFileZone />)
+      let template, schemaUrl
+
+      it('gets the schemaUrl from the resource-template', () => {
+        template = require('../../__fixtures__/lcc_v0.1.0.json')
+        schemaUrl = wrapper.instance().schemaUrl(template)
+        expect(schemaUrl).toEqual('https://ld4p.github.io/sinopia/schemas/0.1.0/resource-template.json')
+      })
+
+      it('displays resource template passing validation', async () => {
+        await wrapper.instance().promiseTemplateValidated(template, schemaUrl)
+        expect(wrapper.state().validTemplate).toBeTruthy()
+      })
+
+      it('gets the schemaUrl from the profile', () => {
+        template = require('../../__fixtures__/place_profile_v0.1.0.json')
+        schemaUrl = wrapper.instance().schemaUrl(template)
+        expect(schemaUrl).toEqual('https://ld4p.github.io/sinopia/schemas/0.1.0/profile.json')
+      })
+
+      it('displays profile passing validation', async () => {
+        await wrapper.instance().promiseTemplateValidated(template, schemaUrl)
+        expect(wrapper.state().validTemplate).toBeTruthy()
+      })
+
+    })
+
+    describe('schema url not in JSON - default schemas used', () => {
+      const wrapper = shallow(<ImportFileZone />)
+      let template, schemaUrl
+
+      it('gets the schemaUrl from the resource-template', () => {
+        template = require('../../__fixtures__/lcc_v0.0.2.json')
+        schemaUrl = wrapper.instance().schemaUrl(template)
+        expect(schemaUrl).toEqual(`https://ld4p.github.io/sinopia/schemas/${Config.defaultProfileSchemaVersion}/resource-template.json`)
+      })
+
+      it('displays resource template passing validation', async () => {
+        await wrapper.instance().promiseTemplateValidated(template, schemaUrl)
+        expect(wrapper.state().validTemplate).toBeTruthy()
+      })
+
+      it('gets the schemaUrl from the profile', () => {
+        template = require('../../__fixtures__/place_profile_v0.0.2.json')
+        schemaUrl = wrapper.instance().schemaUrl(template)
+        expect(schemaUrl).toEqual(`https://ld4p.github.io/sinopia/schemas/${Config.defaultProfileSchemaVersion}/profile.json`)
+      })
+
+      it('displays profile passing validation', async () => {
+        await wrapper.instance().promiseTemplateValidated(template, schemaUrl)
+        expect(wrapper.state().validTemplate).toBeTruthy()
+      })
+
+    })
+  })
+
+  describe('not schema valid', () => {
+    const wrapper = shallow(<ImportFileZone />)
+    let template, schemaUrl
+
+    it('gets the schemaUrl from the resource-template', () => {
+      template = require('../../__fixtures__/lcc_v0.1.0_invalid.json')
+      schemaUrl = wrapper.instance().schemaUrl(template)
+      expect(schemaUrl).toEqual('https://ld4p.github.io/sinopia/schemas/0.1.0/resource-template.json')
+    })
+
+    it('displays an error message when missing required property', async () => {
+      await wrapper.instance().promiseTemplateValidated(template, schemaUrl).catch((err) => {
+        expect(wrapper.state().validTemplate).toBeFalsy()
+        expect(err.toString()).toMatch("should have required property 'author'")
+      })
+    })
+
+    it('gets the schemaUrl from the resource-template', () => {
+      template = require('../../__fixtures__/lcc_v0.1.0_bad_id.json')
+      schemaUrl = wrapper.instance().schemaUrl(template)
+      expect(schemaUrl).toEqual('https://ld4p.github.io/sinopia/schemas/0.1.0/resource-template.json')
+    })
+
+    it('displays an error message when the id is invalid', async () => {
+      await wrapper.instance().promiseTemplateValidated(template, schemaUrl).catch((err) => {
+        expect(wrapper.state().validTemplate).toBeFalsy()
+        expect(err.toString()).toMatch('should match pattern "^\\S+$"')
+      })
+    })
+
+  })
+
+  describe('unfindable schema', () => {
+    const wrapper = shallow(<ImportFileZone />)
+    let template, schemaUrl
+
+    it('gets the schemaUrl from the resource-template', () => {
+      template = require('../../__fixtures__/edition_bad_schema.json')
+      schemaUrl = wrapper.instance().schemaUrl(template)
+      expect(schemaUrl).toEqual('https://ld4p.github.io/sinopia/schemas/not-there.json')
+    })
+
+    it('displays an error message', async () => {
+      await wrapper.instance().promiseTemplateValidated(template, schemaUrl).catch((err) => {
+        expect(wrapper.state().validTemplate).toBeFalsy()
+        expect(err.toString()).toMatch("Error: error getting json schemas")
+      })
+    })
+
+  })
+
 })
 
 describe('<DropZone />', () => {
@@ -57,7 +165,6 @@ describe('<DropZone />', () => {
 
   describe('simulating a file drop calls the file reading functions', () => {
     // NOTE: This is for code coverage only;  there are no expect statements
-    //  NOTE: this is covered by integration/schemaValidation.test but that doesn't show coverage
     // Dropzone throws an error when performing a drop simulate on the input.
     it('lets you input a selected file', () => {
       console.error = jest.fn()

--- a/__tests__/components/editor/ImportFileZone.test.js
+++ b/__tests__/components/editor/ImportFileZone.test.js
@@ -87,7 +87,7 @@ describe('<ImportFileZone />', () => {
     it('displays an error message when missing required property', async () => {
       await wrapper.instance().promiseTemplateValidated(template, schemaUrl).catch((err) => {
         expect(wrapper.state().validTemplate).toBeFalsy()
-        expect(err.toString()).toMatch("should have required property 'author'")
+        expect(err.toString()).toMatch("should have required property")
       })
     })
 

--- a/__tests__/components/editor/ImportFileZone.test.js
+++ b/__tests__/components/editor/ImportFileZone.test.js
@@ -100,7 +100,7 @@ describe('<ImportFileZone />', () => {
     it('displays an error message when the id is invalid', async () => {
       await wrapper.instance().promiseTemplateValidated(template, schemaUrl).catch((err) => {
         expect(wrapper.state().validTemplate).toBeFalsy()
-        expect(err.toString()).toMatch('should match pattern "^\\S+$"')
+        expect(err.toString()).toMatch('should match pattern')
       })
     })
 

--- a/__tests__/components/editor/ImportResourceTemplate.test.js
+++ b/__tests__/components/editor/ImportResourceTemplate.test.js
@@ -1,5 +1,6 @@
 // Copyright 2019 Stanford University see Apache2.txt for license
 
+import 'jsdom-global/register'
 import React from 'react'
 import { shallow } from 'enzyme'
 import ImportResourceTemplate from '../../../src/components/editor/ImportResourceTemplate'

--- a/__tests__/integration/schemaValidation.test.js
+++ b/__tests__/integration/schemaValidation.test.js
@@ -2,145 +2,23 @@
 import pupExpect from 'expect-puppeteer'
 import Config from '../../src/Config'
 
-describe('Editor', () => {
-  beforeAll(async () => {
-    jest.setTimeout(15000);
+describe('Importing a profile/template with bad JSON', () => {
+
+  it('Displays and error message', async () => {
+    jest.setTimeout(5000);
     await page.goto(`http://127.0.0.1:8888/${Config.awsCognitoJWTHashForTest}`)
+
+    await page.goto('http://127.0.0.1:8888/import')
+
+    await page.waitForSelector('button#ImportProfile')
+    await page.click('button#ImportProfile')
+
+    await pupExpect(page).toMatch('Drag and drop a resource template file in the box')
+    const fileInput = await page.$('.DropZone input[type="file"]')
+    await fileInput.uploadFile("__tests__/__fixtures__/ddc_bad_json.json")
+
+    jest.setTimeout(5000);
+    pupExpect(page).toMatchElement('div.alert-warning', { text: 'ERROR - CANNOT USE PROFILE/RESOURCE TEMPLATE: problem parsing JSON template: SyntaxError: Unexpected token # in JSON at position 0' })
   })
 
-  describe('importing a profile/template', () => {
-    // TODO: show ajv.validate was called
-    //   can't easily show because puppeteer is between this test and jest mocks
-    // it('runs validation', () => {
-    // })
-
-    // TODO: show it only fetches and loads any individual schema once
-
-    describe('schema valid', () => {
-      beforeEach(async () => {
-        console.warn(process.env.NODE_ENV)
-        await page.goto('http://127.0.0.1:8888/import')
-      })
-
-      describe('schema url in JSON', () => {
-        it('displays resource template passing validation', async () => {
-          pupExpect(page).not.toMatch('LC Classification Number')
-
-          await page.waitForSelector('button#ImportProfile')
-          await page.click('button#ImportProfile')
-          await pupExpect(page).toMatch('select a file to upload:')
-
-          const fileInput = await page.$('.DropZone input[type="file"]')
-          // await fileInput.uploadFile("__tests__/__fixtures__/lcc_v0.1.0.json")
-          // await pupExpect(page).toMatch('LC Classification Number')
-        })
-
-        it('displays profile passing validation', async () => {
-          pupExpect(page).not.toMatch('Place Associated with a Work')
-
-          await page.waitForSelector('button#ImportProfile')
-          await page.click('button#ImportProfile')
-          await pupExpect(page).toMatch('select a file to upload:')
-
-          const fileInput = await page.$('.DropZone input[type="file"]')
-          // await fileInput.uploadFile("__tests__/__fixtures__/place_profile_v0.1.0.json")
-          // await pupExpect(page).toMatch('Place Associated with a Work')
-        })
-      })
-      describe('schema url not in JSON - v0.0.2 schemas used', () => {
-        it('displays resource template passing validation', async () => {
-          pupExpect(page).not.toMatch('LC Classification Number')
-
-          await page.waitForSelector('button#ImportProfile')
-          await page.click('button#ImportProfile')
-          await pupExpect(page).toMatch('select a file to upload:')
-
-          const fileInput = await page.$('.DropZone input[type="file"]')
-          // const dialog = await pupExpect(page).toDisplayDialog(async () => {
-          //   await fileInput.uploadFile("__tests__/__fixtures__/lcc_v0.0.2.json")
-          // })
-          const exp_msg = `No schema url found in template. Using https://ld4p.github.io/sinopia/schemas/${Config.defaultProfileSchemaVersion}/resource-template.json`
-          // await expect(dialog.message()).toMatch(exp_msg)
-          // await dialog.dismiss()
-          // await pupExpect(page).toMatch('LC Classification Number')
-        })
-        it('displays profile passing validation', async () => {
-          pupExpect(page).not.toMatch('Place Associated with a Work')
-
-          await page.waitForSelector('button#ImportProfile')
-          await page.click('button#ImportProfile')
-          await pupExpect(page).toMatch('select a file to upload:')
-
-          const fileInput = await page.$('.DropZone input[type="file"]')
-          // const dialog = await pupExpect(page).toDisplayDialog(async () => {
-          //   await fileInput.uploadFile("__tests__/__fixtures__/place_profile_v0.0.2.json")
-          // })
-          const exp_msg = `No schema url found in template. Using https://ld4p.github.io/sinopia/schemas/${Config.defaultProfileSchemaVersion}/profile.json`
-          // await expect(dialog.message()).toMatch(exp_msg)
-          // await dialog.dismiss()
-          // await pupExpect(page).toMatch('Place Associated with a Work')
-        })
-      })
-    })
-
-    describe('not schema valid', () => {
-      let dialog
-      beforeAll(async() => {
-        await page.goto('http://127.0.0.1:8888/import')
-        await page.waitForSelector('button#ImportProfile')
-        await page.click('button#ImportProfile')
-        await pupExpect(page).toMatch('select a file to upload:')
-
-        const fileInput = await page.$('.DropZone input[type="file"]')
-        // dialog = await pupExpect(page).toDisplayDialog(() => {
-        //   fileInput.uploadFile("__tests__/__fixtures__/lcc_v0.1.0_invalid.json")
-        // })
-      })
-
-      it('displays dialog', async () => {
-        const exp_msg = "ERROR - CANNOT USE PROFILE/RESOURCE TEMPLATE: problem validating template: Error: [ { keyword: 'required'"
-        // await expect(dialog.message()).toMatch(exp_msg)
-      })
-      it('does not populate form from loaded file', async () => {
-        // await dialog.dismiss()
-        await pupExpect(page).not.toMatch('Invalid Resource Template')
-      })
-    })
-
-    describe('unfindable schema', () => {
-      let dialog
-      beforeAll(async() => {
-        const fileInput = await page.$('.DropZone input[type="file"]')
-        // dialog = await pupExpect(page).toDisplayDialog(async () => {
-        //   await fileInput.uploadFile("__tests__/__fixtures__/edition_bad_schema.json")
-        // })
-      })
-      it('displays dialog', async () => {
-        const exp_msg = "ERROR - CANNOT USE PROFILE/RESOURCE TEMPLATE: problem validating template: Error: error getting json schemas TypeError: Cannot read property '1' of null"
-        // await expect(dialog.message()).toMatch(exp_msg)
-      })
-      it('does not populate form from loaded file', async () => {
-        // await dialog.dismiss()
-        await pupExpect(page).not.toMatch('Edition Bad Schema')
-      })
-    })
-
-    describe('bad JSON', async () => {
-      let dialog
-      beforeAll(async() => {
-        const fileInput = await page.$('.DropZone input[type="file"]')
-        // dialog = await pupExpect(page).toDisplayDialog(async () => {
-        //   await fileInput.uploadFile("__tests__/__fixtures__/ddc_bad_json.json")
-        // })
-      })
-      it('displays dialog', async () => {
-        const exp_msg = "ERROR - CANNOT USE PROFILE/RESOURCE TEMPLATE: problem parsing JSON template: SyntaxError: Unexpected token } in JSON at position"
-        // await expect(dialog.message()).toMatch(exp_msg)
-      })
-      it('does not populate form from loaded file', async () => {
-        // await dialog.dismiss()
-        await pupExpect(page).not.toMatch('DDC Bad JSON')
-      })
-    })
-  })
 })

--- a/__tests__/integration/schemaValidation.test.js
+++ b/__tests__/integration/schemaValidation.test.js
@@ -4,7 +4,7 @@ import Config from '../../src/Config'
 
 describe('Importing a profile/template with bad JSON', () => {
 
-  it('Displays and error message', async () => {
+  it('Displays an error message', async () => {
     jest.setTimeout(5000);
     await page.goto(`http://127.0.0.1:8888/${Config.awsCognitoJWTHashForTest}`)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6570,8 +6570,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6592,14 +6591,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6614,20 +6611,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6744,8 +6738,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6757,7 +6750,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6772,7 +6764,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6780,14 +6771,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6806,7 +6795,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6887,8 +6875,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6900,7 +6887,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6986,8 +6972,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7023,7 +7008,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7043,7 +7027,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7087,14 +7070,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -8818,8 +8799,7 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -8840,14 +8820,12 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -8862,20 +8840,17 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -8992,8 +8967,7 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "ini": {
               "version": "1.3.5",
@@ -9005,7 +8979,6 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -9020,7 +8993,6 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -9028,14 +9000,12 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -9054,7 +9024,6 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -9135,8 +9104,7 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -9148,7 +9116,6 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -9234,8 +9201,7 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -9271,7 +9237,6 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -9291,7 +9256,6 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -9335,14 +9299,12 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },

--- a/src/Config.js
+++ b/src/Config.js
@@ -1,10 +1,11 @@
 class Config {
-  static get defaultProfileSchemaVersion() {
-    return process.env.DEFAULT_PROFILE_SCHEMA_VERSION || '0.0.9'
-  }
 
   static get defaultSinopiaGroupId() {
     return process.env.SINOPIA_GROUP || 'ld4p'
+  }
+
+  static get defaultProfileSchemaVersion() {
+    return process.env.DEFAULT_PROFILE_SCHEMA_VERSION || '0.0.2'
   }
 
   static get sinopiaDomainName() {


### PR DESCRIPTION
This PR was originally about testing the "spaceless" IDs in the JSON schema (See https://github.com/LD4P/sinopia/pull/201) but morphed into refatoring the schema validation tests to happen at the component/unit-test level in stead of integration tests (which were incomplete and error-prone). There is still one integration test for the malformed JSON test which was dificult to test at the unit-test level. A beneficial side-effect is that this refactoring increases overall code-coverage.