### PR TITLE
Removes bullet list of groups retrieved from Trellis

### DIFF
--- a/__tests__/components/editor/SinopiaResourceTemplates.test.js
+++ b/__tests__/components/editor/SinopiaResourceTemplates.test.js
@@ -12,10 +12,6 @@ describe('<SinopiaResourceTemplates />', () => {
   ]
   const wrapper = shallow(<SinopiaResourceTemplates message={message}/>)
 
-  it('has a header for the area where the list of groups in sinopia_Server are displayed', () => {
-    expect(wrapper.find('div > h4').first().text()).toEqual('Groups in Sinopia')
-  })
-
   it('has a header for the area where the table of resource templates for the groups are displayed', () => {
     expect(wrapper.find('div > h4').last().text()).toEqual('Available Resource Templates in Sinopia')
   })

--- a/src/components/editor/SinopiaResourceTemplates.jsx
+++ b/src/components/editor/SinopiaResourceTemplates.jsx
@@ -117,14 +117,6 @@ class SinopiaResourceTemplates extends Component {
     return(
       <div>
         { createResourceMessage }
-        <h4>Groups in Sinopia</h4>
-        <ul>
-          { this.state.groupData.map((container, index) => {
-            return(
-              <li key={index}>{this.resourceToName(container)}</li>
-            )
-          })}
-        </ul>
         <h4>Available Resource Templates in Sinopia</h4>
         <BootstrapTable keyField='key' data={ this.state.templatesForGroup } >
           <TableHeaderColumn thStyle={ thNameClass } tdStyle={ tdNameClass } dataFormat={ this.linkFormatter } dataField='name' dataSort={true} >Template name</TableHeaderColumn>


### PR DESCRIPTION
Removes HTML that displayed a list of groups that retrieved from Trellis.

Fixes #508