### PR TITLE
Make false positives fail and show the pattern that avoids introducing them

### DIFF
--- a/__tests__/components/App.test.js
+++ b/__tests__/components/App.test.js
@@ -51,7 +51,7 @@ describe("#routes", () => {
 
     it('root renders HomePage component', async () => {
       const component = renderRoutes("/")
-      await expect(component.find(HomePage).length).toEqual(1)
+      return await expect(component.find(HomePage).length).toEqual(1)
     })
 
     it('/editor renders Editor component', () => {

--- a/__tests__/components/editor/ImportFileZone.test.js
+++ b/__tests__/components/editor/ImportFileZone.test.js
@@ -85,7 +85,7 @@ describe('<ImportFileZone />', () => {
     })
 
     it('displays an error message when missing required property', async () => {
-      await wrapper.instance().promiseTemplateValidated(template, schemaUrl).catch((err) => {
+      return await wrapper.instance().promiseTemplateValidated(template, schemaUrl).catch((err) => {
         expect(wrapper.state().validTemplate).toBeFalsy()
         expect(err.toString()).toMatch("should have required property")
       })
@@ -98,7 +98,7 @@ describe('<ImportFileZone />', () => {
     })
 
     it('displays an error message when the id is invalid', async () => {
-      await wrapper.instance().promiseTemplateValidated(template, schemaUrl).catch((err) => {
+      return await wrapper.instance().promiseTemplateValidated(template, schemaUrl).catch((err) => {
         expect(wrapper.state().validTemplate).toBeFalsy()
         expect(err.toString()).toMatch('should match pattern')
       })
@@ -117,7 +117,7 @@ describe('<ImportFileZone />', () => {
     })
 
     it('displays an error message', async () => {
-      await wrapper.instance().promiseTemplateValidated(template, schemaUrl).catch((err) => {
+      return await wrapper.instance().promiseTemplateValidated(template, schemaUrl).catch((err) => {
         expect(wrapper.state().validTemplate).toBeFalsy()
         expect(err.toString()).toMatch("Error: error getting json schemas")
       })

--- a/__tests__/components/editor/ImportResourceTemplate.test.js
+++ b/__tests__/components/editor/ImportResourceTemplate.test.js
@@ -48,8 +48,9 @@ describe('creating a non-rdf resource from an uploaded profile', () => {
   it('sets an info message that the resource was created on success', async () => {
     const wrapper = shallow(<ImportResourceTemplate />)
     const promise = Promise.resolve(mockResponse(201, "Created", result))
-    await wrapper.instance().fulfillCreateResourcePromise(promise)
-    expect(wrapper.state('message')).toEqual([ `${result.response.statusText} ${result.response.headers.location}` ])
+    return await wrapper.instance().fulfillCreateResourcePromise(promise).then(() => {
+      expect(wrapper.state('message')).toEqual([ `${result.response.statusText} ${result.response.headers.location}` ])
+    })
   })
 
   it('shows the error message if resource creation fails', async () => {
@@ -99,6 +100,5 @@ describe('creating a non-rdf resource from an uploaded profile', () => {
     wrapper.update()
     expect(wrapper.state().createResourceError).toEqual([responseMock.response])
   })
-  
-})
 
+})

--- a/__tests__/components/editor/PropertyTemplateOutline.test.js
+++ b/__tests__/components/editor/PropertyTemplateOutline.test.js
@@ -278,24 +278,22 @@ describe('<PropertyTemplateOutline /> with propertyTemplate Refs', () => {
   })
 
 
-  // FIXME: from tests giving false positive - see github issue #496
+  const mockResponse = (status, statusText, response) => {
+    return new Response(response, {
+      status: status,
+      statusText: statusText,
+      headers: {
+        'Content-type': 'application/json'
+      }
+    }).body
+  }
+  const asyncCall = (index) => {
+    const response = mockResponse(200, null, responseBody[index])
+    return response
+  }
+  const promises = Promise.all([ asyncCall(0) ])
 
-  // const mockResponse = (status, statusText, response) => {
-  //   return new Response(response, {
-  //     status: status,
-  //     statusText: statusText,
-  //     headers: {
-  //       'Content-type': 'application/json'
-  //     }
-  //   }).body
-  // }
-  // const asyncCall = (index) => {
-  //   const response = mockResponse(200, null, responseBody[index])
-  //   return response
-  // }
-  // const promises = Promise.all([ asyncCall(0) ])
-
-  it.skip('clicking removes collapsed state', async () => {
+  it('clicking removes collapsed state', async () => {
     // FIXME: this test gives false positive - see github issue #496
     // FIXME:  collapsed isn't a state, it's a prop
     // FIXME:  in order to examine STATE after simulate, you must do a fresh "find" from the root component
@@ -303,26 +301,25 @@ describe('<PropertyTemplateOutline /> with propertyTemplate Refs', () => {
     // FIXME:  I believe for this to work, mockHandleCollapsed has to mock the implementation ...
     //   which leads me to believe that this should be an integration test
     // FIXME: the approach below is a failed attempted to 'inject' info to an inner method
-    // await wrapper.instance().fulfillRTPromises(promises).then(() => wrapper.update()).then(() => {
-    //   const childOutlineHeader = wrapper.find(OutlineHeader)
-    //   childOutlineHeader.find('a').simulate('click')
-    //   expect(wrapper.state().collapsed).toBeFalsy() // correct
-    //   expect(wrapper.state().collapsed).toBeTruthy() // incorrect
-    // }).catch(() => {})
+    return await wrapper.instance().fulfillRTPromises(promises).then(() => wrapper.update()).then(() => {
+      const childOutlineHeader = wrapper.find(OutlineHeader)
+      childOutlineHeader.find('a').simulate('click')
+      expect(wrapper.state().collapsed).toBeFalsy() correct
+      expect(wrapper.state().collapsed).toBeTruthy() incorrect
+    })
   })
 
-  it.skip('handles "Add" button click', async () => {
-    // FIXME: this test gives false positive - see github issue #496
+  it('handles "Add" button click', async () => {
     // FIXME: wrapper has OutlineHeader but no PropertyActionButtons, no PropertyTypeRow
     // - it needs to be expanded first?  implying an integration test
     // FIXME: the approach below is a failed attempted to 'inject' info to an inner method
-    // await wrapper.instance().fulfillRTPromises(promises).then(() => wrapper.update()).then(() => {
-    //   const addButton = wrapper.find('div > section > PropertyActionButtons > div > AddButton')
-    //   addButton.handleClick = mockHandleAddClick
-    //   addButton.simulate('click')
-    //   expect(mockHandleAddClick.mock.calls.length).toBe(1) // correct
-    //   expect(mockHandleAddClick.mock.calls.length).toBe(0) // incorrect
-    // }).catch(() => {})
+    return await wrapper.instance().fulfillRTPromises(promises).then(() => wrapper.update()).then(() => {
+      const addButton = wrapper.find('div > section > PropertyActionButtons > div > AddButton')
+      addButton.handleClick = mockHandleAddClick
+      addButton.simulate('click')
+      expect(mockHandleAddClick.mock.calls.length).toBe(1) correct
+      expect(mockHandleAddClick.mock.calls.length).toBe(0) incorrect
+    })
   })
 
   it('handles the addClick method callback call', () => {
@@ -330,18 +327,17 @@ describe('<PropertyTemplateOutline /> with propertyTemplate Refs', () => {
     expect(mockHandleAddClick.mock.calls.length).toBe(1)
   })
 
-  it.skip('handles "Mint URI" button click', async () => {
-    // FIXME: this test gives false positive - see github issue #496
+  it('handles "Mint URI" button click', async () => {
     // FIXME: wrapper has OutlineHeader but no PropertyActionButtons, no PropertyTypeRow
     // - it needs to be expanded first?  implying an integration test
     // FIXME: the approach below is a failed attempted to 'inject' info to an inner method
-    // await wrapper.instance().fulfillRTPromises(promises).then(() => wrapper.update()).then(() => {
-    //   const mintButton = wrapper.find('div > section > PropertyActionButtons > div > MintButton')
-    //   mintButton.handleClick = mockHandleAddClick
-    //   mintButton.simulate('click')
-    //   expect(mockHandleMintUri.mock.calls.length).toBe(1) // correct
-    //   expect(mockHandleMintUri.mock.calls.length).toBe(1) // incorrect
-    // }).catch(() => {})
+    return await wrapper.instance().fulfillRTPromises(promises).then(() => wrapper.update()).then(() => {
+      const mintButton = wrapper.find('div > section > PropertyActionButtons > div > MintButton')
+      mintButton.handleClick = mockHandleAddClick
+      mintButton.simulate('click')
+      expect(mockHandleMintUri.mock.calls.length).toBe(1) correct
+      expect(mockHandleMintUri.mock.calls.length).toBe(1) incorrect
+    })
   })
 
   // TODO: revisit when MintButton is enabled (see github issue #283)

--- a/__tests__/components/editor/ResourceTemplateForm.test.js
+++ b/__tests__/components/editor/ResourceTemplateForm.test.js
@@ -168,58 +168,54 @@ describe('<ResourceTemplateForm /> after fetching data from sinopia server', () 
   )
 
   describe('configured component types', () => {
-
-    it.skip('renders a lookup component', async () => {
-      // FIXME: this test gives false positive - see github issue #496 - perhaps we need an integration test
-      // const lookup = {
-      //   "propertyLabel": "Look up, look down",
-      //   "type": "lookup",
-      //   "editable": "do not override me!",
-      //   "repeatable": "do not override me!",
-      //   "mandatory": "do not override me!",
-      //   "valueConstraint": {
-      //     "useValuesFrom": [
-      //       "urn:ld4p:qa:names:person"
-      //     ]
-      //   }
-      // }
-      // const instance = wrapper.instance()
-      // await instance.fulfillRTPromises(promises).then(() => wrapper.update()).then(() => {
-      //   instance.configuredComponent(lookup, 1)
-      //   expect(wrapper
-      //     .find('div.ResourceTemplateForm Connect(InputLookupQA)').length)
-      //     .toEqual(1)
-      // }).catch(e => {})
+    it('renders a lookup component', async () => {
+      const lookup = {
+        "propertyLabel": "Look up, look down",
+        "type": "lookup",
+        "editable": "do not override me!",
+        "repeatable": "do not override me!",
+        "mandatory": "do not override me!",
+        "valueConstraint": {
+          "useValuesFrom": [
+            "urn:ld4p:qa:names:person"
+          ]
+        }
+      }
+      const instance = wrapper.instance()
+      return await instance.fulfillRTPromises(promises).then(() => wrapper.update()).then(() => {
+        instance.configuredComponent(lookup, 1)
+        expect(wrapper
+          .find('div.ResourceTemplateForm Connect(InputLookupQA)').length)
+          .toEqual(1)
+      })
     })
 
-    it.skip('renders a list component', async () => {
-      // FIXME: this test gives false positive - see github issue #496 - perhaps we need an integration test
-      // const list = {
-      //   "propertyLabel": "What's the frequency Kenneth?",
-      //   "type": "resource",
-      //   "valueConstraint": {
-      //     "useValuesFrom": [
-      //       "https://id.loc.gov/vocabulary/frequencies"
-      //     ]
-      //   }
-      // }
-      // const instance = wrapper.instance()
-      // await instance.fulfillRTPromises(promises).then(() => wrapper.update()).then(() => {
-      //   instance.configuredComponent(list, 1)
-      //   expect(wrapper
-      //     .find('div.ResourceTemplateForm Connect(InputListLOC)').length)
-      //     .toEqual(1)
-      // }).catch(e => {})
+    it('renders a list component', async () => {
+      const list = {
+        "propertyLabel": "What's the frequency Kenneth?",
+        "type": "resource",
+        "valueConstraint": {
+          "useValuesFrom": [
+            "https:id.loc.gov/vocabulary/frequencies"
+          ]
+        }
+      }
+      const instance = wrapper.instance()
+      return await instance.fulfillRTPromises(promises).then(() => wrapper.update()).then(() => {
+        instance.configuredComponent(list, 1)
+        expect(wrapper
+          .find('div.ResourceTemplateForm Connect(InputListLOC)').length)
+          .toEqual(1)
+      })
     })
   })
 
-  it.skip('renders InputLiteral nested component (b/c we have a property of type "literal")', async () => {
-    // FIXME: this test gives false positive - see github issue #496 - perhaps we need an integration test
-    // await wrapper.instance().fulfillRTPromises(promises).then(() => wrapper.update()).then(() => {
-    //   expect(wrapper
-    //     .find('div.ResourceTemplateForm Connect(InputLiteral)').length)
-    //     .toEqual(1)
-    // }).catch(e => {})
+  it('renders InputLiteral nested component (b/c we have a property of type "literal")', async () => {
+    return await wrapper.instance().fulfillRTPromises(promises).then(() => wrapper.update()).then(() => {
+      expect(wrapper
+        .find('div.ResourceTemplateForm Connect(InputLiteral)').length)
+        .toEqual(1)
+    })
   })
 
   it('<form> does not contain redundant form attribute', () => {
@@ -251,31 +247,29 @@ describe('<ResourceTemplateForm /> after fetching data from sinopia server', () 
 })
 
 describe('when there are no findable nested resource templates', () => {
-  // FIXME: from tests giving false positive - see github issue #496
-  // const asyncCall = () => {
-  //   const response = mockResponse(200, null, undefined)
-  //   return response
-  // }
-  // const promises = Promise.all([ asyncCall ])
-  //
-  // const wrapper = shallow(<ResourceTemplateForm
-  //   propertyTemplates={[]}
-  //   resourceTemplate = {rtTest}
-  //   handleGenerateRDF = {mockHandleGenerateLD}
-  //   literals = {lits}
-  //   lookups = {lups}
-  //   rtId = {"resourceTemplate:bf2:Monograph:Instance"}
-  //   parentResourceTemplate = {"resourceTemplate:bf2:Monograph:Instance"}
-  //   generateLD = { ld }
-  // />)
+  const asyncCall = () => {
+    const response = mockResponse(200, null, undefined)
+    return response
+  }
+  const promises = Promise.all([ asyncCall ])
 
-  it.skip('renders error alert box', async () => {
-    // FIXME: this test gives false positive - see github issue #496 - perhaps we need an integration test
-    // await wrapper.instance().fulfillRTPromises(promises).then(() => wrapper.update()).then(() => {
-    //   expect(wrapper.state.errot).toBeTruthy()
-    //   const errorEl = wrapper.find('div.alert')
-    //   expect(errorEl).toHaveLength(1)
-    //   expect(errorEl.text()).toEqual('Sinopia server is offline or has no resource templates to display')
-    // }).catch(e => {})
+  const wrapper = shallow(<ResourceTemplateForm
+    propertyTemplates={[]}
+    resourceTemplate = {rtTest}
+    handleGenerateRDF = {mockHandleGenerateLD}
+    literals = {lits}
+    lookups = {lups}
+    rtId = {"resourceTemplate:bf2:Monograph:Instance"}
+    parentResourceTemplate = {"resourceTemplate:bf2:Monograph:Instance"}
+    generateLD = { ld }
+  />)
+
+  it('renders error alert box', async () => {
+    return await wrapper.instance().fulfillRTPromises(promises).then(() => wrapper.update()).then(() => {
+      expect(wrapper.state.errot).toBeTruthy()
+      const errorEl = wrapper.find('div.alert')
+      expect(errorEl).toHaveLength(1)
+      expect(errorEl.text()).toEqual('Sinopia server is offline or has no resource templates to display')
+    })
   })
 })

--- a/__tests__/components/editor/SinopiaResourceTemplates.test.js
+++ b/__tests__/components/editor/SinopiaResourceTemplates.test.js
@@ -25,7 +25,6 @@ describe('<SinopiaResourceTemplates />', () => {
   })
 
   describe('getting data from the sinopia_server', () => {
-
     const mockResponse = (status, statusText, response) => {
       return new Response(response, {
         status: status,
@@ -47,22 +46,21 @@ describe('<SinopiaResourceTemplates />', () => {
     }
 
     it('sets the state with group data (as Array) from sinopia_server', async() => {
-
       const promise = Promise.resolve(mockResponse(200, null, bodyContains))
       const wrapper2 = shallow(<SinopiaResourceTemplates message={message} />)
-      await wrapper2.instance().fulfillGroupPromise(promise).then(() => wrapper2.update()).then(() => {
+      return await wrapper2.instance().fulfillGroupPromise(promise).then(() => wrapper2.update()).then(() => {
         expect(wrapper2.state('groupData')).toEqual(['ld4p', 'pcc'])
         expect(resourceToName).toHaveBeenCalled()
-      }).catch(e => {})
+      })
     })
 
     it('sets a message if there is no server response', async() => {
       const promise = Promise.resolve(mockResponse(200, null, undefined))
       const wrapper2 = shallow(<SinopiaResourceTemplates message={message} />)
-      await wrapper2.instance().fulfillGroupPromise(promise).then(() => wrapper2.update()).then(() => {
+      return await wrapper2.instance().fulfillGroupPromise(promise).then(() => wrapper2.update()).then(() => {
         expect(wrapper2.state('message')).toBeTruthy()
         expect(resourceToName).toHaveBeenCalled()
-      }).catch(e => {})
+      })
     })
 
     it('sets the state with a list of resource templates from the server', async() => {
@@ -83,14 +81,13 @@ describe('<SinopiaResourceTemplates />', () => {
       const wrapper3 = shallow(<SinopiaResourceTemplates message={message}/>)
       //TODO: figure out how to mock and test a nested promise...
       const spy = jest.spyOn(wrapper3.instance(), 'fulfillGroupData')
-      await wrapper3.instance().fulfillGroupData(bodyContains)
-      expect(spy).toHaveBeenCalled()
+      return await wrapper3.instance().fulfillGroupData(bodyContains).then(() => {
+        expect(spy).toHaveBeenCalled()
+      })
     })
-
   })
 
   describe('linking back to the Editor component', () => {
-
     const cell = 'Note'
     const row = {
       name: "Note",
@@ -102,13 +99,13 @@ describe('<SinopiaResourceTemplates />', () => {
     const wrapper4 = shallow(<SinopiaResourceTemplates message={message}/>)
 
     it('has the header columns for the table of linked resource templates', async () => {
-      await expect(wrapper4.find('BootstrapTable').find('TableHeaderColumn').length).toEqual(3)
+      return await expect(wrapper4.find('BootstrapTable').find('TableHeaderColumn').length).toEqual(3)
     })
 
     it('renders a link to the Editor with the id of the resource template to fetch', async () => {
       const link = await wrapper4.instance().linkFormatter(cell, row)
-      await expect(link.props.to.pathname).toEqual('/editor')
-      await expect(link.props.to.state.resourceTemplateId).toEqual(row.id)
+      expect(link.props.to.pathname).toEqual('/editor')
+      expect(link.props.to.state.resourceTemplateId).toEqual(row.id)
     })
   })
 })


### PR DESCRIPTION
connects to #496 -- this is not a complete fix for #496, just a start to show the pattern.  

Naomi sez:

>Once we all check it off, we can turn this into a real PR and also know what to do for #496 to be done.  

>Note that this is showing a technique and may not be sufficient for the affected tests to pass -- it may only make them fail "correctly".

>Unfortunately I think we have a bunch of tests like this (I wrote some of them!) and we all (me too!) need to understand how to avoid them in the future.

>For example, in trying to get the profile editor build working, i'm referring back to this PR so I can make sure any tests that are problematic (e.g. taking too long or throwing errors in circleci) don't have these problems, too.

- [x] @ndushay 
- [x] @jermnelson 
- [x] @jmartin-sul 
- [x] @jgreben 
- [x] @hudajkhan 