### PR TITLE
Fix resource template table updates

### DIFF
--- a/__tests__/components/editor/ImportResourceTemplate.test.js
+++ b/__tests__/components/editor/ImportResourceTemplate.test.js
@@ -47,16 +47,14 @@ describe('<ImportResourceTemplate />', () => {
       }
     }
 
-    it('invokes createResource(), updateStateFromServerResponse(), and setState() once per template', async () => {
+    it('invokes createResource() and updateStateFromServerResponse() once per template', async () => {
       const createResourceSpy = jest.spyOn(wrapper.instance(), 'createResource').mockImplementation(async () => {})
       const updateStateSpy = jest.spyOn(wrapper.instance(), 'updateStateFromServerResponse').mockReturnValue(null)
-      const setStateSpy = jest.spyOn(wrapper.instance(), 'setState').mockReturnValue(null)
 
       await wrapper.instance().setResourceTemplates(content, 'ld4p')
 
       expect(createResourceSpy).toHaveBeenCalledTimes(2)
       expect(updateStateSpy).toHaveBeenCalledTimes(2)
-      expect(setStateSpy).toHaveBeenCalledTimes(1)
     })
   })
 

--- a/src/components/editor/ImportFileZone.jsx
+++ b/src/components/editor/ImportFileZone.jsx
@@ -283,7 +283,6 @@ DropZone.propTypes = {
 }
 ImportFileZone.propTypes = {
   setResourceTemplateCallback: PropTypes.func,
-  resourceTemplateId: PropTypes.string,
-  defaultRtId: PropTypes.string
+  resourceTemplateId: PropTypes.string
 }
 export default ImportFileZone

--- a/src/components/editor/ImportFileZone.jsx
+++ b/src/components/editor/ImportFileZone.jsx
@@ -261,6 +261,7 @@ class DropZone extends Component {
           <Dropzone
             onFileDialogCancel={() => this.props.showDropZoneCallback(false)}
             onDrop={this.handleOnDrop.bind(this)}
+            multiple={false}
           />
           <aside>
             <h5>Loaded resource template file:</h5>
@@ -281,7 +282,6 @@ DropZone.propTypes = {
   setGroupCallback: PropTypes.func
 }
 ImportFileZone.propTypes = {
-  tempStateCallback: PropTypes.func,
   setResourceTemplateCallback: PropTypes.func,
   resourceTemplateId: PropTypes.string,
   defaultRtId: PropTypes.string

--- a/src/components/editor/SinopiaResourceTemplates.jsx
+++ b/src/components/editor/SinopiaResourceTemplates.jsx
@@ -22,9 +22,8 @@ class SinopiaResourceTemplates extends Component {
   }
 
   async componentDidUpdate(prevProps) {
-    if (this.props.updateKey <= prevProps.updateKey) {
+    if (this.props.updateKey <= prevProps.updateKey)
       return
-    }
 
     await this.fetchResourceTemplatesFromGroups()
   }


### PR DESCRIPTION
Fixes #507 
Fixes #531

Includes:
* Update component state less often: batch up `setState` calls to avoid timing-related failures such as seen in #507 
* Disallow multi-file uploads when importing resource templates (#531)
* Remove unused property type declaration while troubleshooting
* Remove unnecessary braces around single-line `if` action
