### PR TITLE
Prevent upload modal & flash message from showing stale messages

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,6 +5,7 @@
   ],
   "plugins": [
     "@babel/plugin-proposal-class-properties",
-    "@babel/plugin-transform-runtime"
+    "@babel/plugin-transform-runtime",
+    "@babel/plugin-proposal-optional-chaining"
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -818,6 +818,16 @@
         "@babel/plugin-syntax-optional-catch-binding": "^7.2.0"
       }
     },
+    "@babel/plugin-proposal-optional-chaining": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.2.0.tgz",
+      "integrity": "sha512-ea3Q6edZC/55wEBVZAEz42v528VulyO0eir+7uky/sT4XRcdkWJcFi1aPtitTlwUzGnECWJNExWww1SStt+yWw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-optional-chaining": "^7.2.0"
+      }
+    },
     "@babel/plugin-proposal-unicode-property-regex": {
       "version": "7.4.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.4.4.tgz",
@@ -869,6 +879,15 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.2.0.tgz",
       "integrity": "sha512-bDe4xKNhb0LI7IvZHiA13kff0KEfaGX/Hv4lMA9+7TEc63hMNvfKo6ZFpXhKuEp+II/q35Gc4NoMeDZyaUbj9w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-syntax-optional-chaining": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.2.0.tgz",
+      "integrity": "sha512-HtGCtvp5Uq/jH/WNUPkK6b7rufnCPLLlDAFN7cmACoIjaOOiXxUt3SswU5loHqrhtqTsa/WoLQ1OQ1AGuZqaWA==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@babel/core": "^7.4.3",
     "@babel/node": "^7.4.5",
     "@babel/plugin-proposal-class-properties": "^7.4.0",
+    "@babel/plugin-proposal-optional-chaining": "^7.2.0",
     "@babel/plugin-transform-runtime": "^7.4.3",
     "@babel/preset-env": "^7.4.3",
     "@babel/preset-react": "^7.0.0",

--- a/src/components/editor/SinopiaResourceTemplates.jsx
+++ b/src/components/editor/SinopiaResourceTemplates.jsx
@@ -118,8 +118,7 @@ class SinopiaResourceTemplates extends Component {
       )
     }
 
-    let createResourceMessage = <div className="alert alert-info alert-dismissible">
-      <button className="close" data-dismiss="alert" aria-label="close">&times;</button>
+    let createResourceMessage = <div className="alert alert-info">
       { this.props.message.join(', ') }
     </div>;
 


### PR DESCRIPTION
Fixes #534

This branch includes the following changes:
* Reset messages and errors in `ImportResourceTemplate` component when HTTP response is successful
* Reset messages when update handler is finished
* Prevent users from dismissing flash message box, else it never comes back
* Extract code to parse a response object into a human-friendly location into a new function in `ImportResourceTemplate` component
* Add Babel plugin for optional chaining (as dev dependency) via the safe navigation (or "Elvis") operator
  * This lets us safely reach into objects such as HTTP responses without having to check at every level for `null` or `undefined`