### PR TITLE
Refactor and fix resource template components

### DIFF
--- a/__mocks__/SinopiaClientErrorFake.js
+++ b/__mocks__/SinopiaClientErrorFake.js
@@ -1,0 +1,13 @@
+export default class SinopiaClientErrorFake {
+  async createResourceWithHttpInfo() {
+    throw {
+      response: 'i am an error for a created object'
+    }
+  }
+
+  async updateResourceWithHttpInfo() {
+    throw {
+      response: 'i am an error for an updated object'
+    }
+  }
+}

--- a/__mocks__/SinopiaClientSuccessFake.js
+++ b/__mocks__/SinopiaClientSuccessFake.js
@@ -1,0 +1,13 @@
+export default class SinopiaClientSuccessFake {
+  async createResourceWithHttpInfo() {
+    return {
+      response: 'i am a response for a created object'
+    }
+  }
+
+  async updateResourceWithHttpInfo() {
+    return {
+      response: 'i am a response for an updated object'
+    }
+  }
+}

--- a/__tests__/components/editor/ImportResourceTemplate.test.js
+++ b/__tests__/components/editor/ImportResourceTemplate.test.js
@@ -1,15 +1,25 @@
 // Copyright 2019 Stanford University see Apache2.txt for license
 
+import 'isomorphic-fetch'
 import 'jsdom-global/register'
 import React from 'react'
 import { shallow } from 'enzyme'
-import ImportResourceTemplate from '../../../src/components/editor/ImportResourceTemplate'
 import ImportFileZone from '../../../src/components/editor/ImportFileZone'
+import ImportResourceTemplate from '../../../src/components/editor/ImportResourceTemplate'
 import SinopiaResourceTemplates from '../../../src/components/editor/SinopiaResourceTemplates'
-import 'isomorphic-fetch'
+
+// Fake out the sinopia client
+import SinopiaClientErrorFake from '../../../__mocks__/SinopiaClientErrorFake'
+import SinopiaClientSuccessFake from '../../../__mocks__/SinopiaClientSuccessFake'
 
 describe('<ImportResourceTemplate />', () => {
-  const wrapper = shallow(<ImportResourceTemplate />)
+  let wrapper = shallow(<ImportResourceTemplate />)
+
+  // Make sure spies/mocks don't leak between tests
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
   //This test should be expanded when the Import Resource Template page is further defined
   it('contains the main div', () => {
     expect(wrapper.find("div#importResourceTemplate").length).toBe(1)
@@ -23,82 +33,151 @@ describe('<ImportResourceTemplate />', () => {
     expect(wrapper.find(SinopiaResourceTemplates).length).toBe(1)
   })
 
-})
-
-const mockResponse = (status, statusText, response) => {
-  return new Response(response, {
-    status: status,
-    statusText: statusText,
-    headers: {
-      'Content-type': 'application/json'
-    }
-  }).body
-}
-
-describe('creating a non-rdf resource from an uploaded profile', () => {
-  const result = {
-    data: null,
-    response: {
-      headers: {
-        location: "http://localhost:8080/repository/ld4p/resourceTemplate:bf2:Note"
+  describe('setResourceTemplates()', () => {
+    const content = {
+      Profile: {
+        resourceTemplates: [
+          {
+            id: 'template1'
+          },
+          {
+            id: 'template2'
+          }
+        ]
       }
     }
-  }
 
-  it('sets an info message that the resource was created on success', async () => {
-    const wrapper = shallow(<ImportResourceTemplate />)
-    const promise = Promise.resolve(mockResponse(201, "Created", result))
-    await wrapper.instance().fulfillCreateResourcePromise(promise)
-    expect(wrapper.state('message')).toEqual([ `${result.response.statusText} ${result.response.headers.location}` ])
+    it('invokes createResource(), updateStateFromServerResponse(), and setState() once per template', async () => {
+      const createResourceSpy = jest.spyOn(wrapper.instance(), 'createResource').mockImplementation(async () => {})
+      const updateStateSpy = jest.spyOn(wrapper.instance(), 'updateStateFromServerResponse').mockReturnValue(null)
+      const setStateSpy = jest.spyOn(wrapper.instance(), 'setState').mockReturnValue(null)
+
+      await wrapper.instance().setResourceTemplates(content, 'ld4p')
+
+      expect(createResourceSpy).toHaveBeenCalledTimes(2)
+      expect(updateStateSpy).toHaveBeenCalledTimes(2)
+      expect(setStateSpy).toHaveBeenCalledTimes(2)
+    })
   })
 
-  it('shows the error message if resource creation fails', async () => {
-    const wrapper = shallow(<ImportResourceTemplate />)
-    const promise = Promise.resolve(mockResponse(500, "Bad request", null))
-    wrapper.setState({createResourceError: [{statusText: "Bad request"}]})
-    await wrapper.instance().fulfillCreateResourcePromise(promise)
-    await wrapper.update()
-    expect(wrapper.state().message).toEqual( [ 'The sinopia server is not accepting the request for this resource.' ])
+  describe('createResource()', () => {
+    it('returns response from sinopia client call when successful', async () => {
+      wrapper.instance().instance = new SinopiaClientSuccessFake()
+
+      const response = await wrapper.instance().createResource({ foo: 'bar'}, 'ld4p')
+
+      expect(response).toEqual('i am a response for a created object')
+    })
+
+    it('returns error response and adds to state when client call fails', async () => {
+      wrapper.instance().instance = new SinopiaClientErrorFake()
+
+      const setStateSpy = jest.spyOn(wrapper.instance(), 'setState').mockReturnValue(null)
+      const response = await wrapper.instance().createResource({ foo: 'bar'}, 'ld4p')
+
+      expect(response).toEqual('i am an error for a created object')
+      expect(setStateSpy).toHaveBeenCalledWith({
+        createResourceError: ['i am an error for a created object']
+      })
+    })
   })
 
-  it('does not display the error/info alert if the response status is Conflict', async () => {
-    const wrapper = shallow(<ImportResourceTemplate />)
-    const promise = Promise.resolve(mockResponse(409, "Conflict", null))
-    wrapper.setState({createResourceError: [{statusText: "Conflict"}]})
-    await wrapper.instance().fulfillCreateResourcePromise(promise)
-    await wrapper.update()
-    expect(wrapper.state().message).toEqual([])
+  describe('updateResource()', () => {
+    it('returns response from sinopia client call when successful', async () => {
+      wrapper.instance().instance = new SinopiaClientSuccessFake()
+
+      const response = await wrapper.instance().updateResource({ foo: 'bar'}, 'ld4p')
+
+      expect(response).toEqual('i am a response for an updated object')
+    })
+
+    it('returns error response and adds to state when client call fails', async () => {
+      wrapper.instance().instance = new SinopiaClientErrorFake()
+
+      const setStateSpy = jest.spyOn(wrapper.instance(), 'setState').mockReturnValue(null)
+      const response = await wrapper.instance().updateResource({ foo: 'bar'}, 'ld4p')
+
+      expect(response).toEqual('i am an error for an updated object')
+      expect(setStateSpy).toHaveBeenCalledWith({
+        updateResourceError: 'i am an error for an updated object'
+      })
+    })
   })
 
-  const content = { Profile: { resourceTemplates: [ {propertyTemplates: {}} ]}}
+  describe('updateStateFromServerResponse()', () => {
+    it('adds error message to state when update operation does *not* result in HTTP 409 Conflict', () => {
+      // Set new wrapper in each of these tests because we are changing state
+      wrapper = shallow(<ImportResourceTemplate />)
 
-  it('increments and sets the state with an update key to pass into child component to avoid infinite recursion', async () => {
-    const wrapper = shallow(<ImportResourceTemplate />)
-    const promise = Promise.resolve(mockResponse(201, "Created", result))
-    wrapper.instance().fulfillCreateResourcePromise(promise)
-    wrapper.instance().setResourceTemplates(content, 'ld4p')
-    expect(wrapper.state().updateKey).toBeGreaterThan(0)
+      expect(wrapper.state().message).toEqual([])
+
+      wrapper.instance().updateStateFromServerResponse({ status: 200 }, 'update')
+
+      expect(wrapper.state().message).toEqual(['The sinopia server is not accepting the request for this resource.'])
+    })
+    it('sets modalShow to true when receiving HTTP 409 and errors >= profileCount', () => {
+      // Set new wrapper in each of these tests because we are changing state
+      wrapper = shallow(<ImportResourceTemplate />)
+
+      expect(wrapper.state().modalShow).toBe(false)
+
+      wrapper.instance().updateStateFromServerResponse({ status: 409 , headers: {} }, 'create', 0)
+      expect(wrapper.state().modalShow).toBe(true)
+    })
+    it('sets message in state with any create operation not resulting in HTTP 409', () => {
+      // Set new wrapper in each of these tests because we are changing state
+      wrapper = shallow(<ImportResourceTemplate />)
+
+      expect(wrapper.state().message).toEqual([])
+
+      wrapper.instance().updateStateFromServerResponse({ status: 201 , headers: { location: 'http://foo.bar' } }, 'create')
+
+      expect(wrapper.state().message).toEqual(['Created http://foo.bar'])
+    })
   })
 
-  it('sets the conflict errors to be handles by the update functionality', () => {
-    const responseMock = {
-      response: {
-        "req": {
-          "method":"POST",
-          "url":"http://localhost:8080/repository/ld4p",
-          "_data": {},
-        },
-        "statusText":"Conflict",
-        "statusCode":409,
-        "status":409
+  describe('humanReadableStatus()', () => {
+    it('returns human-readable label for HTTP 201', () => {
+      expect(wrapper.instance().humanReadableStatus(201)).toEqual('Created')
+    })
+    it('returns human-readable label for HTTP 204', () => {
+      expect(wrapper.instance().humanReadableStatus(204)).toEqual('Updated')
+    })
+    it('returns human-readable label for HTTP 401', () => {
+      expect(wrapper.instance().humanReadableStatus(401)).toEqual('You are not authorized to do this. Try logging in again!')
+    })
+    it('returns human-readable label for HTTP 409', () => {
+      expect(wrapper.instance().humanReadableStatus(409)).toEqual('Attempting to update')
+    })
+    it('returns human-readable label for any other HTTP status', () => {
+      expect(wrapper.instance().humanReadableStatus(400)).toEqual('Unexpected response (400)!')
+    })
+  })
+
+  describe('handleUpdateResource()', () => {
+    const templates =  [
+      {
+        id: 'template1'
+      },
+      {
+        id: 'template2'
       }
-    }
-    const wrapper = shallow(<ImportResourceTemplate />)
-    const error = mockResponse(409, "Conflict", responseMock)
-    wrapper.instance().updateStateForResourceError(error)
-    wrapper.update()
-    expect(wrapper.state().createResourceError).toEqual([responseMock.response])
-  })
-  
-})
+    ]
 
+    it('updates every template, updates state, closes the modal and reloads', async () => {
+      const updateResourceSpy = jest.spyOn(wrapper.instance(), 'updateResource').mockImplementation(async () => {})
+      const updateStateSpy = jest.spyOn(wrapper.instance(), 'updateStateFromServerResponse').mockReturnValue(null)
+      const setStateSpy = jest.spyOn(wrapper.instance(), 'setState').mockReturnValue(null)
+      const modalCloseSpy = jest.spyOn(wrapper.instance(), 'modalClose').mockReturnValue(null)
+      // TODO: Figure out how to test that window.location.reload fires. Can not spy on read-only property.
+      // const windowLocationSpy = jest.spyOn(window.location, 'reload').mockReturnValue(null)
+
+      await wrapper.instance().handleUpdateResource(templates, 'ld4p')
+
+      expect(updateResourceSpy).toHaveBeenCalledTimes(2)
+      expect(updateStateSpy).toHaveBeenCalledTimes(2)
+      expect(setStateSpy).toHaveBeenCalledTimes(2)
+      expect(modalCloseSpy).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/__tests__/components/editor/ImportResourceTemplate.test.js
+++ b/__tests__/components/editor/ImportResourceTemplate.test.js
@@ -56,7 +56,7 @@ describe('<ImportResourceTemplate />', () => {
 
       expect(createResourceSpy).toHaveBeenCalledTimes(2)
       expect(updateStateSpy).toHaveBeenCalledTimes(2)
-      expect(setStateSpy).toHaveBeenCalledTimes(2)
+      expect(setStateSpy).toHaveBeenCalledTimes(1)
     })
   })
 
@@ -91,16 +91,12 @@ describe('<ImportResourceTemplate />', () => {
       expect(response).toEqual('i am a response for an updated object')
     })
 
-    it('returns error response and adds to state when client call fails', async () => {
+    it('returns error response when client call fails', async () => {
       wrapper.instance().instance = new SinopiaClientErrorFake()
 
-      const setStateSpy = jest.spyOn(wrapper.instance(), 'setState').mockReturnValue(null)
       const response = await wrapper.instance().updateResource({ foo: 'bar'}, 'ld4p')
 
       expect(response).toEqual('i am an error for an updated object')
-      expect(setStateSpy).toHaveBeenCalledWith({
-        updateResourceError: 'i am an error for an updated object'
-      })
     })
   })
 
@@ -111,9 +107,9 @@ describe('<ImportResourceTemplate />', () => {
 
       expect(wrapper.state().message).toEqual([])
 
-      wrapper.instance().updateStateFromServerResponse({ status: 200 }, 'update')
+      wrapper.instance().updateStateFromServerResponse({ status: 200, headers: {} })
 
-      expect(wrapper.state().message).toEqual(['The sinopia server is not accepting the request for this resource.'])
+      expect(wrapper.state().message).toEqual(['Unexpected response (200)! '])
     })
     it('sets modalShow to true when receiving HTTP 409 and errors >= profileCount', () => {
       // Set new wrapper in each of these tests because we are changing state
@@ -121,7 +117,7 @@ describe('<ImportResourceTemplate />', () => {
 
       expect(wrapper.state().modalShow).toBe(false)
 
-      wrapper.instance().updateStateFromServerResponse({ status: 409 , headers: {} }, 'create', 0)
+      wrapper.instance().updateStateFromServerResponse({ status: 409 , headers: {} }, 0)
       expect(wrapper.state().modalShow).toBe(true)
     })
     it('sets message in state with any create operation not resulting in HTTP 409', () => {
@@ -130,7 +126,7 @@ describe('<ImportResourceTemplate />', () => {
 
       expect(wrapper.state().message).toEqual([])
 
-      wrapper.instance().updateStateFromServerResponse({ status: 201 , headers: { location: 'http://foo.bar' } }, 'create')
+      wrapper.instance().updateStateFromServerResponse({ status: 201 , headers: { location: 'http://foo.bar' } })
 
       expect(wrapper.state().message).toEqual(['Created http://foo.bar'])
     })
@@ -167,16 +163,12 @@ describe('<ImportResourceTemplate />', () => {
     it('updates every template, updates state, closes the modal and reloads', async () => {
       const updateResourceSpy = jest.spyOn(wrapper.instance(), 'updateResource').mockImplementation(async () => {})
       const updateStateSpy = jest.spyOn(wrapper.instance(), 'updateStateFromServerResponse').mockReturnValue(null)
-      const setStateSpy = jest.spyOn(wrapper.instance(), 'setState').mockReturnValue(null)
       const modalCloseSpy = jest.spyOn(wrapper.instance(), 'modalClose').mockReturnValue(null)
-      // TODO: Figure out how to test that window.location.reload fires. Can not spy on read-only property.
-      // const windowLocationSpy = jest.spyOn(window.location, 'reload').mockReturnValue(null)
 
       await wrapper.instance().handleUpdateResource(templates, 'ld4p')
 
       expect(updateResourceSpy).toHaveBeenCalledTimes(2)
       expect(updateStateSpy).toHaveBeenCalledTimes(2)
-      expect(setStateSpy).toHaveBeenCalledTimes(2)
       expect(modalCloseSpy).toHaveBeenCalledTimes(1)
     })
   })

--- a/__tests__/components/editor/SinopiaResourceTemplates.test.js
+++ b/__tests__/components/editor/SinopiaResourceTemplates.test.js
@@ -2,8 +2,10 @@ import 'jsdom-global/register'
 import React from 'react'
 import { shallow } from 'enzyme'
 import SinopiaResourceTemplates from '../../../src/components/editor/SinopiaResourceTemplates'
-import BootstrapTable from 'react-bootstrap-table'
+import { getGroups, listResourcesInGroupContainer, getResourceTemplate } from '../../../src/sinopiaServer'
 import 'isomorphic-fetch'
+
+jest.mock('../../../src/sinopiaServer')
 
 describe('<SinopiaResourceTemplates />', () => {
   const message = [
@@ -20,73 +22,216 @@ describe('<SinopiaResourceTemplates />', () => {
     expect(wrapper.find('BootstrapTable').length).toEqual(1)
   })
 
-  describe('getting data from the sinopia_server', () => {
+  describe('constructor()', () => {
+    it('initializes this.errors to empty array', () => {
+      expect(wrapper.state().errors).toEqual([])
+    })
 
-    const mockResponse = (status, statusText, response) => {
-      return new Response(response, {
-        status: status,
-        statusText: statusText,
-        headers: {
-          'Content-type': 'application/json'
-        }
-      }).body
+    it('initializes this.resourceTemplates to empty array', () => {
+      expect(wrapper.state().resourceTemplates).toEqual([])
+    })
+  })
+
+  describe('componentDidUpdate()', () => {
+    const initialUpdateKey = 1
+
+    it('calls fetchResourceTemplatesFromGroups() if updateKey has been incremented', async () => {
+      const wrapper2 = shallow(<SinopiaResourceTemplates message={message} updateKey={initialUpdateKey} />)
+      const fetchSpy = jest.spyOn(wrapper2.instance(), 'fetchResourceTemplatesFromGroups').mockReturnValue(null)
+
+      await wrapper2.setProps({ updateKey: 2 })
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1)
+    })
+    it('returns early if updateKey has not changed', async () => {
+      const wrapper2 = shallow(<SinopiaResourceTemplates message={message} updateKey={initialUpdateKey} />)
+      const fetchSpy = jest.spyOn(wrapper2.instance(), 'fetchResourceTemplatesFromGroups').mockReturnValue(null)
+
+      await wrapper2.setProps({ updateKey: 1 })
+
+      expect(fetchSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('fetchResourceTemplatesFromGroups()', () => {
+    const containsNothing = {
+      response: {
+        body: {}
+      }
     }
 
-    const bodyContains = {
+    const containsGroups = {
       response: {
         body: {
           contains: [
-            'ld4p', 'pcc'
+            'ld4p'
           ]
         }
       }
     }
 
-    it('sets the state with group data (as Array) from sinopia_server', async() => {
-
-      const promise = Promise.resolve(mockResponse(200, null, bodyContains))
-      const wrapper2 = shallow(<SinopiaResourceTemplates message={message} />)
-      await wrapper2.instance().fulfillGroupPromise(promise).then(() => wrapper2.update()).then(() => {
-        expect(wrapper2.state('groupData')).toEqual(['ld4p', 'pcc'])
-        expect(resourceToName).toHaveBeenCalled()
-      }).catch(e => {})
-    })
-
-    it('sets a message if there is no server response', async() => {
-      const promise = Promise.resolve(mockResponse(200, null, undefined))
-      const wrapper2 = shallow(<SinopiaResourceTemplates message={message} />)
-      await wrapper2.instance().fulfillGroupPromise(promise).then(() => wrapper2.update()).then(() => {
-        expect(wrapper2.state('message')).toBeTruthy()
-        expect(resourceToName).toHaveBeenCalled()
-      }).catch(e => {})
-    })
-
-    it('sets the state with a list of resource templates from the server', async() => {
-      const bodyContains = {
-        response: {
-          body: {
-            "@id": 'ld4p',
-            contains: [
-              "http://localhost:8080/repository/ld4p/Note",
-              "http://localhost:8080/repository/ld4p/Barcode",
-              "http://localhost:8080/repository/ld4p/Title",
-              "http://localhost:8080/repository/ld4p/Item"
-            ]
-          }
+    const containsTemplate = {
+      response: {
+        body: {
+          contains: 'imatemplate'
         }
       }
+    }
 
-      const wrapper3 = shallow(<SinopiaResourceTemplates message={message}/>)
-      //TODO: figure out how to mock and test a nested promise...
-      const spy = jest.spyOn(wrapper3.instance(), 'fulfillGroupData')
-      await wrapper3.instance().fulfillGroupData(bodyContains)
-      expect(spy).toHaveBeenCalled()
+    it('does not set state if there are no groups', async () => {
+      getGroups.mockReturnValue(new Promise(resolve => {
+        resolve(containsNothing)
+      }))
+
+      const wrapper2 = shallow(<SinopiaResourceTemplates message={message} />)
+      const setStateFromServerResponseSpy = jest.spyOn(wrapper2.instance(), 'setStateFromServerResponse').mockReturnValue(null)
+
+      await wrapper2.instance().fetchResourceTemplatesFromGroups()
+
+      expect(setStateFromServerResponseSpy).not.toHaveBeenCalled()
     })
 
+    it('does not set state if groups have no resource templates', async () => {
+      getGroups.mockReturnValue(new Promise(resolve => {
+        resolve(containsGroups)
+      }))
+      listResourcesInGroupContainer.mockReturnValue(new Promise(resolve => {
+        resolve(containsNothing)
+      }))
+
+      const wrapper2 = shallow(<SinopiaResourceTemplates message={message} />)
+      const setStateFromServerResponseSpy = jest.spyOn(wrapper2.instance(), 'setStateFromServerResponse').mockReturnValue(null)
+
+      await wrapper2.instance().fetchResourceTemplatesFromGroups()
+
+      expect(setStateFromServerResponseSpy).not.toHaveBeenCalled()
+    })
+
+    it('sets state when there is a non-zero number of templates', async () => {
+      getGroups.mockReturnValue(new Promise(resolve => {
+        resolve(containsGroups)
+      }))
+      listResourcesInGroupContainer.mockReturnValue(new Promise(resolve => {
+        resolve(containsTemplate)
+      }))
+
+      const wrapper2 = shallow(<SinopiaResourceTemplates message={message} />)
+      const setStateFromServerResponseSpy = jest.spyOn(wrapper2.instance(), 'setStateFromServerResponse').mockReturnValue(null)
+
+      await wrapper2.instance().fetchResourceTemplatesFromGroups()
+
+      expect(setStateFromServerResponseSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('adds errors to state if anything throws', async () => {
+      getGroups.mockImplementation(async () => {
+        throw 'uh oh!'
+      })
+
+      const wrapper2 = shallow(<SinopiaResourceTemplates message={message} />)
+      const setStateFromServerResponseSpy = jest.spyOn(wrapper2.instance(), 'setStateFromServerResponse').mockReturnValue(null)
+      // We are spying on and stubbing setState() instead of testing what winds
+      // up in this.state.errors because if we don't stub setState(), it will
+      // trigger componentDidUpdate() which calls
+      // fetchResourceTemplatesFromGroups() again which calls setState() again,
+      // ad infinitum.
+      const setStateSpy = jest.spyOn(wrapper2.instance(), 'setState').mockReturnValue(null)
+
+      await wrapper2.instance().fetchResourceTemplatesFromGroups()
+
+      expect(setStateFromServerResponseSpy).not.toHaveBeenCalled()
+      expect(setStateSpy).toHaveBeenCalledWith({
+        errors: ['uh oh!']
+      })
+    })
+  })
+
+  describe('setStateFromServerResponse()', () => {
+    it('calls getResourceTemplate() once when passed a string', async () => {
+      const getResourceTemplateSpy = jest.fn().mockReturnValue({
+        response: {
+          body: {
+            id: 'foo',
+            resourceLabel: 'bar'
+          }
+        }
+      })
+
+      getResourceTemplate.mockImplementation(async () => {
+        return getResourceTemplateSpy()
+      })
+
+      const wrapper2 = shallow(<SinopiaResourceTemplates message={message} />)
+      const setStateSpy = jest.spyOn(wrapper2.instance(), 'setState').mockReturnValue(null)
+
+      await wrapper2.instance().setStateFromServerResponse('ld4p', 'template1')
+
+      expect(getResourceTemplateSpy.mock.calls.length).toEqual(1)
+      expect(setStateSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('calls getResourceTemplate n times where n is the length of the array passed in', async () => {
+      const getResourceTemplateSpy = jest.fn().mockReturnValue({
+        response: {
+          body: {
+            id: 'foo',
+            resourceLabel: 'bar'
+          }
+        }
+      })
+
+      getResourceTemplate.mockImplementation(async () => {
+        return getResourceTemplateSpy()
+      })
+
+      const wrapper2 = shallow(<SinopiaResourceTemplates message={message} />)
+      const setStateSpy = jest.spyOn(wrapper2.instance(), 'setState').mockReturnValue(null)
+
+      await wrapper2.instance().setStateFromServerResponse('ld4p', ['template1', 'template2', 'template3'])
+
+      expect(getResourceTemplateSpy.mock.calls.length).toEqual(3)
+      expect(setStateSpy).toHaveBeenCalledTimes(3)
+    })
+
+    it('does not add templates to state if they already exist', async () => {
+      const getResourceTemplateSpy = jest.fn().mockReturnValue({
+        response: {
+          body: {
+            id: 'foo',
+            resourceLabel: 'bar'
+          }
+        }
+      })
+
+      getResourceTemplate.mockImplementation(async () => {
+        return getResourceTemplateSpy()
+      })
+
+      const wrapper2 = shallow(<SinopiaResourceTemplates message={message} />)
+      const existingTemplates = [
+        {
+          key: 'foo',
+          name: 'baz',
+          uri: 'template99',
+          id: 'bar',
+          group: 'ld4p'
+        }
+      ]
+      wrapper2.setState({
+        resourceTemplates: existingTemplates
+      })
+      // Prevent setState() from being called for reals. See above for rationale.
+      wrapper2.instance().setState = jest.fn().mockReturnValue(null)
+
+      await wrapper2.instance().setStateFromServerResponse('ld4p', ['template3'])
+
+      expect(getResourceTemplateSpy.mock.calls.length).toEqual(1)
+      // Failure condition would be if the size of the array changed or if name were 'bar'
+      expect(wrapper2.state().resourceTemplates).toEqual(existingTemplates)
+    })
   })
 
   describe('linking back to the Editor component', () => {
-
     const cell = 'Note'
     const row = {
       name: "Note",

--- a/__tests__/components/editor/SinopiaResourceTemplates.test.js
+++ b/__tests__/components/editor/SinopiaResourceTemplates.test.js
@@ -2,7 +2,7 @@ import 'jsdom-global/register'
 import React from 'react'
 import { shallow } from 'enzyme'
 import SinopiaResourceTemplates from '../../../src/components/editor/SinopiaResourceTemplates'
-import { getGroups, listResourcesInGroupContainer, getResourceTemplate } from '../../../src/sinopiaServer'
+import { listResourcesInGroupContainer, getResourceTemplate } from '../../../src/sinopiaServer'
 import 'isomorphic-fetch'
 
 jest.mock('../../../src/sinopiaServer')
@@ -78,23 +78,26 @@ describe('<SinopiaResourceTemplates />', () => {
       }
     }
 
-    it('does not set state if there are no groups', async () => {
-      getGroups.mockReturnValue(new Promise(resolve => {
-        resolve(containsNothing)
-      }))
+    // TODO: Restore this test once RTs are stored in multiple groups
+    it.skip('does not set state if there are no groups', async () => {
+      // getGroups.mockReturnValue(new Promise(resolve => {
+      //   resolve(containsNothing)
+      // }))
 
-      const wrapper2 = shallow(<SinopiaResourceTemplates message={message} />)
-      const setStateFromServerResponseSpy = jest.spyOn(wrapper2.instance(), 'setStateFromServerResponse').mockReturnValue(null)
+      // const wrapper2 = shallow(<SinopiaResourceTemplates message={message} />)
+      // const setStateFromServerResponseSpy = jest.spyOn(wrapper2.instance(), 'setStateFromServerResponse').mockReturnValue(null)
 
-      await wrapper2.instance().fetchResourceTemplatesFromGroups()
+      // await wrapper2.instance().fetchResourceTemplatesFromGroups()
 
-      expect(setStateFromServerResponseSpy).not.toHaveBeenCalled()
+      // expect(setStateFromServerResponseSpy).not.toHaveBeenCalled()
     })
 
     it('does not set state if groups have no resource templates', async () => {
-      getGroups.mockReturnValue(new Promise(resolve => {
-        resolve(containsGroups)
-      }))
+      // TODO: Restore this once RTs are stored in multiple groups
+      //
+      // getGroups.mockReturnValue(new Promise(resolve => {
+      //   resolve(containsGroups)
+      // }))
       listResourcesInGroupContainer.mockReturnValue(new Promise(resolve => {
         resolve(containsNothing)
       }))
@@ -108,9 +111,11 @@ describe('<SinopiaResourceTemplates />', () => {
     })
 
     it('sets state when there is a non-zero number of templates', async () => {
-      getGroups.mockReturnValue(new Promise(resolve => {
-        resolve(containsGroups)
-      }))
+      // TODO: Restore this once RTs are stored in multiple groups
+      //
+      // getGroups.mockReturnValue(new Promise(resolve => {
+      //   resolve(containsGroups)
+      // }))
       listResourcesInGroupContainer.mockReturnValue(new Promise(resolve => {
         resolve(containsTemplate)
       }))
@@ -124,7 +129,7 @@ describe('<SinopiaResourceTemplates />', () => {
     })
 
     it('adds errors to state if anything throws', async () => {
-      getGroups.mockImplementation(async () => {
+      listResourcesInGroupContainer.mockImplementation(async () => {
         throw 'uh oh!'
       })
 

--- a/__tests__/components/editor/UpdateResourceModal.test.js
+++ b/__tests__/components/editor/UpdateResourceModal.test.js
@@ -43,7 +43,7 @@ describe('<UpdateResourceModal> with conflict message', () => {
   })
 
   it('has a modal title with the status text and template id', () => {
-    expect(wrapper.find(Modal.Title).dive().text()).toEqual('sinopia:resourceTemplate:bf2:LCC already exisits')
+    expect(wrapper.find(Modal.Title).dive().text()).toEqual('sinopia:resourceTemplate:bf2:LCC already exists')
   })
 
   it('has a modal body with a question', () => {
@@ -52,7 +52,7 @@ describe('<UpdateResourceModal> with conflict message', () => {
 
   it('has a Yes button, when clicked will call the update function', () => {
     const button = wrapper.find(Button).first()
-    expect(button.dive().text()).toEqual('Yes, overwite')
+    expect(button.dive().text()).toEqual('Yes, overwrite')
     button.simulate('click')
     expect(mockUpdate).toHaveBeenCalled()
   })

--- a/__tests__/reducers/inputs.test.js
+++ b/__tests__/reducers/inputs.test.js
@@ -155,7 +155,7 @@ describe('literal reducer functions', () => {
     })
   })
 
-  it('CHANGE_SELECTIONS overwites items in  current state', () => {
+  it('CHANGE_SELECTIONS overwrites items in  current state', () => {
     const listSetSelections = setMySelections({ "resourceTemplate:Monograph:Instance": {
       'http://schema.org/name': { items: [{ id: 0, label: 'Run the tests', uri: 'http://schema.org/abc'}] }
     }}, {

--- a/jest-puppeteer.config.js
+++ b/jest-puppeteer.config.js
@@ -7,6 +7,7 @@ module.exports = {
   },
   server: {
     command: 'SPOOF_SINOPIA_SERVER=true npm run dev-start',
-    port: 8888
-  },
-};
+    port: 8888,
+    launchTimeout: 10000
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -4538,9 +4538,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "elasticsearch": {
-      "version": "15.4.1",
-      "resolved": "https://registry.npmjs.org/elasticsearch/-/elasticsearch-15.4.1.tgz",
-      "integrity": "sha512-IL46Sv9krCKtpvlI37/vQVQrWx6QeT1OJhfWW6L3fIXzR1Vv5utO+DHYz8AosUI6vlkxShoq+y6sUIBhTF1OIg==",
+      "version": "15.5.0",
+      "resolved": "https://registry.npmjs.org/elasticsearch/-/elasticsearch-15.5.0.tgz",
+      "integrity": "sha512-ZGKKaDkOFAap61ObBNkAxhYXCcAbRfkI4NVoSeLGnTD6/cItvY2j9LII/VV8/zclGe1x5m6DsVp47E4ze4aAeQ==",
       "requires": {
         "agentkeepalive": "^3.4.1",
         "chalk": "^1.0.0",
@@ -13010,9 +13010,9 @@
       "dev": true
     },
     "sinopia_server": {
-      "version": "3.0.0-beta3",
-      "resolved": "https://registry.npmjs.org/sinopia_server/-/sinopia_server-3.0.0-beta3.tgz",
-      "integrity": "sha512-ForYtyIhVdGHMwS/qhfKuCpf+YTcAWgb/boJ5p+hxGqEBTwDhzxWNb89X1FMbGJ9pVOSShvJGDIFZttWEUqRNw==",
+      "version": "3.0.0-beta4",
+      "resolved": "https://registry.npmjs.org/sinopia_server/-/sinopia_server-3.0.0-beta4.tgz",
+      "integrity": "sha512-vSygl81nOi+1SodwfFr9mvCS7o6SjCZ3K47mHKlkgwFc8Rt1l2ekBO7WVPwnYoCPiIY1Xu0GmfL4PI+jhS4hjg==",
       "requires": {
         "elasticsearch": "^15.3.1",
         "superagent": "^4.1.0"
@@ -13658,9 +13658,9 @@
           }
         },
         "mime": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.2.tgz",
-          "integrity": "sha512-zJBfZDkwRu+j3Pdd2aHsR5GfH2jIWhmL1ZzBoc+X+3JEti2hbArWcyJ+1laC1D2/U/W1a/+Cegj0/OnEU2ybjg=="
+          "version": "2.4.3",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.3.tgz",
+          "integrity": "sha512-QgrPRJfE+riq5TPZMcHZOtm8c6K/yYrMbKIoRfapfiGLxS8OTeIfRhUGW5LU7MlRa52KOAGCfUNruqLrIBvWZw=="
         },
         "ms": {
           "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "redux": "^4.0.1",
     "reselect": "^4.0.0",
     "shortid": "^2.2.14",
-    "sinopia_server": "^3.0.0-beta3",
+    "sinopia_server": "^3.0.0-beta4",
     "swagger-client": "^3.8.25",
     "x2js": "^3.2.6"
   },

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -6,7 +6,7 @@ const Footer = () => (
   <div id="footer" className="row">
     <div id="footer-image" className="col-xs-6 col-sm-1">
       <a className='footer-image' rel="license noopener noreferrer" href="http://creativecommons.org/publicdomain/zero/1.0/" target="_blank">
-        <img alt="CC0" src="http://i.creativecommons.org/p/zero/1.0/88x31.png" />
+        <img alt="CC0" src="https://licensebuttons.net/p/zero/1.0/88x31.png" />
       </a>
     </div>
     <div id="footer-text" className="col-xs-6 col-sm-10">

--- a/src/components/editor/ImportResourceTemplate.jsx
+++ b/src/components/editor/ImportResourceTemplate.jsx
@@ -1,6 +1,7 @@
 // Copyright 2018 Stanford University see Apache2.txt for license
 
-import React, {Component} from 'react'
+import SinopiaServer from 'sinopia_server'
+import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import Header from './Header'
 import ImportFileZone from './ImportFileZone'
@@ -8,10 +9,10 @@ import SinopiaResourceTemplates from './SinopiaResourceTemplates'
 import UpdateResourceModal from './UpdateResourceModal'
 import { loadState } from '../../localStorage'
 import Config from '../../../src/Config'
-const SinopiaServer = require('sinopia_server')
+
 const instance = new SinopiaServer.LDPApi()
 const curJwt = loadState('jwtAuth')
-const _ = require('lodash')
+
 instance.apiClient.basePath = Config.sinopiaServerBase
 if (curJwt !== undefined) {
   instance.apiClient.authentications['CognitoUser'].accessToken = curJwt.id_token
@@ -32,91 +33,92 @@ class ImportResourceTemplate extends Component {
   }
 
   componentDidMount() {
-    const incrementedKey = this.state.updateKey +1
-    this.setState({updateKey: incrementedKey})
+    const incrementedKey = this.state.updateKey + 1
+    this.setState({ updateKey: incrementedKey })
   }
 
   modalClose = () => {
     this.setState( { modalShow: false } )
   }
 
-  //resource templates are set via ImportFileZone and passed to ResourceTemplate via redirect to Editor
+  // Resource templates are set via ImportFileZone and passed to ResourceTemplate via redirect to Editor
   setResourceTemplates = (content, group) => {
     const profileCount = content.Profile.resourceTemplates.length
-    content.Profile.resourceTemplates.map(rt => {
-      this.fulfillCreateResourcePromise(this.createResourcePromise(rt, group, profileCount))
+    content.Profile.resourceTemplates.forEach(async rt => {
+      const response = await this.createResource(rt, group)
+      this.updateStateFromServerResponse(response, 'create', profileCount)
       const incrementedKey = this.state.updateKey + 1
-      this.setState({updateKey: incrementedKey})
+      this.setState({ updateKey: incrementedKey })
     })
   }
 
-  createResourcePromise = (content, group, profileCount) => new Promise(async (resolve) => {
-    resolve(
-      await instance.createResourceWithHttpInfo(group, content, { slug: content.id, contentType: 'application/json' }).catch((error) => {
-        this.updateStateForResourceError(error)
+  createResource = async (content, group) => {
+    try {
+      const response = await instance.createResourceWithHttpInfo(group, content, { slug: content.id, contentType: 'application/json' })
+      return response.response
+    } catch(error) {
+      this.setState({
+        createResourceError: [...this.state.createResourceError, error.response]
       })
-    )
-  }).then(response => {
-    if(this.state.createResourceError.length === profileCount) {
-      this.setState({modalShow: true})
-    }
-    return response
-  }).catch(() => {})
-
-  updateResourcePromise = (content, group) => new Promise(async (resolve) => {
-    resolve(
-      await instance.updateResourceWithHttpInfo(group, content.id, content, { contentType: 'application/json' }).catch((error) => {
-        this.setState({
-          updateResourceError: error
-        })
-      })
-    )
-  }).then(response => {
-
-    return response
-  }).catch(() => {})
-
-  fulfillCreateResourcePromise = async (promise) => {
-    await promise.then(result => {
-      const joinedMessages = this.state.message.slice(0)
-
-      if(result.response.statusText !== 'No Content') {
-        this.setState({tempState: `${result.response.statusText} ${result.response.headers.location}`})
-        joinedMessages.push(this.state.tempState)
-        this.setState({message: joinedMessages})
-      }
-
-    }).catch(() => {
-      if (this.state.createResourceError[0].statusText !== 'Conflict') {
-        const msg = 'The sinopia server is not accepting the request for this resource.'
-        this.state.updateResourceError ? this.setState({message: [`${msg}: ${this.state.updateResourceError}`]}) : this.setState({message: [msg]})
-      }
-    })
-  }
-
-  updateStateForResourceError = (error) => {
-    if(_.get(error, 'response.statusText') === 'Conflict') {
-      const response = error.response
-      const joinedConflicts = this.state.createResourceError.slice(0)
-      this.setState({tempConflictError: response})
-      joinedConflicts.push(this.state.tempConflictError)
-      this.setState({createResourceError: joinedConflicts})
+      return error.response
     }
   }
 
-  updateAllResources = (rts, group) => {
-    return Promise.all(rts.map(async rt =>
-      await this.fulfillCreateResourcePromise(this.updateResourcePromise(rt, group))
-    ))
+  updateResource = async (content, group) => {
+    try {
+      const response = await instance.updateResourceWithHttpInfo(group, content.id, content, { contentType: 'application/json' })
+      return response.response
+    } catch(error) {
+      this.setState({ updateResourceError: error })
+      return error.response
+    }
   }
 
-  handleUpdateResource = async (rts, group) => {
-    await this.updateAllResources(rts, group).then(() => {
-      const incrementedKey = this.state.updateKey + 1
-      this.setState({updateKey: incrementedKey})
-      this.modalClose()
-      window.location.reload()
+  updateStateFromServerResponse = (response, operation, profileCount) => {
+    // HTTP status 409 == Conflict
+    if (operation == 'update' && response.status !== 409) {
+      const msg = 'The sinopia server is not accepting the request for this resource.'
+      this.state.updateResourceError ?
+        this.setState({ message: [`${msg}: ${this.state.updateResourceError}`] }) :
+        this.setState({ message: [msg] })
+    }
+
+    // HTTP status 409 == Conflict
+    if (response.status === 409 && this.state.createResourceError.length >= profileCount) {
+      this.setState({ modalShow: true })
+    }
+
+    const location = response.headers.location || ''
+    const newMessage = `${this.humanReadableStatus(response.status)} ${location}`
+    this.setState({
+      message: [...this.state.message, newMessage]
     })
+  }
+
+  humanReadableStatus = status => {
+    switch(status) {
+      case 201:
+        return 'Created'
+      case 204:
+        return 'Updated'
+      case 401:
+        return 'You are not authorized to do this. Try logging in again!'
+      case 409:
+        return 'Attempting to update'
+      default:
+        return `Unexpected response (${status})!`
+    }
+  }
+
+  handleUpdateResource = (rts, group) => {
+    rts.forEach(async rt => {
+      const response = await this.updateResource(rt, group)
+      this.updateStateFromServerResponse(response, 'update')
+    })
+    const incrementedKey = this.state.updateKey + 1
+    this.setState({ updateKey: incrementedKey })
+    this.modalClose()
+    window.location.reload()
   }
 
   render() {
@@ -144,4 +146,4 @@ ImportResourceTemplate.propTypes = {
   triggerHandleOffsetMenu: PropTypes.func
 }
 
-export default (ImportResourceTemplate)
+export default ImportResourceTemplate

--- a/src/components/editor/SinopiaResourceTemplates.jsx
+++ b/src/components/editor/SinopiaResourceTemplates.jsx
@@ -1,13 +1,13 @@
 // Copyright 2019 Stanford University see Apache2.txt for license
 
+import SinopiaServer from 'sinopia_server'
 import React, {Component} from 'react'
 import PropTypes from 'prop-types'
 import { Link } from 'react-router-dom'
-import {BootstrapTable, TableHeaderColumn} from 'react-bootstrap-table'
+import { BootstrapTable, TableHeaderColumn } from 'react-bootstrap-table'
 import Config from '../../../src/Config'
 import { getGroups, listResourcesInGroupContainer, getResourceTemplate } from '../../sinopiaServer'
-const _ = require('lodash')
-const SinopiaServer = require('sinopia_server')
+
 const instance = new SinopiaServer.LDPApi()
 instance.apiClient.basePath = Config.sinopiaServerBase
 
@@ -15,71 +15,68 @@ class SinopiaResourceTemplates extends Component {
   constructor(props) {
     super(props)
     this.state = {
-      message: '',
-      groupData: [],
-      templatesForGroup: [],
-      contains: []
+      errors: [],
+      resourceTemplates: [],
     }
   }
 
   async componentDidUpdate(prevProps) {
-    if (this.props.updateKey > prevProps.updateKey) {
-      const groupPromise = getGroups().then(data => {
-        return data
-      }).catch(() => {})
+    if (this.props.updateKey <= prevProps.updateKey) {
+      return
+    }
 
-      await this.fulfillGroupPromise(groupPromise).then(async () => {
-        this.state.groupData.map(group => {
-          const groupName = this.resourceToName(group)
-          listResourcesInGroupContainer(groupName).then((data) => {
-            this.fulfillGroupData(data)
-          }).catch(() => {})
-        })
+    await this.fetchResourceTemplatesFromGroups()
+  }
+
+  fetchResourceTemplatesFromGroups = async () => {
+    try {
+      const getGroupsResponse = await getGroups()
+      const contains = [].concat(getGroupsResponse.response.body.contains).filter(Boolean)
+      contains.forEach(async group => {
+        const groupName = this.resourceToName(group)
+        const listResourcesInGroupResponse = await listResourcesInGroupContainer(groupName)
+        // Short-circuit listing resources in a group if it contains nothing
+        if (listResourcesInGroupResponse.response.body.contains)
+          this.setStateFromServerResponse(groupName, listResourcesInGroupResponse.response.body.contains)
       })
+    } catch(error) {
+      const errors = [...this.state.errors, error]
+      this.setState({ errors: errors })
     }
   }
 
-  fulfillGroupPromise = (promise) => {
-    promise.then(data => {
-      const contains = [].concat(data.response.body.contains)
-      this.setState({groupData: contains})
-    }).catch((error) => {
-      this.setState({message: error})
+  setStateFromServerResponse = (groupName, groupContains) => {
+    // Array-ify the value of `groupContains` as it can be either a string or an array
+    const templateIds = [].concat(groupContains)
+
+    templateIds.forEach(async templateId => {
+      const templateName = this.resourceToName(templateId)
+      const templateResponse = await getResourceTemplate(templateName, groupName)
+      const resourceTemplateBody = templateResponse.response.body
+
+      const retrievedTemplateObject = {
+        key: resourceTemplateBody.id,
+        name: resourceTemplateBody.resourceLabel,
+        uri: templateId,
+        id: resourceTemplateBody.id,
+        group: groupName
+      }
+
+      const templates = [...this.state.resourceTemplates]
+      console.dir(templates)
+      // Check if newly retrieved template is already stored in component state. If not, add it.
+      if (!templates.some(template => template.key === retrievedTemplateObject.key))
+        templates.push(retrievedTemplateObject)
+      console.dir(retrievedTemplateObject)
+      this.setState({
+        resourceTemplates: templates
+      })
     })
-    return promise
   }
 
-  fulfillGroupData = (data) => {
-    const groupName = this.resourceToName(data.response.body['@id'])
-
-    if (data.response.body.contains !== undefined) {
-      const contains = [].concat(data.response.body.contains)
-
-      contains.map(c => {
-        const name = this.resourceToName(c)
-
-        this.groupDataPromise(groupName, name).then((data) => {
-          const rt = data.response.body
-          this.setState({tempState: {key: rt.id, name: rt.resourceLabel, uri: c, id: rt.id, group: groupName}})
-          const joined = this.state.templatesForGroup.slice(0)
-          if (!_.find(joined, ['key', this.state.tempState.key])) {
-            joined.push(this.state.tempState)
-          }
-          this.setState({templatesForGroup: joined})
-        }).catch(() => {})
-      })
-    }
-
-  }
-
-  groupDataPromise = (groupName, name) => new Promise(async (resolve) => {
-    // await resolve(instance.getResourceWithHttpInfo(groupName, name, { acceptEncoding: 'application/json' }))
-    await resolve(getResourceTemplate(name, groupName))
-  })
-
-  resourceToName = (resource) => {
+  resourceToName = resource => {
     const idx = resource.lastIndexOf('/')
-    return resource.substring(idx+1)
+    return resource.substring(idx + 1)
   }
 
   linkFormatter = (cell, row) => {
@@ -88,12 +85,12 @@ class SinopiaResourceTemplates extends Component {
     )
   }
 
-  render(){
-    if (this.state.message) {
+  render() {
+    if (this.state.errors.length > 0) {
       return (
         <div className="alert alert-warning alert-dismissible">
           <button className="close" data-dismiss="alert" aria-label="close">&times;</button>
-          No connection to the Sinopia Server is available, or there are no resources for any group
+          No connection to the Sinopia Server is available, or there are no resources for any group.
         </div>
       )
     }
@@ -103,7 +100,7 @@ class SinopiaResourceTemplates extends Component {
       { this.props.message.join(', ') }
     </div>;
 
-    if(this.props.message.length === 0) {
+    if (this.props.message.length === 0) {
       createResourceMessage = <span />
     }
 
@@ -118,7 +115,7 @@ class SinopiaResourceTemplates extends Component {
       <div>
         { createResourceMessage }
         <h4>Available Resource Templates in Sinopia</h4>
-        <BootstrapTable keyField='key' data={ this.state.templatesForGroup } >
+        <BootstrapTable keyField='key' data={ this.state.resourceTemplates } >
           <TableHeaderColumn thStyle={ thNameClass } tdStyle={ tdNameClass } dataFormat={ this.linkFormatter } dataField='name' dataSort={true} >Template name</TableHeaderColumn>
           <TableHeaderColumn thStyle={ thIDClass } tdStyle={ tdIDClass } dataField='id' dataSort={true} >ID</TableHeaderColumn>
           <TableHeaderColumn thStyle={ thGroupClass } tdStyle={ tdGroupClass } dataField='group' dataSort={true} >Group</TableHeaderColumn>

--- a/src/components/editor/SinopiaResourceTemplates.jsx
+++ b/src/components/editor/SinopiaResourceTemplates.jsx
@@ -63,11 +63,11 @@ class SinopiaResourceTemplates extends Component {
       }
 
       const templates = [...this.state.resourceTemplates]
-      console.dir(templates)
+
       // Check if newly retrieved template is already stored in component state. If not, add it.
       if (!templates.some(template => template.key === retrievedTemplateObject.key))
         templates.push(retrievedTemplateObject)
-      console.dir(retrievedTemplateObject)
+
       this.setState({
         resourceTemplates: templates
       })

--- a/src/components/editor/UpdateResourceModal.jsx
+++ b/src/components/editor/UpdateResourceModal.jsx
@@ -32,7 +32,7 @@ class UpdateResourceModal extends Component {
         group = this.resourceToName(req.url)
         const rt = req._data
         rts.push(rt)
-        titleMessages.push(`${rt.id} already exisits`)
+        titleMessages.push(`${rt.id} already exists`)
       }
     })
 
@@ -54,7 +54,7 @@ class UpdateResourceModal extends Component {
             Do you want to overwrite these resource templates?
           </Modal.Body>
           <Modal.Footer>
-            <Button onClick={() => {this.props.update(this.state.rts, this.state.group)}}>Yes, overwite</Button>
+            <Button onClick={() => {this.props.update(this.state.rts, this.state.group)}}>Yes, overwrite</Button>
             <Button onClick={this.props.close}>No, get me out of here!</Button>
           </Modal.Footer>
         </Modal>
@@ -70,4 +70,4 @@ UpdateResourceModal.propTypes = {
   update: PropTypes.func,
 }
 
-export default (UpdateResourceModal)
+export default UpdateResourceModal

--- a/src/sinopiaServer.js
+++ b/src/sinopiaServer.js
@@ -1,10 +1,10 @@
 import SinopiaServer from 'sinopia_server'
-
 import { loadState } from './localStorage'
 import Config from './Config'
 
 const instance = new SinopiaServer.LDPApi()
 const curJwt = loadState('jwtAuth')
+
 instance.apiClient.basePath = Config.sinopiaServerBase
 if (curJwt !== undefined) {
   instance.apiClient.authentications['CognitoUser'].accessToken = curJwt.id_token
@@ -65,10 +65,14 @@ const getSpoofedResourceTemplate = (templateId) => {
     emptyTemplate['error'] = `ERROR: un-spoofed resourceTemplate: ${templateId}`
     return emptyTemplate
   }
+
   const spoofedResponse = { response: {} }
+
   spoofedResponse['response']['body'] = resourceTemplateId2Json.find((template) => {
-    if(template.id == templateId) return template
+    if(template.id == templateId)
+      return template
   }).json
+
   return new Promise(resolve => {
     resolve(spoofedResponse)
   })
@@ -100,9 +104,7 @@ const getResourceTemplateFromServer = (templateId, group) => {
     return emptyTemplate
   }
 
-  return new Promise(resolve => {
-    resolve(instance.getResourceWithHttpInfo(group, templateId, { acceptEncoding: 'application/json' }))
-  })
+  return instance.getResourceWithHttpInfo(group, templateId, { acceptEncoding: 'application/json' })
 }
 
 export const getResourceTemplate = (templateId, group) => {
@@ -124,9 +126,7 @@ export const getGroups = () => {
       })
     })
 
-  return new Promise(resolve => {
-    resolve(instance.getBaseWithHttpInfo())
-  })
+  return instance.getBaseWithHttpInfo()
 }
 
 export const listResourcesInGroupContainer = (group) => {
@@ -135,7 +135,5 @@ export const listResourcesInGroupContainer = (group) => {
       resolve(spoofedResourcesInGroupContainer(group))
     })
 
-  return new Promise(resolve => {
-    resolve(instance.getGroupWithHttpInfo(group))
-  })
+  return instance.getGroupWithHttpInfo(group)
 }


### PR DESCRIPTION
Fixes #506 
Fixes #507 

Includes:
* Bump sinopia_server to 3.0.0-beta4
  * Using the newer version of the sinopia client allows the editor to invoke the updateResource API with a custom content type (application/json). Prior to this change, updates worked (apparently) but what was happening was the editor was issuing PUT requests and getting 204s... but not modifying the NonRDFSource. Instead the RDFSource that Trellis auto-attaches to every NonRDFSource was being modified.
* Use new SSL-based location of the CreativeCommons image
  * This gets rid of the constant mixed content errors in the console.
* Correct two typos that are surfaced in the user-facing UI
* Avoid wrapping promises in other promises (coming from the sinopia client)
* Refactor resource template components
* Add test coverage for refactoring of SinopiaResourceTemplates component
* Add test coverage for refactoring of ImportResourceTemplate component
* Include some fixes to Import component and some fakes to make it easier to test the sinopia client implementation