### PR TITLE
More test cleanup

### DIFF
--- a/__tests__/components/editor/OutlineHeader.test.js
+++ b/__tests__/components/editor/OutlineHeader.test.js
@@ -3,6 +3,7 @@
 import React from 'react'
 import { shallow } from 'enzyme'
 import OutlineHeader from '../../../src/components/editor/OutlineHeader'
+import { faMinusSquare, faPlusSquare } from '@fortawesome/free-solid-svg-icons'
 
 describe('<OutlineHeader />', () => {
   let headerProps = {
@@ -15,5 +16,18 @@ describe('<OutlineHeader />', () => {
 
   it('Contains a FontAwesomeIcon and label value from props', () => {
     expect(wrapper.find("div").text()).toBe(` <FontAwesomeIcon /> ${headerProps.label}`)
+  })
+
+  it('anchor is plus when collapsed', () => {
+    const faWrapper = wrapper.find('[icon]')
+    expect(faWrapper.getElement(0).props.icon).toEqual(faPlusSquare)
+  })
+
+  it('anchor is minus when expanded', () => {
+    let expandedProps = Object.assign({}, headerProps)
+    expandedProps.collapsed = false
+    const expWrapper = shallow(<OutlineHeader {...expandedProps} />)
+    const faWrapper = expWrapper.find('[icon]')
+    expect(faWrapper.getElement(0).props.icon).toEqual(faMinusSquare)
   })
 })

--- a/__tests__/components/editor/PropertyTemplateOutline.test.js
+++ b/__tests__/components/editor/PropertyTemplateOutline.test.js
@@ -291,25 +291,25 @@ describe('<PropertyTemplateOutline /> with propertyTemplate Refs', () => {
     expect(childOutlineHeader.props().collapsed).toBeTruthy()
   })
 
-  it('clicking removes collapsed state', async () => {
-    // FIXME: this test gives false positive
-    await wrapper.instance().fullfillRTPromises(promises).then(() => wrapper.update()).then(() => {
-      const childOutlineHeader = wrapper.find(OutlineHeader)
-      childOutlineHeader.find('a').simulate('click')
-      expect(wrapper.state().collapsed).toBeFalsy() // correct
-      expect(wrapper.state().collapsed).toBeTruthy() // incorrect
-    }).catch(() => {})
+  it.skip('clicking removes collapsed state', async () => {
+    // FIXME: this test gives false positive - see github issue #496
+    // await wrapper.instance().fullfillRTPromises(promises).then(() => wrapper.update()).then(() => {
+    //   const childOutlineHeader = wrapper.find(OutlineHeader)
+    //   childOutlineHeader.find('a').simulate('click')
+    //   expect(wrapper.state().collapsed).toBeFalsy() // correct
+    //   expect(wrapper.state().collapsed).toBeTruthy() // incorrect
+    // }).catch(() => {})
   })
 
-  it('handles "Add" button click', async () => {
-    // FIXME: this test gives false positive
-    await wrapper.instance().fullfillRTPromises(promises).then(() => wrapper.update()).then(() => {
-      const addButton = wrapper.find('div > section > PropertyActionButtons > div > AddButton')
-      addButton.handleClick = mockHandleAddClick
-      addButton.simulate('click')
-      expect(mockHandleAddClick.mock.calls.length).toBe(1) // correct
-      expect(mockHandleAddClick.mock.calls.length).toBe(0) // incorrect
-    }).catch(() => {})
+  it.skip('handles "Add" button click', async () => {
+    // FIXME: this test gives false positive - see github issue #496
+    // await wrapper.instance().fullfillRTPromises(promises).then(() => wrapper.update()).then(() => {
+    //   const addButton = wrapper.find('div > section > PropertyActionButtons > div > AddButton')
+    //   addButton.handleClick = mockHandleAddClick
+    //   addButton.simulate('click')
+    //   expect(mockHandleAddClick.mock.calls.length).toBe(1) // correct
+    //   expect(mockHandleAddClick.mock.calls.length).toBe(0) // incorrect
+    // }).catch(() => {})
   })
 
   it('handles the addClick method callback call', () => {
@@ -317,15 +317,15 @@ describe('<PropertyTemplateOutline /> with propertyTemplate Refs', () => {
     expect(mockHandleAddClick.mock.calls.length).toBe(1)
   })
 
-  it ('handles "Mint URI" button click', async () => {
-    // FIXME: this test gives false positive
-    await wrapper.instance().fullfillRTPromises(promises).then(() => wrapper.update()).then(() => {
-      const mintButton = wrapper.find('div > section > PropertyActionButtons > div > MintButton')
-      mintButton.handleClick = mockHandleAddClick
-      mintButton.simulate('click')
-      expect(mockHandleMintUri.mock.calls.length).toBe(1) // correct
-      expect(mockHandleMintUri.mock.calls.length).toBe(1) // incorrect
-    }).catch(() => {})
+  it.skip('handles "Mint URI" button click', async () => {
+    // FIXME: this test gives false positive - see github issue #496
+    // await wrapper.instance().fullfillRTPromises(promises).then(() => wrapper.update()).then(() => {
+    //   const mintButton = wrapper.find('div > section > PropertyActionButtons > div > MintButton')
+    //   mintButton.handleClick = mockHandleAddClick
+    //   mintButton.simulate('click')
+    //   expect(mockHandleMintUri.mock.calls.length).toBe(1) // correct
+    //   expect(mockHandleMintUri.mock.calls.length).toBe(1) // incorrect
+    // }).catch(() => {})
   })
 
   // TODO: revisit when MintButton is enabled (see github issue #283)

--- a/__tests__/components/editor/PropertyTemplateOutline.test.js
+++ b/__tests__/components/editor/PropertyTemplateOutline.test.js
@@ -7,19 +7,11 @@ import InputLiteral from '../../../src/components/editor/InputLiteral'
 import InputListLOC from '../../../src/components/editor/InputListLOC'
 import InputLookupQA from '../../../src/components/editor/InputLookupQA'
 import OutlineHeader from '../../../src/components/editor/OutlineHeader'
+// FIXME: from tests giving false positive - see github issue #496
+// import { PropertyActionButtons, AddButton } from '../../../src/components/editor/PropertyActionButtons'
 import Config from '../../../src/Config'
 import { getLookupConfigItem, PropertyTemplateOutline, valueTemplateRefTest, getLookupConfigItems } from '../../../src/components/editor/PropertyTemplateOutline'
 import PropertyTypeRow from '../../../src/components/editor/PropertyTypeRow'
-
-const mockResponse = (status, statusText, response) => {
-  return new Response(response, {
-    status: status,
-    statusText: statusText,
-    headers: {
-      'Content-type': 'application/json'
-    }
-  }).body
-}
 
 const responseBody = [{
   response: {
@@ -49,12 +41,6 @@ const responseBody = [{
   }
 }]
 
-const asyncCall = (index) => {
-  const response = mockResponse(200, null, responseBody[index])
-  return response
-}
-
-const promises = Promise.all([ asyncCall(0) ])
 const mockHandleCollapsed = jest.fn()
 const mockHandleAddClick = jest.fn()
 const mockHandleMintUri = jest.fn()
@@ -90,7 +76,6 @@ describe('getLookupConfigItem module function', () => {
 })
 
 describe('<PropertyTemplateOutline />', () => {
-  const mockInitNewResourceTemplate = jest.fn()
   const propertyRtProps = {
     propertyTemplate:
       {
@@ -257,7 +242,8 @@ describe('<PropertyTemplateOutline /> with <InputLookupQA /> component', () => {
 
 describe('<PropertyTemplateOutline /> with propertyTemplate Refs', () => {
   const property = {
-    propertyTemplate: {
+    propertyTemplate:
+    {
       "propertyLabel": "Notes about the CreativeWork",
       "remark": "This is a great note",
       "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
@@ -291,8 +277,32 @@ describe('<PropertyTemplateOutline /> with propertyTemplate Refs', () => {
     expect(childOutlineHeader.props().collapsed).toBeTruthy()
   })
 
+
+  // FIXME: from tests giving false positive - see github issue #496
+
+  // const mockResponse = (status, statusText, response) => {
+  //   return new Response(response, {
+  //     status: status,
+  //     statusText: statusText,
+  //     headers: {
+  //       'Content-type': 'application/json'
+  //     }
+  //   }).body
+  // }
+  // const asyncCall = (index) => {
+  //   const response = mockResponse(200, null, responseBody[index])
+  //   return response
+  // }
+  // const promises = Promise.all([ asyncCall(0) ])
+
   it.skip('clicking removes collapsed state', async () => {
     // FIXME: this test gives false positive - see github issue #496
+    // FIXME:  collapsed isn't a state, it's a prop
+    // FIXME:  in order to examine STATE after simulate, you must do a fresh "find" from the root component
+    //  https://github.com/airbnb/enzyme/issues/1229#issuecomment-462496246
+    // FIXME:  I believe for this to work, mockHandleCollapsed has to mock the implementation ...
+    //   which leads me to believe that this should be an integration test
+    // FIXME: the approach below is a failed attempted to 'inject' info to an inner method
     // await wrapper.instance().fullfillRTPromises(promises).then(() => wrapper.update()).then(() => {
     //   const childOutlineHeader = wrapper.find(OutlineHeader)
     //   childOutlineHeader.find('a').simulate('click')
@@ -303,6 +313,9 @@ describe('<PropertyTemplateOutline /> with propertyTemplate Refs', () => {
 
   it.skip('handles "Add" button click', async () => {
     // FIXME: this test gives false positive - see github issue #496
+    // FIXME: wrapper has OutlineHeader but no PropertyActionButtons, no PropertyTypeRow
+    // - it needs to be expanded first?  implying an integration test
+    // FIXME: the approach below is a failed attempted to 'inject' info to an inner method
     // await wrapper.instance().fullfillRTPromises(promises).then(() => wrapper.update()).then(() => {
     //   const addButton = wrapper.find('div > section > PropertyActionButtons > div > AddButton')
     //   addButton.handleClick = mockHandleAddClick
@@ -319,6 +332,9 @@ describe('<PropertyTemplateOutline /> with propertyTemplate Refs', () => {
 
   it.skip('handles "Mint URI" button click', async () => {
     // FIXME: this test gives false positive - see github issue #496
+    // FIXME: wrapper has OutlineHeader but no PropertyActionButtons, no PropertyTypeRow
+    // - it needs to be expanded first?  implying an integration test
+    // FIXME: the approach below is a failed attempted to 'inject' info to an inner method
     // await wrapper.instance().fullfillRTPromises(promises).then(() => wrapper.update()).then(() => {
     //   const mintButton = wrapper.find('div > section > PropertyActionButtons > div > MintButton')
     //   mintButton.handleClick = mockHandleAddClick

--- a/src/components/editor/InputLiteral.jsx
+++ b/src/components/editor/InputLiteral.jsx
@@ -63,10 +63,8 @@ export class InputLiteral extends Component {
       if (!currentcontent) {
         return
       }
-      /** Input field is repeatable, add user input to array.**/
       if (this.props.propertyTemplate.repeatable == "true") {
         this.addUserInput(userInputArray, currentcontent)
-      /** Input field is not repeatable **/
       } else if (this.props.propertyTemplate.repeatable == "false") {
         this.notRepeatableAfterUserInput(userInputArray, currentcontent)
       }


### PR DESCRIPTION
- Adds unit tests for OutlineHeader
- skips and leaves breadcrumbs for false positive test cited in #496

(I also beefed up issue #496)