### PR TITLE
Going directly to editor route redirects to the "Resource Templates" tab

### DIFF
--- a/__tests__/components/App.test.js
+++ b/__tests__/components/App.test.js
@@ -12,6 +12,8 @@ import Editor from '../../src/components/editor/Editor'
 import Browse from '../../src/components/editor/Browse'
 import Login from '../../src/components/Login'
 import Footer from '../../src/components/Footer'
+import { saveState } from '../../src/localStorage'
+import ImportResourceTemplate from "../../src/components/editor/ImportResourceTemplate";
 
 describe('<App />', () =>{
   const wrapper = shallow(<App.WrappedComponent />)
@@ -36,6 +38,17 @@ describe("#routes", () => {
         </MemoryRouter>
       )
 
+    const renderEditorRoute = path =>
+      mount(
+        <MemoryRouter initialEntries={[path]}>
+          <RootContainer>
+            <App>
+              <Editor location={{state: { resourceTemplateId: 'resourceTemplate:bf2:Monograph:Instance' }}} />
+            </App>
+          </RootContainer>
+        </MemoryRouter>
+      )
+
     it('root renders HomePage component', async () => {
       const component = renderRoutes("/")
       await expect(component.find(HomePage).length).toEqual(1)
@@ -44,11 +57,13 @@ describe("#routes", () => {
     it('/editor renders Editor component', () => {
       // Stub `Config.spoofSinopiaServer` static getter to force RT to come from server
       jest.spyOn(Config, 'spoofSinopiaServer', 'get').mockReturnValue(false)
-      const component = renderRoutes("/editor")
-      expect(component.find(Editor).length).toEqual(1)
+      saveState({loginJwt: Config.awsCognitoJWTHashForTest, isAuthenticated: true}, 'jwtAuth')
+      const component = renderEditorRoute("/editor")
+      expect(component.find(ImportResourceTemplate).length).toEqual(1)
     })
 
     it('/templates renders the Login component (with location props) if the user is not authenticated', () => {
+      saveState({loginJwt: {}, isAuthenticated: false}, 'jwtAuth')
       const component = renderRoutes("/templates")
       expect(component.find(Login).length).toEqual(1)
       expect(component.find(Login).prop('location')).toBeDefined()

--- a/__tests__/sinopiaServer.test.js
+++ b/__tests__/sinopiaServer.test.js
@@ -58,4 +58,38 @@ describe('sinopiaServerSpoof', () => {
     })
 
   })
+
+  describe('spoofedResourcesInGroupContainer', () => {
+    it('returns a spoofed response object with contained resource template IDs', () => {
+      expect(sinopiaServer.spoofedResourcesInGroupContainer('ld4p')).toMatchObject({
+        response: {
+          body: {
+            "@id": "http://spoof.trellis.io/ld4p",
+            contains: [
+              "http://spoof.trellis.io/ld4p/resourceTemplate:bf2:Monograph:Instance",
+              "http://spoof.trellis.io/ld4p/resourceTemplate:bf2:Monograph:Work",
+              "http://spoof.trellis.io/ld4p/resourceTemplate:bf2:Identifiers:Barcode",
+              "http://spoof.trellis.io/ld4p/resourceTemplate:bf2:Note",
+              "http://spoof.trellis.io/ld4p/resourceTemplate:bf2:ParallelTitle",
+              "http://spoof.trellis.io/ld4p/resourceTemplate:bf2:Title",
+              "http://spoof.trellis.io/ld4p/resourceTemplate:bf2:Title:Note",
+              "http://spoof.trellis.io/ld4p/resourceTemplate:bflc:TranscribedTitle",
+              "http://spoof.trellis.io/ld4p/resourceTemplate:bf2:Title:VarTitle",
+              "http://spoof.trellis.io/ld4p/resourceTemplate:bf2:WorkTitle",
+              "http://spoof.trellis.io/ld4p/resourceTemplate:bf2:WorkVariantTitle",
+              "http://spoof.trellis.io/ld4p/resourceTemplate:bf2:Identifiers:LC",
+              "http://spoof.trellis.io/ld4p/resourceTemplate:bf2:Identifiers:DDC",
+              "http://spoof.trellis.io/ld4p/resourceTemplate:bf2:Identifiers:Shelfmark",
+              "http://spoof.trellis.io/ld4p/resourceTemplate:bf2:Item",
+              "http://spoof.trellis.io/ld4p/resourceTemplate:bf2:Item:Retention",
+              "http://spoof.trellis.io/ld4p/resourceTemplate:bf2:Item:ItemAcqSource",
+              "http://spoof.trellis.io/ld4p/resourceTemplate:bf2:Item:Enumeration",
+              "http://spoof.trellis.io/ld4p/resourceTemplate:bf2:Item:Chronology"
+            ]
+          }
+        }
+      })
+    })
+  })
+
 })

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -44,13 +44,11 @@ class App extends Component{
       />
     )
 
-    const defaultRtId = 'resourceTemplate:bf2:Monograph:Instance'
-
     return(
       <div id="app">
         <Switch>
           <Route exact path='/' render={(props)=><HomePage {...props} triggerHandleOffsetMenu={this.props.handleOffsetMenu} />} />
-          <Route exact path='/editor' render={(props)=><Editor {...props} resourceTemplateId={defaultRtId} triggerHandleOffsetMenu={this.props.handleOffsetMenu} />} />
+          <Route exact path='/editor' render={(props)=><Editor {...props} triggerHandleOffsetMenu={this.props.handleOffsetMenu} />} />
           <PrivateRoute exact path='/templates' component={(props)=><ImportResourceTemplate {...props} triggerHandleOffsetMenu={this.props.handleOffsetMenu} />}/>
           <Route exact path='/browse' render={(props)=><Browse {...props} triggerHandleOffsetMenu={this.props.handleOffsetMenu} />} />
           <Route path="/login" render={(props)=><Login {...props} location={{state: { from: props.location }}}/>} />

--- a/src/components/editor/Editor.jsx
+++ b/src/components/editor/Editor.jsx
@@ -29,9 +29,7 @@ class Editor extends Component {
           resourceTemplateId: this.props.location.state.resourceTemplateId
         })
       } else {
-        this.setState({
-          resourceTemplateId: this.props.resourceTemplateId
-        })
+        this.props.history.push("/templates");
       }
       this.setState({tempRtState: false})
     }
@@ -51,6 +49,7 @@ class Editor extends Component {
   )
 
   render() {
+
     let authenticationMessage = <div className="alert alert-warning alert-dismissible">
       <button className="close" data-dismiss="alert" aria-label="close">&times;</button>
       Alert! No data can be saved unless you are logged in with group permissions.
@@ -98,7 +97,8 @@ Editor.propTypes = {
   resetStore: PropTypes.func,
   jwtAuth: PropTypes.object,
   location: PropTypes.object,
-  resourceTemplateId: PropTypes.string
+  resourceTemplateId: PropTypes.string,
+  history: PropTypes.object
 }
 
 const mapDispatchToProps = dispatch => ({

--- a/src/components/editor/ResourceTemplateForm.jsx
+++ b/src/components/editor/ResourceTemplateForm.jsx
@@ -233,7 +233,6 @@ ResourceTemplateForm.propTypes = {
   rdfOuterSubject: PropTypes.object,
   propPredicate: PropTypes.string,
   buttonID: PropTypes.number,
-  generateLD: PropTypes.object.isRequired,
   handleMyItemsChange: PropTypes.func,
   handleRemoveAllContent: PropTypes.func
 }

--- a/src/components/editor/SinopiaResourceTemplates.jsx
+++ b/src/components/editor/SinopiaResourceTemplates.jsx
@@ -5,7 +5,8 @@ import PropTypes from 'prop-types'
 import { Link } from 'react-router-dom'
 import {BootstrapTable, TableHeaderColumn} from 'react-bootstrap-table'
 import Config from '../../../src/Config'
-import { getGroups, listReourcesInGroupContainer, getResourceTemplate } from '../../sinopiaServer'
+import { getGroups, listResourcesInGroupContainer,
+         getResourceTemplate, listResourcesInGroupContainer } from '../../sinopiaServer'
 const _ = require('lodash')
 const SinopiaServer = require('sinopia_server')
 const instance = new SinopiaServer.LDPApi()
@@ -31,7 +32,7 @@ class SinopiaResourceTemplates extends Component {
       await this.fulfillGroupPromise(groupPromise).then(async () => {
         this.state.groupData.map(group => {
           const groupName = this.resourceToName(group)
-          listReourcesInGroupContainer(groupName).then((data) => {
+          listResourcesInGroupContainer(groupName).then((data) => {
             this.fulfillGroupData(data)
           }).catch(() => {})
         })

--- a/src/components/editor/SinopiaResourceTemplates.jsx
+++ b/src/components/editor/SinopiaResourceTemplates.jsx
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types'
 import { Link } from 'react-router-dom'
 import {BootstrapTable, TableHeaderColumn} from 'react-bootstrap-table'
 import Config from '../../../src/Config'
+import { getGroups, listReourcesInGroupContainer, getResourceTemplate } from '../../sinopiaServer'
 const _ = require('lodash')
 const SinopiaServer = require('sinopia_server')
 const instance = new SinopiaServer.LDPApi()
@@ -23,18 +24,14 @@ class SinopiaResourceTemplates extends Component {
 
   async componentDidUpdate(prevProps) {
     if (this.props.updateKey > prevProps.updateKey) {
-      const groupPromise = new Promise((resolve) => {
-        resolve(instance.getBaseWithHttpInfo())
-      }).then((data) => {
+      const groupPromise = getGroups().then(data => {
         return data
       }).catch(() => {})
 
       await this.fulfillGroupPromise(groupPromise).then(async () => {
-        this.state.groupData.map((group) => {
+        this.state.groupData.map(group => {
           const groupName = this.resourceToName(group)
-          new Promise((resolve) => {
-            resolve(instance.getGroupWithHttpInfo(groupName))
-          }).then((data) => {
+          listReourcesInGroupContainer(groupName).then((data) => {
             this.fulfillGroupData(data)
           }).catch(() => {})
         })
@@ -43,7 +40,7 @@ class SinopiaResourceTemplates extends Component {
   }
 
   fulfillGroupPromise = (promise) => {
-    promise.then((data) => {
+    promise.then(data => {
       const contains = [].concat(data.response.body.contains)
       this.setState({groupData: contains})
     }).catch((error) => {
@@ -58,7 +55,7 @@ class SinopiaResourceTemplates extends Component {
     if (data.response.body.contains !== undefined) {
       const contains = [].concat(data.response.body.contains)
 
-      contains.map((c) => {
+      contains.map(c => {
         const name = this.resourceToName(c)
 
         this.groupDataPromise(groupName, name).then((data) => {
@@ -76,7 +73,8 @@ class SinopiaResourceTemplates extends Component {
   }
 
   groupDataPromise = (groupName, name) => new Promise(async (resolve) => {
-    await resolve(instance.getResourceWithHttpInfo(groupName, name, { acceptEncoding: 'application/json' }))
+    // await resolve(instance.getResourceWithHttpInfo(groupName, name, { acceptEncoding: 'application/json' }))
+    await resolve(getResourceTemplate(name, groupName))
   })
 
   resourceToName = (resource) => {

--- a/src/components/editor/SinopiaResourceTemplates.jsx
+++ b/src/components/editor/SinopiaResourceTemplates.jsx
@@ -5,8 +5,7 @@ import PropTypes from 'prop-types'
 import { Link } from 'react-router-dom'
 import {BootstrapTable, TableHeaderColumn} from 'react-bootstrap-table'
 import Config from '../../../src/Config'
-import { getGroups, listResourcesInGroupContainer,
-         getResourceTemplate, listResourcesInGroupContainer } from '../../sinopiaServer'
+import { getGroups, listResourcesInGroupContainer, getResourceTemplate } from '../../sinopiaServer'
 const _ = require('lodash')
 const SinopiaServer = require('sinopia_server')
 const instance = new SinopiaServer.LDPApi()

--- a/src/sinopiaServer.js
+++ b/src/sinopiaServer.js
@@ -129,7 +129,7 @@ export const getGroups = () => {
   })
 }
 
-export const listReourcesInGroupContainer = (group) => {
+export const listResourcesInGroupContainer = (group) => {
   if (Config.spoofSinopiaServer)
     return new Promise(resolve => {
       resolve(spoofedResourcesInGroupContainer(group))

--- a/src/sinopiaServer.js
+++ b/src/sinopiaServer.js
@@ -74,6 +74,22 @@ const getSpoofedResourceTemplate = (templateId) => {
   })
 }
 
+export const spoofedResourcesInGroupContainer = (group) => {
+  const container = `http://spoof.trellis.io/${group}`
+  const ids = []
+  resourceTemplateId2Json.map(rt => {
+    ids.push(`${container}/${rt.id}`)
+  })
+  return {
+    response: {
+      body: {
+        "@id": container,
+        contains: ids
+      }
+    }
+  }
+}
+
 const getResourceTemplateFromServer = (templateId, group) => {
   // Allow function to be called without second arg
   if (!group)
@@ -94,4 +110,32 @@ export const getResourceTemplate = (templateId, group) => {
     return getSpoofedResourceTemplate(templateId)
 
   return getResourceTemplateFromServer(templateId, group)
+}
+
+export const getGroups = () => {
+  if (Config.spoofSinopiaServer)
+    return new Promise(resolve => {
+      resolve({
+        response: {
+          body: {
+            contains: 'http://spoof.trellis.io/ld4p'
+          }
+        }
+      })
+    })
+
+  return new Promise(resolve => {
+    resolve(instance.getBaseWithHttpInfo())
+  })
+}
+
+export const listReourcesInGroupContainer = (group) => {
+  if (Config.spoofSinopiaServer)
+    return new Promise(resolve => {
+      resolve(spoofedResourcesInGroupContainer(group))
+    })
+
+  return new Promise(resolve => {
+    resolve(instance.getGroupWithHttpInfo(group))
+  })
 }


### PR DESCRIPTION
Fixes #480 

- Redirect to Import Templates if there is no resourceTemplateId in state (i.e. no template to edit with yet)
- Spoof all of the local templates in the list of available resource templates (because we no longer will be loading a default RT for testing)