### PR TITLE
Display messages for all resource templates in a profile

### DIFF
--- a/__tests__/components/editor/ImportResourceTemplate.test.js
+++ b/__tests__/components/editor/ImportResourceTemplate.test.js
@@ -51,7 +51,7 @@ describe('<ImportResourceTemplate />', () => {
       }
     }
 
-    it('invokes resets messages, creates one resource per template, and then updates state', async () => {
+    it('resets messages, creates one resource per template, and then updates state', async () => {
       const createResourceSpy = jest.spyOn(wrapper.instance(), 'createResource').mockImplementation(async () => {})
       const updateStateSpy = jest.spyOn(wrapper.instance(), 'updateStateFromServerResponses').mockReturnValue(null)
       const resetMessagesSpy = jest.spyOn(wrapper.instance(), 'resetMessages').mockReturnValue(null)

--- a/__tests__/components/editor/SinopiaResourceTemplates.test.js
+++ b/__tests__/components/editor/SinopiaResourceTemplates.test.js
@@ -9,11 +9,12 @@ import { getEntityTagFromGroupContainer, listResourcesInGroupContainer, getResou
 jest.mock('../../../src/sinopiaServer')
 
 describe('<SinopiaResourceTemplates />', () => {
-  const message = [
+  const messages = [
     'Created http://localhost:8080/repository/ld4p/Note/sinopia:resourceTemplate:bf2:Note1',
     'Created http://localhost:8080/repository/ld4p/Note/sinopia:resourceTemplate:bf2:Note2'
   ]
-  const wrapper = mount(<SinopiaResourceTemplates message={message}/>)
+
+  const wrapper = mount(<SinopiaResourceTemplates messages={messages}/>)
 
   it('has a header for the area where the table of resource templates for the groups are displayed', () => {
     expect(wrapper.find('div > h4').last().text()).toEqual('Available Resource Templates in Sinopia')
@@ -41,7 +42,7 @@ describe('<SinopiaResourceTemplates />', () => {
     const initialUpdateKey = 1
 
     it('calls fetchResourceTemplatesFromGroups() and resets errors if updateKey has been incremented', async () => {
-      const wrapper2 = shallow(<SinopiaResourceTemplates message={message} updateKey={initialUpdateKey} />)
+      const wrapper2 = shallow(<SinopiaResourceTemplates messages={messages} updateKey={initialUpdateKey} />)
       const fetchSpy = jest.spyOn(wrapper2.instance(), 'fetchResourceTemplatesFromGroups').mockReturnValue(null)
       const setStateSpy = jest.spyOn(wrapper2.instance(), 'setState').mockReturnValue(null)
 
@@ -52,7 +53,7 @@ describe('<SinopiaResourceTemplates />', () => {
     })
 
     it('calls fetchResourceTemplatesFromGroups() and resets errors if server has new templates', async () => {
-      const wrapper2 = shallow(<SinopiaResourceTemplates message={message} updateKey={initialUpdateKey} />)
+      const wrapper2 = shallow(<SinopiaResourceTemplates messages={messages} updateKey={initialUpdateKey} />)
       const fetchSpy = jest.spyOn(wrapper2.instance(), 'fetchResourceTemplatesFromGroups').mockReturnValue(null)
       const serverCheckSpy = jest.spyOn(wrapper2.instance(), 'serverHasNewTemplates').mockReturnValue(true)
       const setStateSpy = jest.spyOn(wrapper2.instance(), 'setState').mockReturnValue(null)
@@ -65,7 +66,7 @@ describe('<SinopiaResourceTemplates />', () => {
     })
 
     it('returns early if updateKey has not changed and no new templates on server', async () => {
-      const wrapper2 = shallow(<SinopiaResourceTemplates message={message} updateKey={initialUpdateKey} />)
+      const wrapper2 = shallow(<SinopiaResourceTemplates messages={messages} updateKey={initialUpdateKey} />)
       const fetchSpy = jest.spyOn(wrapper2.instance(), 'fetchResourceTemplatesFromGroups').mockReturnValue(null)
       const serverCheckSpy = jest.spyOn(wrapper2.instance(), 'serverHasNewTemplates').mockReturnValue(false)
       const setStateSpy = jest.spyOn(wrapper2.instance(), 'setState').mockReturnValue(null)
@@ -83,7 +84,7 @@ describe('<SinopiaResourceTemplates />', () => {
       getEntityTagFromGroupContainer.mockImplementation(async () => {
         return 'foobar'
       })
-      const wrapper2 = shallow(<SinopiaResourceTemplates message={message} updateKey={1} />)
+      const wrapper2 = shallow(<SinopiaResourceTemplates messages={messages} updateKey={1} />)
       wrapper2.setState({ resourceTemplatesEtag: 'foobar' })
 
       expect(await wrapper2.instance().serverHasNewTemplates()).toEqual(false)
@@ -93,17 +94,17 @@ describe('<SinopiaResourceTemplates />', () => {
       getEntityTagFromGroupContainer.mockImplementation(async () => {
         return 'bazquux'
       })
-      const wrapper2 = shallow(<SinopiaResourceTemplates message={message} updateKey={1} />)
+      const wrapper2 = shallow(<SinopiaResourceTemplates messages={messages} updateKey={1} />)
 
       expect(await wrapper2.instance().serverHasNewTemplates()).toEqual(true)
       expect(wrapper2.state().resourceTemplatesEtag).toEqual('bazquux')
     })
 
-    it('returns false and logs a message when there are errors', async () => {
+    it('returns false and logs a messages when there are errors', async () => {
       getEntityTagFromGroupContainer.mockImplementation(async () => {
         throw 'ack!'
       })
-      const wrapper2 = shallow(<SinopiaResourceTemplates message={message} updateKey={1} />)
+      const wrapper2 = shallow(<SinopiaResourceTemplates messages={messages} updateKey={1} />)
       const consoleSpy = jest.spyOn(console, 'error')
 
       expect(await wrapper2.instance().serverHasNewTemplates()).toEqual(false)
@@ -131,7 +132,7 @@ describe('<SinopiaResourceTemplates />', () => {
         resolve(containsNothing)
       }))
 
-      const wrapper2 = shallow(<SinopiaResourceTemplates message={message} />)
+      const wrapper2 = shallow(<SinopiaResourceTemplates messages={messages} />)
       const setStateFromServerResponseSpy = jest.spyOn(wrapper2.instance(), 'setStateFromServerResponse').mockReturnValue(null)
 
       await wrapper2.instance().fetchResourceTemplatesFromGroups()
@@ -144,7 +145,7 @@ describe('<SinopiaResourceTemplates />', () => {
         resolve(containsTemplate)
       }))
 
-      const wrapper2 = shallow(<SinopiaResourceTemplates message={message} />)
+      const wrapper2 = shallow(<SinopiaResourceTemplates messages={messages} />)
       const setStateFromServerResponseSpy = jest.spyOn(wrapper2.instance(), 'setStateFromServerResponse').mockReturnValue(null)
 
       await wrapper2.instance().fetchResourceTemplatesFromGroups()
@@ -157,7 +158,7 @@ describe('<SinopiaResourceTemplates />', () => {
         throw 'uh oh!'
       })
 
-      const wrapper2 = shallow(<SinopiaResourceTemplates message={message} />)
+      const wrapper2 = shallow(<SinopiaResourceTemplates messages={messages} />)
       const setStateFromServerResponseSpy = jest.spyOn(wrapper2.instance(), 'setStateFromServerResponse').mockReturnValue(null)
       // We are spying on and stubbing setState() instead of testing what winds
       // up in this.state.errors because if we don't stub setState(), it will
@@ -190,7 +191,7 @@ describe('<SinopiaResourceTemplates />', () => {
         return getResourceTemplateSpy()
       })
 
-      const wrapper2 = shallow(<SinopiaResourceTemplates message={message} />)
+      const wrapper2 = shallow(<SinopiaResourceTemplates messages={messages} />)
       const setStateSpy = jest.spyOn(wrapper2.instance(), 'setState').mockReturnValue(null)
 
       await wrapper2.instance().setStateFromServerResponse('ld4p', 'template1')
@@ -213,7 +214,7 @@ describe('<SinopiaResourceTemplates />', () => {
         return getResourceTemplateSpy()
       })
 
-      const wrapper2 = shallow(<SinopiaResourceTemplates message={message} />)
+      const wrapper2 = shallow(<SinopiaResourceTemplates messages={messages} />)
       const setStateSpy = jest.spyOn(wrapper2.instance(), 'setState').mockReturnValue(null)
 
       await wrapper2.instance().setStateFromServerResponse('ld4p', ['template1', 'template2', 'template3'])
@@ -236,7 +237,7 @@ describe('<SinopiaResourceTemplates />', () => {
         return getResourceTemplateSpy()
       })
 
-      const wrapper2 = shallow(<SinopiaResourceTemplates message={message} />)
+      const wrapper2 = shallow(<SinopiaResourceTemplates messages={messages} />)
       const existingTemplates = [
         {
           key: 'foo',
@@ -269,7 +270,7 @@ describe('<SinopiaResourceTemplates />', () => {
       group: "ld4p"
     }
 
-    const wrapper4 = shallow(<SinopiaResourceTemplates message={message}/>)
+    const wrapper4 = shallow(<SinopiaResourceTemplates messages={messages}/>)
 
     it('renders a link to the Editor with the id of the resource template to fetch', async () => {
       const link = await wrapper4.instance().linkFormatter(cell, row)

--- a/__tests__/components/editor/UpdateResourceModal.test.js
+++ b/__tests__/components/editor/UpdateResourceModal.test.js
@@ -8,7 +8,6 @@ import Button from 'react-bootstrap/lib/Button'
 import UpdateResourceModal from '../../../src/components/editor/UpdateResourceModal'
 
 describe('<UpdateResourceModal> with conflict message', () => {
-
   const messages = [{
     "req": {
       "method":"POST",
@@ -37,7 +36,7 @@ describe('<UpdateResourceModal> with conflict message', () => {
 
   const mockUpdate = jest.fn()
   const mockClose = jest.fn()
-  const wrapper = shallow(<UpdateResourceModal show={true} close={mockClose} message={messages} update={mockUpdate} />)
+  const wrapper = shallow(<UpdateResourceModal show={true} close={mockClose} messages={messages} update={mockUpdate} />)
   wrapper.update()
 
   it('renders the component as a Modal', () => {
@@ -82,7 +81,7 @@ describe('message with no data (or id)', () => {
 
   const mockUpdate = jest.fn()
   const mockClose = jest.fn()
-  const wrapper = shallow(<UpdateResourceModal show={true} close={mockClose} message={messages} update={mockUpdate} />)
+  const wrapper = shallow(<UpdateResourceModal show={true} close={mockClose} messages={messages} update={mockUpdate} />)
   wrapper.update()
 
   expect(wrapper.state().titleMessage).toEqual("")

--- a/src/components/editor/ImportFileZone.jsx
+++ b/src/components/editor/ImportFileZone.jsx
@@ -56,8 +56,8 @@ class ImportFileZone extends Component {
       template = JSON.parse(fileReader.result)
 
       this.promiseTemplateValidated(template, this.schemaUrl(template))
-        .then(() => {
-          this.props.setResourceTemplateCallback(template, this.state.group)
+        .then(async () => {
+          await this.props.setResourceTemplateCallback(template, this.state.group)
         })
         .catch(err => {
           this.setState({message: `ERROR - CANNOT USE PROFILE/RESOURCE TEMPLATE: problem validating template: ${err}`})

--- a/src/components/editor/SinopiaResourceTemplates.jsx
+++ b/src/components/editor/SinopiaResourceTemplates.jsx
@@ -120,11 +120,11 @@ class SinopiaResourceTemplates extends Component {
     }
 
     const createResourceMessage =
-          this.props.message.length === 0 ?
+          this.props.messages.length === 0 ?
           ( <span /> ) :
           (
             <div className="alert alert-info">
-              { this.props.message.join(', ') }
+              { this.props.messages.join(', ') }
             </div>
           )
 
@@ -159,7 +159,7 @@ class SinopiaResourceTemplates extends Component {
 }
 
 SinopiaResourceTemplates.propTypes = {
-  message: PropTypes.array,
+  messages: PropTypes.array,
   updateKey: PropTypes.number
 }
 

--- a/src/components/editor/UpdateResourceModal.jsx
+++ b/src/components/editor/UpdateResourceModal.jsx
@@ -20,7 +20,7 @@ class UpdateResourceModal extends Component {
     let group = ''
     let rts = []
     let titleMessages = []
-    const messages = this.props.message
+    const messages = this.props.messages
 
     messages.map(message => {
       if(_.get(message, 'req._data.id')) {
@@ -50,7 +50,7 @@ class UpdateResourceModal extends Component {
             Do you want to overwrite these resource templates?
           </Modal.Body>
           <Modal.Footer>
-            <Button onClick={() => {this.props.update(this.state.rts, this.state.group)}}>Yes, overwrite</Button>
+            <Button onClick={async () => {await this.props.update(this.state.rts, this.state.group)}}>Yes, overwrite</Button>
             <Button onClick={this.props.close}>No, get me out of here!</Button>
           </Modal.Footer>
         </Modal>
@@ -61,8 +61,8 @@ class UpdateResourceModal extends Component {
 
 UpdateResourceModal.propTypes = {
   close: PropTypes.func,
-  show: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
-  message: PropTypes.array,
+  show: PropTypes.bool,
+  messages: PropTypes.array,
   update: PropTypes.func,
 }
 


### PR DESCRIPTION
Fixes #554

Includes:
* Reset `ImportResourceTemplate` messages when initiating a new upload, not when wrapping one up for simplicity (before we get stuck in a maze of callbacks)
* Rework `updateStateFromServerResponse` as `updateStateFromServerResponses` so we can report on multiple requests at one time, collecting all the messages at once
* Change 409 Conflict message to be clearer (we're not *attempting* to update; we are waiting on a user prompt)
* Rename `ImportResourceTemplate.state.message` to `flashMessages` to make intent clearer
* Rename `ImportResourceTemplate.state.createResourceError` to `modalMessages` to make intent clearer
* Move resetting of `updateKey` into `updateStateFromServerResponses` so it's centrally located