### PR TITLE
Inputlistloc selector reducer

### DIFF
--- a/__tests__/components/editor/InputListLOC.test.js
+++ b/__tests__/components/editor/InputListLOC.test.js
@@ -13,9 +13,10 @@ const plProps = {
       "propertyLabel": "Frequency (RDA 2.14)",
       "remark": "http://access.rdatoolkit.org/2.14.html",
       "mandatory": "false",
-      "repeatable": "true",
+      "repeatable": "false",
       "type": "lookup",
       "valueConstraint": {
+        "repeatable": "true",
         "defaults": [{
           "defaultURI": "http://id.loc.gov/vocabulary/carriers/nc",
           "defaultLiteral": "volume"
@@ -60,7 +61,7 @@ describe('<InputList />', () => {
     expect(wrapper.find(Typeahead).props().placeholder).toMatch("Frequency (RDA 2.14)")
   })
 
-  it('sets the typeahead component multiple attribute according to the repeatable value from the template', () => {
+  it('sets the typeahead component multiple attribute according to the repeatable value from valueContraints in the property template', () => {
     expect(wrapper.find('#targetComponent').props().multiple).toBe(true)
   })
 

--- a/__tests__/reducers/inputs.test.js
+++ b/__tests__/reducers/inputs.test.js
@@ -1,4 +1,4 @@
-import { removeAllContent, removeMyItem, setMyItems  } from '../../src/reducers/literal'
+import { removeAllContent, removeMyItem, setMyItems, setMySelections } from '../../src/reducers/inputs'
 
 describe('literal reducer functions', () => {
 
@@ -130,6 +130,78 @@ describe('literal reducer functions', () => {
           items: [{ id: 2, content: "add this!"}],
           reduxPath: ['resourceTemplate:Monograph:Instance', 'http://schema.org/description']
         }
+      }
+    })
+  })
+
+  it('CHANGE_SELECTIONS adds items to state', () => {
+    const listSetSelections = setMySelections({ "resourceTemplate:Monograph:Instance": {
+      'http://schema.org/name': { items: [] }
+    }}, {
+      type: 'CHANGE_SELECTIONS',
+      payload: {
+        id: 'abc123',
+        uri: 'http://schema.org/name',
+        reduxPath: ['resourceTemplate:Monograph:Instance', 'http://schema.org/name'],
+        items: [ { id: 0, label: 'Run the tests', uri: 'http://schema.org/abc'} ]
+      }
+    })
+    expect(listSetSelections).toEqual({
+      "resourceTemplate:Monograph:Instance": {
+        'http://schema.org/name': {
+          items: [{ id: 0, label: 'Run the tests', uri: 'http://schema.org/abc'}]
+        }
+      }
+    })
+  })
+
+  it('CHANGE_SELECTIONS overwites items in  current state', () => {
+    const listSetSelections = setMySelections({ "resourceTemplate:Monograph:Instance": {
+      'http://schema.org/name': { items: [{ id: 0, label: 'Run the tests', uri: 'http://schema.org/abc'}] }
+    }}, {
+      type: 'CHANGE_SELECTIONS',
+      payload: {
+        id: 'def456',
+        uri: 'http://schema.org/name',
+        reduxPath: ['resourceTemplate:Monograph:Instance', 'http://schema.org/name'],
+        items: [
+          { id: 0, label: 'Run the tests', uri: 'http://schema.org/abc'},
+          { id: 1, label: 'See if they pass', uri: 'http://schema.org/def'}
+        ]
+      }
+    })
+    expect(listSetSelections).toEqual({
+      "resourceTemplate:Monograph:Instance": {
+        'http://schema.org/name': {
+          items: [
+            { id: 0, label: 'Run the tests', uri: 'http://schema.org/abc'},
+            { id: 1, label: 'See if they pass', uri: 'http://schema.org/def'}
+          ]
+        }
+      }
+    })
+  })
+
+  it('CHANGE_SELECTIONS removes all items in  current state by overwriting with an empty object', () => {
+    const listSetSelections = setMySelections({ "resourceTemplate:Monograph:Instance": {
+      'http://schema.org/name': {
+        items: [
+          { id: 0, label: 'Run the tests', uri: 'http://schema.org/abc'},
+          { id: 1, label: 'See if they pass', uri: 'http://schema.org/def'}
+        ]
+      }
+    }}, {
+      type: 'CHANGE_SELECTIONS',
+      payload: {
+        id: 'nomatter',
+        uri: 'http://not/importanr',
+        reduxPath: ['resourceTemplate:Monograph:Instance', 'http://schema.org/name'],
+        items: []
+      }
+    })
+    expect(listSetSelections).toEqual({
+      "resourceTemplate:Monograph:Instance": {
+        'http://schema.org/name': {items: []}
       }
     })
   })

--- a/src/components/editor/InputListLOC.jsx
+++ b/src/components/editor/InputListLOC.jsx
@@ -4,9 +4,9 @@ import React, { Component } from 'react';
 import { Typeahead } from 'react-bootstrap-typeahead'
 import PropTypes from 'prop-types'
 import PropertyRemark from './PropertyRemark'
-
 import { connect } from 'react-redux'
 import { changeSelections } from '../../actions/index'
+import shortid from 'shortid'
 
 class InputListLOC extends Component {
   constructor(props) {
@@ -22,8 +22,8 @@ class InputListLOC extends Component {
       const defaultValue = this.props.propertyTemplate.valueConstraint.defaults[0]
       const defaults = [{
         id: defaultValue.defaultURI,
-        uri: defaultValue.defaultURI,
-        label: defaultValue.defaultLiteral
+        label: defaultValue.defaultLiteral,
+        uri: defaultValue.defaultURI
       }]
       this.state.defaults = defaults
       this.setPayLoad(defaults)
@@ -36,7 +36,7 @@ class InputListLOC extends Component {
     let payload = {
       id: this.props.propertyTemplate.propertyURI,
       items: items,
-      rtId: this.props.rtId
+      reduxPath: this.props.reduxPath,
     }
     this.props.handleSelectedChange(payload)
   }
@@ -53,7 +53,7 @@ class InputListLOC extends Component {
     let lookupUri, isMandatory, isRepeatable
     try {
       isMandatory = JSON.parse(this.props.propertyTemplate.mandatory)
-      isRepeatable = JSON.parse(this.props.propertyTemplate.repeatable)
+      isRepeatable = JSON.parse(this.props.propertyTemplate.valueConstraint.repeatable)
       lookupUri = this.props.lookupConfig.value.uri
     } catch (error) {
       console.log(`Some properties were not defined in the json file: ${error}`)
@@ -82,10 +82,11 @@ class InputListLOC extends Component {
               .then(json => {
                 for(var i in json){
                   try{
+                    const newId = shortid.generate()
                     const item = Object.getOwnPropertyDescriptor(json, i)
                     const uri = item.value["@id"]
                     const label = item.value["http://www.loc.gov/mads/rdf/v1#authoritativeLabel"][0]["@value"]
-                    opts.push({ id: uri, uri: uri, label: label })
+                    opts.push({ id: newId, label: label, uri: uri })
                   } catch (error) {
                     //ignore
                   }
@@ -119,13 +120,7 @@ InputListLOC.propTypes = {
 }
 
 const mapStatetoProps = (state) => {
-  // let data = state.lookups.formData
-  let result = Object.assign({}, state)
-  // if (data !== undefined){
-  //   result = { formData: data }
-  // }
-
-  return result
+  return Object.assign({}, state)
 }
 
 const mapDispatchtoProps = dispatch => ({

--- a/src/components/editor/ResourceTemplateForm.jsx
+++ b/src/components/editor/ResourceTemplateForm.jsx
@@ -146,7 +146,9 @@ export class ResourceTemplateForm extends Component {
     if (listComponent === 'list'){
       result = (
         <PropertyPanel pt={pt} key={index} float={index} rtId={this.props.rtId}>
-          <InputListLOC propertyTemplate = {pt} lookupConfig = {lookupConfigItem} key = {index} rtId = {this.props.rtId} />
+          <InputListLOC key = {index} propertyTemplate = {pt}
+                        lookupConfig = {lookupConfigItem}
+                        reduxPath={[this.props.rtId, pt.propertyURI]} />
         </PropertyPanel>
       )
     } else if (listComponent ===  'lookup'){

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -2,7 +2,7 @@
 import { combineReducers } from 'redux'
 import lang from './lang'
 import authenticate from './authenticate'
-import { removeAllContent, setMyItems, removeMyItem } from './literal'
+import {removeAllContent, setMyItems, removeMyItem, setMySelections} from './inputs'
 import shortid from 'shortid'
 
 const inputPropertySelector = (state, props) => {
@@ -98,6 +98,8 @@ const selectorReducer = (state={}, action) => {
       return setResourceTemplate(state, action)
     case 'SET_ITEMS':
       return setMyItems(state, action)
+    case 'CHANGE_SELECTIONS':
+      return setMySelections(state, action)
     case 'REFRESH_RESOURCE_TEMPLATE':
       return refreshResourceTemplate(state, action)
     case 'REMOVE_ITEM':

--- a/src/reducers/inputs.js
+++ b/src/reducers/inputs.js
@@ -37,7 +37,7 @@ export const setMyItems = (state, action) => {
 }
 
 export const setMySelections = (state, action) => {
-  let newState = Object.assign({}, state)
+  const newState = Object.assign({}, state)
   const reduxPath = action.payload.reduxPath
   let level = 0
   reduxPath.reduce((obj, key) => {

--- a/src/reducers/inputs.js
+++ b/src/reducers/inputs.js
@@ -36,6 +36,23 @@ export const setMyItems = (state, action) => {
   return newState
 }
 
+export const setMySelections = (state, action) => {
+  let newState = Object.assign({}, state)
+  const reduxPath = action.payload.reduxPath
+  let level = 0
+  reduxPath.reduce((obj, key) => {
+    level++
+    if (level === reduxPath.length) {
+      if ((key in obj) != true) {
+        obj[key] = { items: [] }
+      }
+      obj[key].items = action.payload.items
+    }
+    return obj[key]
+  }, newState)
+  return newState
+}
+
 export const removeMyItem = (state, action) => {
   const newState = Object.assign({}, state)
   const reduxPath = action.payload.reduxPath


### PR DESCRIPTION
Fixes #430 

- Renames `literal` reducer to `inputs` because it is now being used by more than one input component
- Add a redux function to set the selections from the typeahead option list. Selections are overwritten every time with everything in the `selected` array because the typeahead component keeps track of what's in there
- Reorder the properties in the default payload to match what's set when selections are made
- Remove the un-used rtId and add the reduxPath as needed by the new selectorReducer way of setting the redux state
- Whether the typeahead component allows multiple selections should come from the repeatable property of the valueConstraint and not the property template.