### PR TITLE
Tiny test tweaks (no code changed)

### DIFF
--- a/__tests__/components/App.test.js
+++ b/__tests__/components/App.test.js
@@ -68,7 +68,8 @@ describe("#routes", () => {
 
   })
 
-  //TODO: Fix getting jwtAuth props to appear in the App component so that PrivateRoute will not trigger the Login component
+  //TODO: https://github.com/LD4P/sinopia_editor/issues/380
+  //  Fix getting jwtAuth props to appear in the App component so that PrivateRoute will not trigger the Login component
   // describe('Private route', () => {
   //   const renderRoutes = path =>
   //     mount(

--- a/__tests__/components/editor/Header.test.js
+++ b/__tests__/components/editor/Header.test.js
@@ -11,24 +11,18 @@ describe('<Header />', () => {
     expect(wrapper.find("h1.editor-logo").text()).toBe("LINKED DATA EDITOR")
   })
 
-  //Nav tabs tests
-  
-  //Expect to find three tabs
-  it ('displays the header tabs', () => {
-      expect(wrapper.find("ul.editor-navtabs NavLink").length).toBe(3);
+  describe('nav tabs', () => {
+    it ('displays 3 header tabs', () => {
+      expect(wrapper.find("ul.editor-navtabs NavLink").length).toBe(3)
+    })
+    it ('has browse URL', () => {
+      expect(wrapper.find("ul.editor-navtabs NavLink[to='/browse']").length).toBe(1)
+    })
+    it ('has editor URL', () => {
+      expect(wrapper.find("ul.editor-navtabs NavLink[to='/editor']").length).toBe(1)
+    })
+    it ('has Import Resource Template URL', () => {
+      expect(wrapper.find("ul.editor-navtabs NavLink[to='/import']").length).toBe(1)
+    })
   })
-
-  //Expect to find BROWSE URL
-  it ('uses the browse URL', () => {
-        expect(wrapper.find("ul.editor-navtabs NavLink[to='/browse']").length).toBe(1);
-   })
-
-   //Expect to find EDITOR URL
-     it ('uses the editor URL', () => {
-        expect(wrapper.find("ul.editor-navtabs NavLink[to='/editor']").length).toBe(1);
-   })
-   //Expect to find Import Resource Template URL
-     it ('uses the Import Resource Template URL', () => {
-        expect(wrapper.find("ul.editor-navtabs NavLink[to='/import']").length).toBe(1);
-   })
 })


### PR DESCRIPTION
Reviewing PR #471 made me wonder if there were more commented out tests, besides schemaValidation, that should be skipped.  I did a super quick grep check and ended up making these two tweaks.

Yay - the answer was we only have one other commented out test and the whole test was commented out, not just the guts.