### PR TITLE
Remove vestiges of wireframed resource template components

### DIFF
--- a/__tests__/components/editor/ResourceTemplate.test.js
+++ b/__tests__/components/editor/ResourceTemplate.test.js
@@ -55,6 +55,10 @@ describe('<ResourceTemplate />', () => {
     expect(wrapper.find('div.ResourceTemplate').length).toEqual(1)
   })
 
+  it('displays the resource label of the resource template', () => {
+    expect(wrapper.find('h1').text()).toEqual(responseBody.response.body.resourceLabel)
+  })
+
   // TODO: if we have more than one resourceTemplate form, they need to have unique ids (see #130)
   it('contains <div> with id resourceTemplate', () => {
     expect(wrapper.find('div#resourceTemplate').length).toEqual(1)

--- a/src/components/editor/Editor.jsx
+++ b/src/components/editor/Editor.jsx
@@ -73,11 +73,7 @@ class Editor extends Component {
         <Header triggerEditorMenu={this.props.triggerHandleOffsetMenu}/>
         { authenticationMessage }
         <div className="row">
-          <section className="col-md-9">
-            <h3>Resource Template Label</h3>
-            <h1>[Clone|Edit] <em>Name of Resource</em></h1>
-          </section>
-          <section className="col-md-3">
+          <section className="col-md-3" style={{float: 'right'}}>
             <button type="button" className="btn btn-primary btn-sm" onClick={this.handleRdfShow}>Preview RDF</button>
           </section>
         </div>

--- a/src/components/editor/ResourceTemplate.jsx
+++ b/src/components/editor/ResourceTemplate.jsx
@@ -36,7 +36,10 @@ class ResourceTemplate extends Component {
   renderRtData = () => {
     return (
       <div className='ResourceTemplate'>
-        <div id="resourceTemplate">
+        <div id="resourceTemplate" style={{marginTop: '-30px'}}>
+          <section className="col-md-9">
+            <h1><em>{this.state.rtData.resourceLabel}</em></h1>
+          </section>
           <ResourceTemplateForm
             propertyTemplates = {this.state.rtData.propertyTemplates}
             resourceTemplate = {this.state.rtData}

--- a/static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/MonographInstance.json
+++ b/static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/MonographInstance.json
@@ -127,7 +127,7 @@
       "remark": "http://access.rdatoolkit.org/3.3.html"
     },
     {
-      "propertyLabel": "WITH ALL VALUE CONSTRAINTS",
+      "propertyLabel": "Item Information",
       "propertyURI": "http://id.loc.gov/ontologies/bibframe/itemPortion",
       "repeatable": "true",
       "resourceTemplates": [],
@@ -177,7 +177,7 @@
         "defaults": []
       },
       "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
-      "propertyLabel": "LOC Names: locnames_ld4l_cache/person",
+      "propertyLabel": "Agent Contribution",
       "remark": "http://id.loc.gov/authorities/names.html"
     },
     {
@@ -217,7 +217,7 @@
       }
     },
     {
-      "propertyLabel": "LITERAL WITH DEFAULT",
+      "propertyLabel": "Holdings",
       "propertyURI": "http://id.loc.gov/ontologies/bibframe/heldBy",
       "resourceTemplates": [],
       "type": "literal",


### PR DESCRIPTION
- Use actual property template labels for spoofed Monograph:Instance instead of the ones we started with for wire-framing

- Move the resource template label down from the Editor component so we can display the actual RT label (plus some inline styling)

- Remove the `[Clone|Edit]` button placeholders. When we need those buttons we will make real ones.