### PR TITLE
ResourceTemplateForm.test: skip tests giving false positives

### DIFF
--- a/__tests__/components/editor/PropertyTemplateOutline.test.js
+++ b/__tests__/components/editor/PropertyTemplateOutline.test.js
@@ -303,7 +303,7 @@ describe('<PropertyTemplateOutline /> with propertyTemplate Refs', () => {
     // FIXME:  I believe for this to work, mockHandleCollapsed has to mock the implementation ...
     //   which leads me to believe that this should be an integration test
     // FIXME: the approach below is a failed attempted to 'inject' info to an inner method
-    // await wrapper.instance().fullfillRTPromises(promises).then(() => wrapper.update()).then(() => {
+    // await wrapper.instance().fulfillRTPromises(promises).then(() => wrapper.update()).then(() => {
     //   const childOutlineHeader = wrapper.find(OutlineHeader)
     //   childOutlineHeader.find('a').simulate('click')
     //   expect(wrapper.state().collapsed).toBeFalsy() // correct
@@ -316,7 +316,7 @@ describe('<PropertyTemplateOutline /> with propertyTemplate Refs', () => {
     // FIXME: wrapper has OutlineHeader but no PropertyActionButtons, no PropertyTypeRow
     // - it needs to be expanded first?  implying an integration test
     // FIXME: the approach below is a failed attempted to 'inject' info to an inner method
-    // await wrapper.instance().fullfillRTPromises(promises).then(() => wrapper.update()).then(() => {
+    // await wrapper.instance().fulfillRTPromises(promises).then(() => wrapper.update()).then(() => {
     //   const addButton = wrapper.find('div > section > PropertyActionButtons > div > AddButton')
     //   addButton.handleClick = mockHandleAddClick
     //   addButton.simulate('click')
@@ -335,7 +335,7 @@ describe('<PropertyTemplateOutline /> with propertyTemplate Refs', () => {
     // FIXME: wrapper has OutlineHeader but no PropertyActionButtons, no PropertyTypeRow
     // - it needs to be expanded first?  implying an integration test
     // FIXME: the approach below is a failed attempted to 'inject' info to an inner method
-    // await wrapper.instance().fullfillRTPromises(promises).then(() => wrapper.update()).then(() => {
+    // await wrapper.instance().fulfillRTPromises(promises).then(() => wrapper.update()).then(() => {
     //   const mintButton = wrapper.find('div > section > PropertyActionButtons > div > MintButton')
     //   mintButton.handleClick = mockHandleAddClick
     //   mintButton.simulate('click')

--- a/__tests__/components/editor/ResourceTemplateForm.test.js
+++ b/__tests__/components/editor/ResourceTemplateForm.test.js
@@ -184,7 +184,7 @@ describe('<ResourceTemplateForm /> after fetching data from sinopia server', () 
       //   }
       // }
       // const instance = wrapper.instance()
-      // await instance.fullfillRTPromises(promises).then(() => wrapper.update()).then(() => {
+      // await instance.fulfillRTPromises(promises).then(() => wrapper.update()).then(() => {
       //   instance.configuredComponent(lookup, 1)
       //   expect(wrapper
       //     .find('div.ResourceTemplateForm Connect(InputLookupQA)').length)
@@ -204,7 +204,7 @@ describe('<ResourceTemplateForm /> after fetching data from sinopia server', () 
       //   }
       // }
       // const instance = wrapper.instance()
-      // await instance.fullfillRTPromises(promises).then(() => wrapper.update()).then(() => {
+      // await instance.fulfillRTPromises(promises).then(() => wrapper.update()).then(() => {
       //   instance.configuredComponent(list, 1)
       //   expect(wrapper
       //     .find('div.ResourceTemplateForm Connect(InputListLOC)').length)
@@ -215,7 +215,7 @@ describe('<ResourceTemplateForm /> after fetching data from sinopia server', () 
 
   it.skip('renders InputLiteral nested component (b/c we have a property of type "literal")', async () => {
     // FIXME: this test gives false positive - see github issue #496 - perhaps we need an integration test
-    // await wrapper.instance().fullfillRTPromises(promises).then(() => wrapper.update()).then(() => {
+    // await wrapper.instance().fulfillRTPromises(promises).then(() => wrapper.update()).then(() => {
     //   expect(wrapper
     //     .find('div.ResourceTemplateForm Connect(InputLiteral)').length)
     //     .toEqual(1)
@@ -271,7 +271,7 @@ describe('when there are no findable nested resource templates', () => {
 
   it.skip('renders error alert box', async () => {
     // FIXME: this test gives false positive - see github issue #496 - perhaps we need an integration test
-    // await wrapper.instance().fullfillRTPromises(promises).then(() => wrapper.update()).then(() => {
+    // await wrapper.instance().fulfillRTPromises(promises).then(() => wrapper.update()).then(() => {
     //   expect(wrapper.state.errot).toBeTruthy()
     //   const errorEl = wrapper.find('div.alert')
     //   expect(errorEl).toHaveLength(1)

--- a/__tests__/components/editor/ResourceTemplateForm.test.js
+++ b/__tests__/components/editor/ResourceTemplateForm.test.js
@@ -2,9 +2,7 @@
 
 import React from 'react'
 import 'jsdom-global/register'
-import ButtonToolbar from 'react-bootstrap/lib/ButtonToolbar'
-import { mount, shallow } from 'enzyme'
-import InputLiteral from '../../../src/components/editor/InputLiteral'
+import { shallow } from 'enzyme'
 import { ResourceTemplateForm } from '../../../src/components/editor/ResourceTemplateForm'
 
 const rtProps = {
@@ -98,7 +96,6 @@ const responseBody = [{
   }
 }]
 
-// const lits = { id: 0, content: 'content' }
 const lits =  {formData: [{id: 0, uri: 'http://uri', items: [
         {content: '12345', id: 0, bnode: {termType: 'BlankNode', value: 'n3-0'}, propPredicate: 'http://predicate'}
       ], rtId: 'resourceTemplate:bf2'}]}
@@ -151,12 +148,12 @@ const mockHandleGenerateLD = jest.fn()
 
 describe('<ResourceTemplateForm /> after fetching data from sinopia server', () => {
 
-  const asyncCall = (index) => {
-    const response = mockResponse(200, null, responseBody[index])
-    return response
-  }
-
-  const promises = Promise.all([ asyncCall(0) ])
+  // FIXME: from tests giving false positive - see github issue #496
+  // const asyncCall = (index) => {
+  //   const response = mockResponse(200, null, responseBody[index])
+  //   return response
+  // }
+  // const promises = Promise.all([ asyncCall(0) ])
 
   const wrapper = shallow(
     <ResourceTemplateForm {...rtProps}
@@ -171,56 +168,58 @@ describe('<ResourceTemplateForm /> after fetching data from sinopia server', () 
   )
 
   describe('configured component types', () => {
-    const lookup = {
-      "propertyLabel": "Look up, look down",
-      "type": "lookup",
-      "editable": "do not override me!",
-      "repeatable": "do not override me!",
-      "mandatory": "do not override me!",
-      "valueConstraint": {
-        "useValuesFrom": [
-          "urn:ld4p:qa:names:person"
-        ]
-      }
-    }
 
-    it('renders a lookup component', async () => {
-      const instance = wrapper.instance()
-      await instance.fullfillRTPromises(promises).then(() => wrapper.update()).then(() => {
-        instance.configuredComponent(lookup, 1)
-        expect(wrapper
-          .find('div.ResourceTemplateForm Connect(InputLookupQA)').length)
-          .toEqual(1)
-      }).catch(e => {})
+    it.skip('renders a lookup component', async () => {
+      // FIXME: this test gives false positive - see github issue #496 - perhaps we need an integration test
+      // const lookup = {
+      //   "propertyLabel": "Look up, look down",
+      //   "type": "lookup",
+      //   "editable": "do not override me!",
+      //   "repeatable": "do not override me!",
+      //   "mandatory": "do not override me!",
+      //   "valueConstraint": {
+      //     "useValuesFrom": [
+      //       "urn:ld4p:qa:names:person"
+      //     ]
+      //   }
+      // }
+      // const instance = wrapper.instance()
+      // await instance.fullfillRTPromises(promises).then(() => wrapper.update()).then(() => {
+      //   instance.configuredComponent(lookup, 1)
+      //   expect(wrapper
+      //     .find('div.ResourceTemplateForm Connect(InputLookupQA)').length)
+      //     .toEqual(1)
+      // }).catch(e => {})
     })
 
-    const list = {
-      "propertyLabel": "What's the frequency Kenneth?",
-      "type": "resource",
-      "valueConstraint": {
-        "useValuesFrom": [
-          "https://id.loc.gov/vocabulary/frequencies"
-        ]
-      }
-    }
-
-    it('renders a list component', async () => {
-      const instance = wrapper.instance()
-      await instance.fullfillRTPromises(promises).then(() => wrapper.update()).then(() => {
-        instance.configuredComponent(list, 1)
-        expect(wrapper
-          .find('div.ResourceTemplateForm Connect(InputListLOC)').length)
-          .toEqual(1)
-      }).catch(e => {})
+    it.skip('renders a list component', async () => {
+      // FIXME: this test gives false positive - see github issue #496 - perhaps we need an integration test
+      // const list = {
+      //   "propertyLabel": "What's the frequency Kenneth?",
+      //   "type": "resource",
+      //   "valueConstraint": {
+      //     "useValuesFrom": [
+      //       "https://id.loc.gov/vocabulary/frequencies"
+      //     ]
+      //   }
+      // }
+      // const instance = wrapper.instance()
+      // await instance.fullfillRTPromises(promises).then(() => wrapper.update()).then(() => {
+      //   instance.configuredComponent(list, 1)
+      //   expect(wrapper
+      //     .find('div.ResourceTemplateForm Connect(InputListLOC)').length)
+      //     .toEqual(1)
+      // }).catch(e => {})
     })
   })
 
-  it('renders InputLiteral nested component (b/c we have a property of type "literal")', async () => {
-    await wrapper.instance().fullfillRTPromises(promises).then(() => wrapper.update()).then(() => {
-      expect(wrapper
-        .find('div.ResourceTemplateForm Connect(InputLiteral)').length)
-        .toEqual(1)
-    }).catch(e => {})
+  it.skip('renders InputLiteral nested component (b/c we have a property of type "literal")', async () => {
+    // FIXME: this test gives false positive - see github issue #496 - perhaps we need an integration test
+    // await wrapper.instance().fullfillRTPromises(promises).then(() => wrapper.update()).then(() => {
+    //   expect(wrapper
+    //     .find('div.ResourceTemplateForm Connect(InputLiteral)').length)
+    //     .toEqual(1)
+    // }).catch(e => {})
   })
 
   it('<form> does not contain redundant form attribute', () => {
@@ -252,30 +251,31 @@ describe('<ResourceTemplateForm /> after fetching data from sinopia server', () 
 })
 
 describe('when there are no findable nested resource templates', () => {
-  const asyncCall = () => {
-    const response = mockResponse(200, null, undefined)
-    return response
-  }
+  // FIXME: from tests giving false positive - see github issue #496
+  // const asyncCall = () => {
+  //   const response = mockResponse(200, null, undefined)
+  //   return response
+  // }
+  // const promises = Promise.all([ asyncCall ])
+  //
+  // const wrapper = shallow(<ResourceTemplateForm
+  //   propertyTemplates={[]}
+  //   resourceTemplate = {rtTest}
+  //   handleGenerateRDF = {mockHandleGenerateLD}
+  //   literals = {lits}
+  //   lookups = {lups}
+  //   rtId = {"resourceTemplate:bf2:Monograph:Instance"}
+  //   parentResourceTemplate = {"resourceTemplate:bf2:Monograph:Instance"}
+  //   generateLD = { ld }
+  // />)
 
-  const promises = Promise.all([ asyncCall ])
-
-  const wrapper = shallow(<ResourceTemplateForm
-    propertyTemplates={[]}
-    resourceTemplate = {rtTest}
-    handleGenerateRDF = {mockHandleGenerateLD}
-    literals = {lits}
-    lookups = {lups}
-    rtId = {"resourceTemplate:bf2:Monograph:Instance"}
-    parentResourceTemplate = {"resourceTemplate:bf2:Monograph:Instance"}
-    generateLD = { ld }
-  />)
-
-  it('renders error alert box', async () => {
-    await wrapper.instance().fullfillRTPromises(promises).then(() => wrapper.update()).then(() => {
-        expect(wrapper.state.errot).toBeTruthy()
-        const errorEl = wrapper.find('div.alert')
-        expect(errorEl).toHaveLength(1)
-        expect(errorEl.text()).toEqual('Sinopia server is offline or has no resource templates to display')
-    }).catch(e => {})
+  it.skip('renders error alert box', async () => {
+    // FIXME: this test gives false positive - see github issue #496 - perhaps we need an integration test
+    // await wrapper.instance().fullfillRTPromises(promises).then(() => wrapper.update()).then(() => {
+    //   expect(wrapper.state.errot).toBeTruthy()
+    //   const errorEl = wrapper.find('div.alert')
+    //   expect(errorEl).toHaveLength(1)
+    //   expect(errorEl.text()).toEqual('Sinopia server is offline or has no resource templates to display')
+    // }).catch(e => {})
   })
 })

--- a/src/components/editor/PropertyTemplateOutline.jsx
+++ b/src/components/editor/PropertyTemplateOutline.jsx
@@ -62,7 +62,7 @@ export class PropertyTemplateOutline extends Component {
     }
   }
 
-  fullfillRTPromises = async (promiseAll) => {
+  fulfillRTPromises = async (promiseAll) => {
     await promiseAll.then(rts => {
       rts.map(rt => {
         this.setState({tempState: rt.response.body})
@@ -171,7 +171,7 @@ export class PropertyTemplateOutline extends Component {
     event.preventDefault()
     let newOutput = this.state.output
 
-    this.fullfillRTPromises(this.resourceTemplatePromises(property.valueConstraint.valueTemplateRefs)).then(() => {
+    this.fulfillRTPromises(this.resourceTemplatePromises(property.valueConstraint.valueTemplateRefs)).then(() => {
 
       const input = this.handleComponentCase(property)
 

--- a/src/components/editor/ResourceTemplateForm.jsx
+++ b/src/components/editor/ResourceTemplateForm.jsx
@@ -34,7 +34,7 @@ export class ResourceTemplateForm extends Component {
   }
 
   componentDidMount() {
-    this.fullfillRTPromises(this.resourceTemplatePromises(this.joinedRTs())).then(() => {
+    this.fulfillRTPromises(this.resourceTemplatePromises(this.joinedRTs())).then(() => {
       this.setState({
         componentForm: (
           this.renderComponentForm()
@@ -43,7 +43,7 @@ export class ResourceTemplateForm extends Component {
     })
   }
 
-  fullfillRTPromises = async (promiseAll) => {
+  fulfillRTPromises = async (promiseAll) => {
     await promiseAll.then(async (rts) => {
       rts.map(rt => {
         this.setState({tempState: rt.response.body})


### PR DESCRIPTION
These are just like the false positives I found for PropertyTemplateOutline.test.  I put "expect(1).toBe(2)" in the blocks with expect statements, and these tests passed.  :-(

I also corrected the misspelling of fulfill and got rid of unused imports.