### PR TITLE
 PropertyActionButtons: AddButton, MintButton are components

### DIFF
--- a/__tests__/components/editor/PropertyActionButtons.test.js
+++ b/__tests__/components/editor/PropertyActionButtons.test.js
@@ -3,17 +3,39 @@
 import React from 'react'
 import { shallow } from 'enzyme'
 
-import PropertyActionButtons from '../../../src/components/editor/PropertyActionButtons'
+import { AddButton, MintButton, PropertyActionButtons } from '../../../src/components/editor/PropertyActionButtons'
 
-describe('<PropertyActionButtons />', () => {
+describe('<AddButton />', () => {
+  const addButtonWrapper = shallow(<AddButton />)
 
-  const wrapper = shallow(<PropertyActionButtons />)
-  const buttons = wrapper.find('button')
-
-  it('has two buttons', () => {
-    expect(buttons.length).toEqual(2)
-    expect(buttons.find('.btn-default')).toBeTruthy()
-    expect(buttons.find('.btn-success')).toBeTruthy()
+  it('has label "Add"', () => {
+    expect(addButtonWrapper.text()).toEqual("Add")
   })
 
+  it('is not disabled by default', () => {
+    expect(addButtonWrapper.instance().state.disabled).toBeFalsy()
+  })
+})
+
+describe('<MintButton />', () => {
+  const mintButtonWrapper = shallow(<MintButton />)
+
+  it('has label "Mint URI"', () => {
+    expect(mintButtonWrapper.text()).toEqual("Mint URI")
+  })
+
+  it('is disabled by default', () => {
+    expect(mintButtonWrapper.instance().state.disabled).toBeTruthy()
+  })
+})
+
+describe('<PropertyActionButtons />', () => {
+  const propertyActionWrapper = shallow(<PropertyActionButtons />)
+
+  it('contains AddButton', () => {
+    expect(propertyActionWrapper.find(AddButton)).toBeTruthy()
+  })
+  it('contains MintButton', () => {
+    expect(propertyActionWrapper.find(MintButton)).toBeTruthy()
+  })
 })

--- a/src/components/editor/PropertyActionButtons.jsx
+++ b/src/components/editor/PropertyActionButtons.jsx
@@ -3,6 +3,38 @@
 import React, {Component} from 'react'
 import PropTypes from 'prop-types'
 
+export class AddButton extends Component {
+
+  constructor(props) {
+    super(props)
+    this.state = {
+      disabled: false
+    }
+  }
+
+  render() {
+    return(<button className="btn btn-default btn-sm"
+            onClick={this.props.onClick}
+            disabled={this.state.disabled}>Add</button>)
+  }
+}
+
+export class MintButton extends Component {
+
+  constructor(props) {
+    super(props)
+    this.state = {
+      disabled: true
+    }
+  }
+
+  render() {
+    return(<button onClick={this.props.onClick}
+                   disabled={this.state.disabled}
+                   className="btn btn-success btn-sm">Mint URI</button>)
+  }
+}
+
 export class PropertyActionButtons extends Component {
 
   constructor(props) {
@@ -11,10 +43,18 @@ export class PropertyActionButtons extends Component {
 
   render() {
     return(<div className="btn-group" role="group" aria-label="...">
-      <button onClick={this.props.handleMintUri} className="btn btn-success btn-sm">Mint URI</button>
-      <button className="btn btn-default btn-sm" onClick={this.props.handleAddClick}>Add</button>
+      <MintButton onClick={this.props.handleMintUri} />
+      <AddButton onClick={this.props.handleAddClick} />
     </div>)
   }
+}
+
+AddButton.propTypes = {
+  onClick: PropTypes.func
+}
+
+MintButton.propTypes = {
+  onClick: PropTypes.func
 }
 
 PropertyActionButtons.propTypes = {


### PR DESCRIPTION
@jermnelson made the changes to <PropertyActionButtons>;  I mostly mucked about with tests.

Make "Add" and "MintURI" buttons into components.

Found a bit of a testing boondoggle in PropertyTemplateOutline tests -- a number of false positives.  Will be addressing those by making issues and/or PRs.

This PR should help with all things about repeatable properties for M3:
- #387 Add Button should be disabled when repeatable is false and more than one value
- #346 Handle repeatable true for a resource
- #217 implement repeatable = true (yes, prob a dup ticket, but UAT ticket)
- #210 allow duplicate values when property is repeatable