### PR TITLE
Fix AWS Cognito Domain to remove extra https in login link

### DIFF
--- a/__tests__/Config.test.js
+++ b/__tests__/Config.test.js
@@ -29,7 +29,7 @@ describe('Config', () => {
     })
 
     it('aws cognito domain has static value', () => {
-      expect(Config.awsCognitoDomain).toEqual('sinopia-development.auth.us-west-2.amazoncognito.com')
+      expect(Config.awsCognitoDomain).toEqual('https://sinopia-development.auth.us-west-2.amazoncognito.com')
     })
 
     it('sinopia server url has a static value', () => {
@@ -86,7 +86,7 @@ describe('Config', () => {
         SINOPIA_GROUP: 'foobar',
         TRELLIS_BASE_URL: 'https://sinopia_server.foo',
         COGNITO_CLIENT_ID: '1a2b3c',
-        AWS_COGNITO_DOMAIN: 'sinopia-foo.amazoncognito.com'
+        AWS_COGNITO_DOMAIN: 'https://sinopia-foo.amazoncognito.com'
       }
     })
 
@@ -116,7 +116,7 @@ describe('Config', () => {
     })
 
     it('aws cognito domain overrides static value', () => {
-      expect(Config.awsCognitoDomain).toEqual('sinopia-foo.amazoncognito.com')
+      expect(Config.awsCognitoDomain).toEqual('https://sinopia-foo.amazoncognito.com')
     })
 
     describe('interpolated links from environmental overrides', () => {

--- a/src/Config.js
+++ b/src/Config.js
@@ -13,7 +13,7 @@ class Config {
   }
 
   static get awsCognitoDomain() {
-    return process.env.AWS_COGNITO_DOMAIN || 'sinopia-development.auth.us-west-2.amazoncognito.com'
+    return process.env.AWS_COGNITO_DOMAIN || 'https://sinopia-development.auth.us-west-2.amazoncognito.com'
   }
 
   static get spoofSinopiaServer() {
@@ -40,19 +40,19 @@ class Config {
   }
 
   static get awsCognitoLoginUrl() {
-    return `https://${this.awsCognitoDomain}/login?response_type=token&client_id=${this.awsClientID}&redirect_uri=${this.sinopiaUrl}`
+    return `${this.awsCognitoDomain}/login?response_type=token&client_id=${this.awsClientID}&redirect_uri=${this.sinopiaUrl}`
   }
 
   static get awsCognitoLogoutUrl() {
-    return `https://${this.awsCognitoDomain}/logout?response_type=token&client_id=${this.awsClientID}&logout_uri=${this.sinopiaUrl}&redirect_uri=${this.sinopiaUrl}`
+    return `${this.awsCognitoDomain}/logout?response_type=token&client_id=${this.awsClientID}&logout_uri=${this.sinopiaUrl}&redirect_uri=${this.sinopiaUrl}`
   }
 
   static get awsCognitoForgotPasswordUrl() {
-    return `https://${this.awsCognitoDomain}/forgotPassword?response_type=token&client_id=${this.awsClientID}&redirect_uri=${this.sinopiaUrl}`
+    return `${this.awsCognitoDomain}/forgotPassword?response_type=token&client_id=${this.awsClientID}&redirect_uri=${this.sinopiaUrl}`
   }
 
   static get awsCognitoResetPasswordUrl() {
-    return `https://${this.awsCognitoDomain}/signup?response_type=token&client_id=${this.awsClientID}&redirect_uri=${this.sinopiaUrl}`
+    return `${this.awsCognitoDomain}/signup?response_type=token&client_id=${this.awsClientID}&redirect_uri=${this.sinopiaUrl}`
   }
 
   static get awsCognitoJWTHashForTest() {


### PR DESCRIPTION
The last PR did not fix the login link to AWS. I believe this should do the trick.