### PR TITLE
Redux state changes to support RDF generation

### DIFF
--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -76,7 +76,7 @@ export const refreshResourceTemplate = (state, action) => {
 export const setResourceTemplate = (state, action) => {
   const rtKey = action.payload.id
   let output = Object.create(state)
-  action.payload.propertyTemplates.forEach((property) => {
+  action.payload.propertyTemplates.map((property) => {
     let propertyAction = {
       payload: {
         reduxPath: [rtKey, property.propertyURI],

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -38,7 +38,8 @@ export const populatePropertyDefaults = (propertyTemplate) => {
   if (propertyTemplate === undefined || propertyTemplate === null || Object.keys(propertyTemplate).length < 1) {
     return defaults
   }
-  if (propertyTemplate.valueConstraint.defaults && propertyTemplate.valueConstraint.defaults.length > 0) {
+
+  if (propertyTemplate?.valueConstraint?.defaults && propertyTemplate.valueConstraint.defaults.length > 0) {
     propertyTemplate.valueConstraint.defaults.map((row) => {
       defaults.push({
         id: makeShortID(),
@@ -59,8 +60,7 @@ export const refreshResourceTemplate = (state, action) => {
   }
   const defaults = populatePropertyDefaults(propertyTemplate)
 
-  const items =  defaults.length > 0 ? { items: defaults } : {}
-
+  const items =  defaults.length > 0 ? { items: defaults, rdfPredicate: propertyTemplate.propertyURI } : {}
   const lastKey = reduxPath.pop()
   const lastObject = reduxPath.reduce((newState, key) =>
       newState[key] = newState[key] || {},
@@ -68,7 +68,7 @@ export const refreshResourceTemplate = (state, action) => {
   if (Object.keys(items).includes('items')) {
     lastObject[lastKey] = items
   } else {
-    lastObject[lastKey] = {}
+    lastObject[lastKey] = { rdfPredicate: propertyTemplate.propertyURI }
   }
   return newState
 }

--- a/src/reducers/inputs.js
+++ b/src/reducers/inputs.js
@@ -21,8 +21,11 @@ export const setMyItems = (state, action) => {
   reduxPath.reduce((obj, key) => {
     level++
     if (level === reduxPath.length) {
-      if ((key in obj) != true || !Object.keys(obj[key]).includes('items')) {
-        obj[key] = { items: [] }
+      if (!(key in obj)) {
+        obj[key] = {}
+      }
+      if (!Object.keys(obj[key]).includes('items')) {
+        obj[key]["items"] = []
       }
       action.payload.items.map((row) => {
         obj[key].items.push(row)

--- a/src/reducers/inputs.js
+++ b/src/reducers/inputs.js
@@ -31,9 +31,9 @@ export const setMyItems = (state, action) => {
         obj[key].items.push(row)
       })
     }
-    if (!Object.keys(obj).includes(key)) {
-      obj[key] = {}
-    }
+    // if (!Object.keys(obj).includes(key)) {
+    //   obj[key] = {}
+    // }
     return obj[key]
   }, newState)
   return newState

--- a/src/sinopiaServerSpoof.js
+++ b/src/sinopiaServerSpoof.js
@@ -19,6 +19,8 @@ const retentionRt = require('../static/spoofedFilesFromServer/fromSinopiaServer/
 const itemAcqSourceRt = require('../static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/ItemAcqSource.json')
 const enumerationRt = require('../static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/ItemEnumeration.json')
 const chronologyRt = require('../static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/ItemChronology.json')
+const sampleResource = require('../static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/SampleResource.json')
+const supplementaryContent = require('../static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/SupplementaryContent.json')
 
 export const resourceTemplateId2Json = [
   {id: 'resourceTemplate:bf2:Monograph:Instance', json: monographInstanceRt},
@@ -39,7 +41,9 @@ export const resourceTemplateId2Json = [
   {id: 'resourceTemplate:bf2:Item:Retention', json: retentionRt},
   {id: 'resourceTemplate:bf2:Item:ItemAcqSource', json: itemAcqSourceRt},
   {id: 'resourceTemplate:bf2:Item:Enumeration', json: enumerationRt},
-  {id: 'resourceTemplate:bf2:Item:Chronology', json: chronologyRt}
+  {id: 'resourceTemplate:bf2:Item:Chronology', json: chronologyRt},
+  {id: 'Sinopia:RT:Fixture:SampleResource', json: sampleResource},
+  {id: 'Sinopia:RT:Fixture:Suppl', json: supplementaryContent}
 ]
 
 const emptyTemplate = { propertyTemplates : [{}] }

--- a/static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/SampleResource.json
+++ b/static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/SampleResource.json
@@ -1,0 +1,57 @@
+{
+  "propertyTemplates": [
+    {
+      "mandatory": "true",
+      "repeatable": "true",
+      "type": "literal",
+      "resourceTemplates": [],
+      "valueConstraint": {
+        "valueTemplateRefs": [],
+        "useValuesFrom": [],
+        "defaults": [],
+        "valueDataType": {}
+      },
+      "propertyLabel": "Example 2: literal, repeatable, required, no default",
+      "propertyURI": "http://id.loc.gov/ontologies/bibframe/copyrightDate"
+    },
+    {
+      "mandatory": "true",
+      "repeatable": "true",
+      "type": "lookup",
+      "resourceTemplates": [],
+      "valueConstraint": {
+        "valueTemplateRefs": [],
+        "useValuesFrom": [
+          "urn:ld4p:qa:subjects"
+        ],
+        "defaults": [],
+        "valueDataType": {}
+      },
+      "propertyLabel": "Example 10: lookup repeatable, required, no default",
+      "propertyURI": "http://id.loc.gov/ontologies/bibframe/subject"
+    },
+    {
+      "mandatory": "false",
+      "repeatable": "false",
+      "type": "resource",
+      "resourceTemplates": [],
+      "valueConstraint": {
+        "valueTemplateRefs": [
+          "Sinopia:RT:Fixture:Suppl"
+        ],
+        "useValuesFrom": [],
+        "defaults": [],
+        "valueDataType": {}
+      },
+      "propertyLabel": "Example 17: refer to another resource template, repeatable no",
+      "propertyURI": "http://id.loc.gov/ontologies/bibframe/supplementaryContent",
+      "remark": ""
+    }
+  ],
+  "id": "Sinopia:RT:Fixture:SampleResource",
+  "resourceURI": "http://id.loc.gov/ontologies/bibframe/Work",
+  "remark": "This is a sample Resource Template, content is meaningless, Resource URI = http://id.loc.gov/ontologies/bibframe/Work; for literal examples, property URI = http://id.loc.gov/ontologies/bibframe/copyrightDate; for lookup examples, property URI = http://id.loc.gov/ontologies/bibframe/subject; for examples that point to another RT, property URI is http://id.loc.gov/ontologies/bibframe/note",
+  "resourceLabel": "Resource Template to test RDF output",
+  "author": "Michelle Futornick",
+  "schema": "https://ld4p.github.io/sinopia/schemas/0.0.9/resource-template.json"
+}

--- a/static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/SupplementaryContent.json
+++ b/static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/SupplementaryContent.json
@@ -1,0 +1,38 @@
+{
+  "propertyTemplates": [
+    {
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "resourceTemplates": [],
+      "valueConstraint": {
+        "valueTemplateRefs": [],
+        "useValuesFrom": [],
+        "defaults": [],
+        "valueDataType": {}
+      },
+      "propertyLabel": "URI for Supplementary Content",
+      "propertyURI": "http://id.loc.gov/ontologies/bflc/target"
+    },
+    {
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "resourceTemplates": [],
+      "valueConstraint": {
+        "valueTemplateRefs": [],
+        "useValuesFrom": [],
+        "defaults": [],
+        "valueDataType": {}
+      },
+      "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+      "propertyLabel": "Supplementary Content"
+    }
+  ],
+  "id": "Sinopia:RT:Fixture:Suppl",
+  "resourceURI": "http://id.loc.gov/ontologies/bibframe/SupplementaryContent",
+  "resourceLabel": "Supplementary Content",
+  "author": "michelle",
+  "remark": "this Resource Template is referred to by Sinopia:RT:Fixture:SampleResource",
+  "schema": "https://ld4p.github.io/sinopia/schemas/0.0.9/resource-template.json"
+}


### PR DESCRIPTION
The first steps for RDF generation in the Linked Data editor involves adding the following properties to the Redux state:

- `rdfPredicate` property set for propertyTemplates