### PR TITLE
Handles missing valueConstraint and valueTemplateRef in PropertyTemplateOutline

### DIFF
--- a/__tests__/components/editor/PropertyTemplateOutline.test.js
+++ b/__tests__/components/editor/PropertyTemplateOutline.test.js
@@ -369,3 +369,43 @@ describe('<PropertyTemplateOutline /> with propertyTemplate of type resource', (
     expect(mockHandleMintUri.mock.calls.length).toBe(1)
   })
 })
+
+describe('<PropertyTemplateOutline /> handles propertyTemplate variations', () => {
+
+  it('displays the propertyLabel when missing valueConstraint.valueTemplateRefs', () => {
+    const missingValueTemplateRefsProperty = {
+      "propertyTemplate": {
+        "mandatory": "false",
+        "repeatable": "true",
+        "type": "lookup",
+        "valueConstraint": {
+          "useValuesFrom": [
+            "http://id.loc.gov/authorities/subjects"
+          ]
+        },
+        "propertyLabel": "Search LCSH",
+        "propertyURI": "http://www.loc.gov/mads/rdf/v1#authoritativeLabel"
+        }
+    }
+    const wrapper = shallow(<PropertyTemplateOutline {...missingValueTemplateRefsProperty} />)
+    const outlineHeader = wrapper.find(OutlineHeader)
+    expect(outlineHeader.props().label).toEqual(
+      missingValueTemplateRefsProperty.propertyTemplate.propertyLabel)
+ })
+
+ it('displays the propertyLabel when missing valueConstraint', () => {
+   const missingValueConstraintProperty = {
+     "propertyTemplate": {
+       "mandatory": "false",
+       "repeatable": "true",
+       "type": "literal",
+       "propertyLabel": "A Book",
+       "propertyURI": "http:///schema.org/Book"
+     }
+   }
+   const wrapper = shallow(<PropertyTemplateOutline {...missingValueConstraintProperty} />)
+   const outlineHeader = wrapper.find(OutlineHeader)
+   expect(outlineHeader.props().label).toEqual(
+     missingValueConstraintProperty.propertyTemplate.propertyLabel)
+ })
+})

--- a/src/components/editor/PropertyTemplateOutline.jsx
+++ b/src/components/editor/PropertyTemplateOutline.jsx
@@ -180,12 +180,7 @@ export class PropertyTemplateOutline extends Component {
   handleClick = (property) => (event) => {
     event.preventDefault()
     let newOutput = this.state.output
-    const templateRefList = []
-    if(hasValueTemplateRef(property)) {
-      property.valueConstraint.valueTemplateRefs.map((row) => {
-        templateRefList.push(row)
-      })
-    }
+    const templateRefList = hasValueTemplateRef(property) ? property.valueConstraint.valueTemplateRefs : []
     this.fulfillRTPromises(this.resourceTemplatePromises(templateRefList))
       .then(() => {
         const propertyJsx = this.propertyComponentJsx(property)

--- a/src/components/editor/PropertyTemplateOutline.jsx
+++ b/src/components/editor/PropertyTemplateOutline.jsx
@@ -180,8 +180,11 @@ export class PropertyTemplateOutline extends Component {
   handleClick = (property) => (event) => {
     event.preventDefault()
     let newOutput = this.state.output
-
-    this.fulfillRTPromises(this.resourceTemplatePromises(property.valueConstraint.valueTemplateRefs))
+    const templateRefList = []
+    if(hasValueTemplateRef(property)) {
+      templateRefList.splice(0,0,property.valueConstraint.valueTemplateRefs)
+    }
+    this.fulfillRTPromises(this.resourceTemplatePromises(templateRefList))
       .then(() => {
         const propertyJsx = this.propertyComponentJsx(property)
         let existingJsx

--- a/src/components/editor/PropertyTemplateOutline.jsx
+++ b/src/components/editor/PropertyTemplateOutline.jsx
@@ -182,7 +182,9 @@ export class PropertyTemplateOutline extends Component {
     let newOutput = this.state.output
     const templateRefList = []
     if(hasValueTemplateRef(property)) {
-      templateRefList.splice(0,0,property.valueConstraint.valueTemplateRefs)
+      property.valueConstraint.valueTemplateRefs.map((row) => {
+        templateRefList.push(row)
+      })
     }
     this.fulfillRTPromises(this.resourceTemplatePromises(templateRefList))
       .then(() => {


### PR DESCRIPTION
Adds check for missing valueConstraint and valueConstraint.valueTemplateRefs when user clicks on the plus.

Fixes #509

Todo:
- [x] Test for specific Resource Templates that have propertyTemplates missing `valueConstraint` and `valueConstraint.valueTemplateRefs`