### PR TITLE
Missing templates

### DIFF
--- a/__tests__/components/editor/ResourceTemplateForm.test.js
+++ b/__tests__/components/editor/ResourceTemplateForm.test.js
@@ -8,15 +8,14 @@ import { ResourceTemplateForm } from '../../../src/components/editor/ResourceTem
 
 describe('<ResourceTemplateForm /> functional testing', () => {
 
- const basicRt = { resourceURI: 'http://schema.org/name' }
- const basicWrapper = shallow(<ResourceTemplateForm propertyTemplates={[]}
-    rtId={'resource:schema:Name'}
-    resourceTemplate={ basicRt } />)
+  const basicRt = { resourceURI: 'http://schema.org/name' }
+  const basicWrapper = shallow(<ResourceTemplateForm propertyTemplates={[]}
+                                                     rtId={'resource:schema:Name'}
+                                                     resourceTemplate={ basicRt } />)
 
- const testId = jest.spyOn(shortid, 'generate').mockReturnValue('abcd45')
+  shortid.generate = jest.fn().mockReturnValue('abcd45')
 
- describe('resourceTemplateFields expectations and outputs', () => {
-
+  describe('resourceTemplateFields expectations and outputs', () => {
     it('empty array, null, or undefined resource templates', () => {
       expect(basicWrapper.instance().resourceTemplateFields([])).toEqual([])
       expect(basicWrapper.instance().resourceTemplateFields(null)).toEqual([])
@@ -53,62 +52,8 @@ describe('<ResourceTemplateForm /> functional testing', () => {
         "abcd45",
         "resourceTemplate:bf2:Note"])
     })
-
   })
 })
-
-const rtProps = {
-  "propertyTemplates": [
-    {
-      "propertyLabel": "Literally",
-      "type": "literal"
-    },
-    {
-      "propertyLabel": "Look up, look down",
-      "type": "lookup",
-      "editable": "do not override me!",
-      "repeatable": "do not override me!",
-      "mandatory": "do not override me!",
-      "valueConstraint": {
-        "useValuesFrom": [
-          "urn:ld4p:qa:names:person"
-        ]
-      }
-    },
-    {
-      "propertyLabel": "What's the frequency Kenneth?",
-      "type": "resource",
-      "valueConstraint": {
-        "useValuesFrom": [
-          "https://id.loc.gov/vocabulary/frequencies"
-        ]
-      }
-    },
-    {
-      "propertyLabel": "Chain chain chains",
-      "type": "resource",
-      "valueConstraint": {
-        "valueTemplateRefs": [
-          "resourceTemplate:bf2:Note"
-        ]
-      },
-      "mandatory": "true"
-    },
-    {
-      "propertyLabel": "YAM (yet another modal)",
-      "type": "resource",
-      "valueConstraint": {
-        "valueTemplateRefs": [
-          "resourceTemplate:bf2:Note"
-        ]
-      }
-    },
-    {
-      "propertyLabel": "Non-modal resource",
-      "type": "resource"
-    }
-  ]
-}
 
 const mockResponse = (status, statusText, response) => {
   return new Response(response, {
@@ -148,133 +93,143 @@ const responseBody = [{
   }
 }]
 
-const lits =  {formData: [{id: 0, uri: 'http://uri', items: [
-        {content: '12345', id: 0, bnode: {termType: 'BlankNode', value: 'n3-0'}, propPredicate: 'http://predicate'}
-      ], rtId: 'resourceTemplate:bf2'}]}
-const lups = { id: 'id', uri: 'uri', label: 'label' }
-const ld = {
-  "@context": {
-    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
-    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
-    "xsd": "http://www.w3.org/2001/XMLSchema#",
-    "bf": "http://id.loc.gov/ontologies/bibframe/",
-    "bflc": "http://id.loc.gov/ontologies/bflc/",
-    "madsrdf": "http://www.loc.gov/mads/rdf/v1#",
-    "pmo": "http://performedmusicontology.org/ontology/"
-  },
-  "@graph": [
-    {
-      "@id": "n3-0",
-      "@type": "http://id.loc.gov/ontologies/bibframe/Instance",
-      "http://id.loc.gov/ontologies/bibframe/issuance": {
-        "@id": "http://id.loc.gov/vocabulary/issuance/mono"
-      },
-      "http://id.loc.gov/ontologies/bibframe/carrier": {
-        "@id": "http://id.loc.gov/vocabulary/carriers/nc"
-      },
-      "http://id.loc.gov/ontologies/bibframe/responsibilityStatement": "STMT",
-      "http://id.loc.gov/ontologies/bibframe/note": {
-        "@id": "n3-8"
-      }
-    },
-    {
-      "@id": "http://id.loc.gov/vocabulary/issuance/mono",
-      "@type": "http://id.loc.gov/ontologies/bibframe/issuance",
-      "rdfs:label": "single unit"
-    },
-    {
-      "@id": "http://id.loc.gov/vocabulary/carriers/nc",
-      "@type": "http://id.loc.gov/ontologies/bibframe/carrier",
-      "rdfs:label": "volume"
-    },
-    {
-      "@id": "n3-8",
-      "@type": "http://id.loc.gov/ontologies/bibframe/Note",
-      "http://www.w3.org/2000/01/rdf-schema#label": "NOTE"
-    }
-  ]
-}
-
 const rtTest = { resourceURI: "http://id.loc.gov/ontologies/bibframe/Work" }
-const mockHandleGenerateLD = jest.fn()
-
-
 
 describe('<ResourceTemplateForm /> after fetching data from sinopia server', () => {
 
-  // FIXME: from tests giving false positive - see github issue #496
-  // const asyncCall = (index) => {
-  //   const response = mockResponse(200, null, responseBody[index])
-  //   return response
-  // }
-  // const promises = Promise.all([ asyncCall(0) ])
-
-  const wrapper = shallow(
-    <ResourceTemplateForm {...rtProps}
-      resourceTemplate = {rtTest}
-      handleGenerateRDF = {mockHandleGenerateLD}
-      literals = {lits}
-      lookups = {lups}
-      rtId = {"resourceTemplate:bf2:Monograph:Instance"}
-      parentResourceTemplate = {"resourceTemplate:bf2:Monograph:Instance"}
-      generateLD = { ld }
-    />
-  )
+  const mockAsyncCall = (index) => {
+    const response = mockResponse(200, null, responseBody[index])
+    return response
+  }
+  const promises = Promise.all([ mockAsyncCall(0) ])
 
   describe('configured component types', () => {
 
-    it.skip('renders a lookup component', async () => {
-      // FIXME: this test gives false positive - see github issue #496 - perhaps we need an integration test
-      // const lookup = {
-      //   "propertyLabel": "Look up, look down",
-      //   "type": "lookup",
-      //   "editable": "do not override me!",
-      //   "repeatable": "do not override me!",
-      //   "mandatory": "do not override me!",
-      //   "valueConstraint": {
-      //     "useValuesFrom": [
-      //       "urn:ld4p:qa:names:person"
-      //     ]
-      //   }
-      // }
-      // const instance = wrapper.instance()
-      // await instance.fulfillRTPromises(promises).then(() => wrapper.update()).then(() => {
-      //   instance.configuredComponent(lookup, 1)
-      //   expect(wrapper
-      //     .find('div.ResourceTemplateForm Connect(InputLookupQA)').length)
-      //     .toEqual(1)
-      // }).catch(e => {})
+    it('renders a lookup component', async () => {
+      const rtProps = {
+        "propertyTemplates": [
+          {
+            "propertyLabel": "Look up, look down",
+            "type": "lookup",
+            "editable": "do not override me!",
+            "repeatable": "do not override me!",
+            "mandatory": "do not override me!",
+            "valueConstraint": {
+              "useValuesFrom": [
+                "urn:ld4p:qa:names:person"
+              ]
+            }
+          }
+        ]
+      }
+
+      const wrapper = shallow(<ResourceTemplateForm {...rtProps} resourceTemplate = {rtTest}/>)
+
+      expect.assertions(2)
+      const instance = await wrapper.instance()
+      await instance.fulfillRTPromises(promises).then(() => wrapper.update())
+      expect(wrapper.find('div.ResourceTemplateForm Connect(InputLookupQA)').length).toEqual(1)
+      expect(wrapper.find('div.ResourceTemplateForm Connect(InputListLOC)').length).toEqual(0)
     })
 
-    it.skip('renders a list component', async () => {
-      // FIXME: this test gives false positive - see github issue #496 - perhaps we need an integration test
-      // const list = {
-      //   "propertyLabel": "What's the frequency Kenneth?",
-      //   "type": "resource",
-      //   "valueConstraint": {
-      //     "useValuesFrom": [
-      //       "https://id.loc.gov/vocabulary/frequencies"
-      //     ]
-      //   }
-      // }
-      // const instance = wrapper.instance()
-      // await instance.fulfillRTPromises(promises).then(() => wrapper.update()).then(() => {
-      //   instance.configuredComponent(list, 1)
-      //   expect(wrapper
-      //     .find('div.ResourceTemplateForm Connect(InputListLOC)').length)
-      //     .toEqual(1)
-      // }).catch(e => {})
+    it('renders a list component', async () => {
+      const rtProps = {
+        "propertyTemplates": [
+          {
+            "propertyLabel": "What's the frequency Kenneth?",
+            "type": "resource",
+            "valueConstraint": {
+              "useValuesFrom": [
+                "https://id.loc.gov/vocabulary/frequencies"
+              ]
+            }
+          }
+        ]
+      }
+
+      const wrapper = shallow(<ResourceTemplateForm {...rtProps} resourceTemplate = {rtTest}/>)
+
+      expect.assertions(2)
+      const instance = await wrapper.instance()
+      await instance.fulfillRTPromises(promises).then(() => wrapper.update())
+      expect(wrapper.find('div.ResourceTemplateForm Connect(InputListLOC)').length).toEqual(1)
+      expect(wrapper.find('div.ResourceTemplateForm Connect(InputLookupQA)').length).toEqual(0)
     })
   })
 
-  it.skip('renders InputLiteral nested component (b/c we have a property of type "literal")', async () => {
-    // FIXME: this test gives false positive - see github issue #496 - perhaps we need an integration test
-    // await wrapper.instance().fulfillRTPromises(promises).then(() => wrapper.update()).then(() => {
-    //   expect(wrapper
-    //     .find('div.ResourceTemplateForm Connect(InputLiteral)').length)
-    //     .toEqual(1)
-    // }).catch(e => {})
+  it('renders InputLiteral nested component (b/c we have a property of type "literal")', async () => {
+    const rtProps = {
+      "propertyTemplates": [
+        {
+          "propertyLabel": "Literally",
+          "type": "literal"
+        }
+      ]
+    }
+
+    const wrapper = shallow(<ResourceTemplateForm {...rtProps} resourceTemplate = {rtTest}/>)
+
+    expect.assertions(2)
+    const instance = await wrapper.instance()
+    await instance.fulfillRTPromises(promises).then(() => wrapper.update())
+    expect(wrapper.find('div.ResourceTemplateForm Connect(InputLiteral)').length).toEqual(1)
+    expect(wrapper.find('div.ResourceTemplateForm Connect(InputListLOC)').length).toEqual(0)
   })
+
+  const rtProps = {
+    "propertyTemplates": [
+      {
+        "propertyLabel": "Literally",
+        "type": "literal"
+      },
+      {
+        "propertyLabel": "Look up, look down",
+        "type": "lookup",
+        "editable": "do not override me!",
+        "repeatable": "do not override me!",
+        "mandatory": "do not override me!",
+        "valueConstraint": {
+          "useValuesFrom": [
+            "urn:ld4p:qa:names:person"
+          ]
+        }
+      },
+      {
+        "propertyLabel": "What's the frequency Kenneth?",
+        "type": "resource",
+        "valueConstraint": {
+          "useValuesFrom": [
+            "https://id.loc.gov/vocabulary/frequencies"
+          ]
+        }
+      },
+      {
+        "propertyLabel": "Chain chain chains",
+        "type": "resource",
+        "valueConstraint": {
+          "valueTemplateRefs": [
+            "resourceTemplate:bf2:Note"
+          ]
+        },
+        "mandatory": "true"
+      },
+      {
+        "propertyLabel": "YAM (yet another modal)",
+        "type": "resource",
+        "valueConstraint": {
+          "valueTemplateRefs": [
+            "resourceTemplate:bf2:Note"
+          ]
+        }
+      },
+      {
+        "propertyLabel": "Non-modal resource",
+        "type": "resource"
+      }
+    ]
+  }
+
+  const wrapper = shallow(<ResourceTemplateForm {...rtProps} resourceTemplate = {rtTest}/>)
 
   it('<form> does not contain redundant form attribute', () => {
     expect(wrapper.find('form[role="form"]').length).toEqual(0)
@@ -305,31 +260,60 @@ describe('<ResourceTemplateForm /> after fetching data from sinopia server', () 
 })
 
 describe('when there are no findable nested resource templates', () => {
-  // FIXME: from tests giving false positive - see github issue #496
-  // const asyncCall = () => {
-  //   const response = mockResponse(200, null, undefined)
-  //   return response
-  // }
-  // const promises = Promise.all([ asyncCall ])
-  //
-  // const wrapper = shallow(<ResourceTemplateForm
-  //   propertyTemplates={[]}
-  //   resourceTemplate = {rtTest}
-  //   handleGenerateRDF = {mockHandleGenerateLD}
-  //   literals = {lits}
-  //   lookups = {lups}
-  //   rtId = {"resourceTemplate:bf2:Monograph:Instance"}
-  //   parentResourceTemplate = {"resourceTemplate:bf2:Monograph:Instance"}
-  //   generateLD = { ld }
-  // />)
 
-  it.skip('renders error alert box', async () => {
-    // FIXME: this test gives false positive - see github issue #496 - perhaps we need an integration test
-    // await wrapper.instance().fulfillRTPromises(promises).then(() => wrapper.update()).then(() => {
-    //   expect(wrapper.state.errot).toBeTruthy()
-    //   const errorEl = wrapper.find('div.alert')
-    //   expect(errorEl).toHaveLength(1)
-    //   expect(errorEl.text()).toEqual('Sinopia server is offline or has no resource templates to display')
-    // }).catch(e => {})
+  const mockAsyncCall = () => {
+    const response = mockResponse(200, null, undefined)
+    return response
+  }
+  const promises = Promise.all([ mockAsyncCall ])
+
+  const rtProps = {
+    "propertyTemplates": [
+      {
+        "propertyLabel": "Look up, look down",
+        "type": "lookup",
+        "editable": "do not override me!",
+        "repeatable": "do not override me!",
+        "mandatory": "do not override me!",
+        "valueConstraint": {
+          "useValuesFrom": [
+            "urn:ld4p:qa:names:person"
+          ]
+        }
+      },
+      {
+        "propertyLabel": "Chain chain chains",
+        "type": "resource",
+        "valueConstraint": {
+          "valueTemplateRefs": [
+            "resourceTemplate:bf2:Note"
+          ]
+        },
+        "mandatory": "true"
+      },
+      {
+        "propertyLabel": "YAM (yet another modal)",
+        "type": "resource",
+        "valueConstraint": {
+          "valueTemplateRefs": [
+            "resourceTemplate:bf2:Note"
+          ]
+        }
+      }
+    ]
+  }
+
+  const wrapper = shallow(<ResourceTemplateForm {...rtProps} resourceTemplate = {rtTest}/>)
+
+  it('renders error alert box', async () => {
+    expect.assertions(3)
+    const instance = await wrapper.instance()
+    await instance.fulfillRTPromises(promises).then(() => wrapper.update())
+
+    expect(await wrapper.state('templateError')).toBeTruthy()
+
+    const errorEl = wrapper.find('div.alert')
+    expect(errorEl).toHaveLength(1)
+    expect(errorEl.text()).toMatch('There are missing resource templates required by resource template: http://id.loc.gov/ontologies/bibframe/Work.Please make sure all referenced templates in property template are uploaded first.')
   })
 })

--- a/src/Utilities.js
+++ b/src/Utilities.js
@@ -1,0 +1,5 @@
+// Copyright 2018, 2019 Stanford University see Apache2.txt for license
+
+export const resourceToName = (uri) => {
+  return uri.substr(uri.lastIndexOf('/') + 1)
+}

--- a/src/components/editor/ImportResourceTemplate.jsx
+++ b/src/components/editor/ImportResourceTemplate.jsx
@@ -96,10 +96,8 @@ class ImportResourceTemplate extends Component {
 
   updateStateForResourceError = (error) => {
     if(_.get(error, 'response.statusText') === 'Conflict') {
-      const response = error.response
-      const joinedConflicts = this.state.createResourceError.slice(0)
-      this.setState({tempConflictError: response})
-      joinedConflicts.push(this.state.tempConflictError)
+      const joinedConflicts = [...this.state.createResourceError]
+      joinedConflicts.push(error.response)
       this.setState({createResourceError: joinedConflicts})
     }
   }

--- a/src/components/editor/PropertyTemplateOutline.jsx
+++ b/src/components/editor/PropertyTemplateOutline.jsx
@@ -67,9 +67,8 @@ export class PropertyTemplateOutline extends Component {
   fulfillRTPromises = async (promiseAll) => {
     await promiseAll.then(rts => {
       rts.map(rt => {
-        this.setState({tempState: rt.response.body})
-        const joinedRts = this.state.nestedResourceTemplates.slice(0)
-        joinedRts.push(this.state.tempState)
+        const joinedRts = [...this.state.nestedResourceTemplates]
+        joinedRts.push(rt.response.body)
         this.setState({nestedResourceTemplates: joinedRts})
       })
     }).catch(() => {})

--- a/src/components/editor/SinopiaResourceTemplates.jsx
+++ b/src/components/editor/SinopiaResourceTemplates.jsx
@@ -6,6 +6,7 @@ import { Link } from 'react-router-dom'
 import {BootstrapTable, TableHeaderColumn} from 'react-bootstrap-table'
 import Config from '../../../src/Config'
 import { getGroups, listResourcesInGroupContainer, getResourceTemplate } from '../../sinopiaServer'
+import { resourceToName } from '../../Utilities'
 const _ = require('lodash')
 const SinopiaServer = require('sinopia_server')
 const instance = new SinopiaServer.LDPApi()
@@ -30,7 +31,7 @@ class SinopiaResourceTemplates extends Component {
 
       await this.fulfillGroupPromise(groupPromise).then(async () => {
         this.state.groupData.map(group => {
-          const groupName = this.resourceToName(group)
+          const groupName = resourceToName(group)
           listResourcesInGroupContainer(groupName).then((data) => {
             this.fulfillGroupData(data)
           }).catch(() => {})
@@ -50,13 +51,13 @@ class SinopiaResourceTemplates extends Component {
   }
 
   fulfillGroupData = (data) => {
-    const groupName = this.resourceToName(data.response.body['@id'])
+    const groupName = resourceToName(data.response.body['@id'])
 
     if (data.response.body.contains !== undefined) {
       const contains = [].concat(data.response.body.contains)
 
       contains.map(c => {
-        const name = this.resourceToName(c)
+        const name = resourceToName(c)
 
         this.groupDataPromise(groupName, name).then((data) => {
           const rt = data.response.body
@@ -73,14 +74,9 @@ class SinopiaResourceTemplates extends Component {
   }
 
   groupDataPromise = (groupName, name) => new Promise(async (resolve) => {
-    // await resolve(instance.getResourceWithHttpInfo(groupName, name, { acceptEncoding: 'application/json' }))
     await resolve(getResourceTemplate(name, groupName))
   })
 
-  resourceToName = (resource) => {
-    const idx = resource.lastIndexOf('/')
-    return resource.substring(idx+1)
-  }
 
   linkFormatter = (cell, row) => {
     return(

--- a/src/components/editor/UpdateResourceModal.jsx
+++ b/src/components/editor/UpdateResourceModal.jsx
@@ -4,6 +4,7 @@ import React, {Component} from 'react'
 import PropTypes from 'prop-types'
 import Button from 'react-bootstrap/lib/Button'
 import Modal from 'react-bootstrap/lib/Modal'
+import { resourceToName } from '../../Utilities'
 const _ = require('lodash')
 
 class UpdateResourceModal extends Component {
@@ -15,11 +16,6 @@ class UpdateResourceModal extends Component {
     }
   }
 
-  resourceToName = (resource) => {
-    const idx = resource.lastIndexOf('/')
-    return resource.substring(idx+1)
-  }
-
   componentDidMount() {
     let group = ''
     let rts = []
@@ -29,7 +25,7 @@ class UpdateResourceModal extends Component {
     messages.map(message => {
       if(_.get(message, 'req._data.id')) {
         const req = message.req
-        group = this.resourceToName(req.url)
+        group = resourceToName(req.url)
         const rt = req._data
         rts.push(rt)
         titleMessages.push(`${rt.id} already exisits`)


### PR DESCRIPTION
Fixes #517 
Fixes #496 for ResourceTemplateFormTest

- Collect ids from resource templates that could not be fetched from server and display them in error message:

![Screen Shot 2019-05-14 at 4 19 47 PM](https://user-images.githubusercontent.com/3093850/57738388-1bfec780-7664-11e9-8c16-a0c1292da1e8.png)

- Fix false positives in ResourceTemplateForm tests and test for missing template message

- There was a function that was needed to be used in three different components to get the resource name out of a URI (everything after the last `/`). Switch to using a one-liner instead of repeating that function (or creating a global function)