### PR TITLE
Fix lookup config bug in InputListLOC

### DIFF
--- a/__tests__/components/editor/InputListLOC.test.js
+++ b/__tests__/components/editor/InputListLOC.test.js
@@ -115,12 +115,17 @@ describe('<Typeahead /> component', () => {
       jest.restoreAllMocks()
     })
 
+    const defaults = [{
+      "defaultLiteral": "volume",
+      "defaultURI": "http://id.loc.gov/vocabulary/carriers/nc"
+    }]
+
     it('sets the default values according to the property template if they exist', () => {
-      const defaults = [{
-        "defaultLiteral": "volume",
-        "defaultURI": "http://id.loc.gov/vocabulary/carriers/nc"
-      }]
       expect(wrapper.instance().props.propertyTemplate.valueConstraint.defaults).toEqual(defaults)
+    })
+
+    it('sets the defaults state as the defaults array', () => {
+      expect(wrapper.state('defaults').length).toEqual(1)
     })
 
     it('logs an error when no defaults are set', () => {

--- a/__tests__/components/editor/InputListLOC.test.js
+++ b/__tests__/components/editor/InputListLOC.test.js
@@ -150,17 +150,10 @@ describe('<Typeahead /> component', () => {
         }
       }
       const infoSpy = jest.spyOn(console, 'info').mockReturnValue(null)
-      const wrapper2 = shallow(<InputList.WrappedComponent {...plProps} handleSelectedChange={mockFormDataFn} />)
+      const wrapper2 = shallow(<InputListLOC.WrappedComponent {...plProps} handleSelectedChange={mockFormDataFn} />)
 
       expect(wrapper2.state('defaults')).toEqual([])
       expect(infoSpy).toBeCalledWith(`no defaults defined in property template: ${JSON.stringify(plProps.propertyTemplate)}`)
-// =======
-//       const errorSpy = jest.spyOn(console, 'error').mockReturnValue(null)
-//       const wrapper2 = shallow(<InputListLOC.WrappedComponent {...plProps} handleSelectedChange={mockFormDataFn} />)
-//
-//       expect(wrapper2.instance().props.propertyTemplate.valueConstraint.defaults).toBeUndefined()
-//       expect(errorSpy).toBeCalledWith(`no defaults defined in property template: ${JSON.stringify(plProps.propertyTemplate)}`)
-// >>>>>>> Fix bug where lookup config is returning an array and InputListLOC expects an object
     })
   })
 

--- a/__tests__/components/editor/InputListLOC.test.js
+++ b/__tests__/components/editor/InputListLOC.test.js
@@ -3,7 +3,7 @@
 import React from 'react'
 import { shallow } from 'enzyme'
 import { Typeahead } from 'react-bootstrap-typeahead'
-import InputList from '../../../src/components/editor/InputListLOC'
+import InputListLOC from '../../../src/components/editor/InputListLOC'
 
 const plProps = {
   "propertyTemplate":
@@ -31,10 +31,52 @@ const plProps = {
     }
 }
 
-describe('<InputList />', () => {
+const mockLookupConfig = [
+  {
+    "label": "carriers",
+    "uri": "https://id.loc.gov/vocabulary/carriers",
+    "component": "list"
+  },
+  {
+    "label": "frequency",
+    "uri": undefined,
+    "component": "list"
+  }
+]
+
+describe('<InputListLOC /> configuration', () => {
   // our mock formData function to replace the one provided by mapDispatchToProps
   const mockFormDataFn = jest.fn()
-  const wrapper = shallow(<InputList.WrappedComponent {...plProps} handleSelectedChange={mockFormDataFn} />)
+
+  beforeEach(() => {
+    global.alert = jest.fn()
+  })
+
+  afterEach(() => {
+    global.alert = alert
+  })
+
+  it('expects a single lookupConfig object', () => {
+    shallow(<InputListLOC.WrappedComponent {...plProps} handleSelectedChange={mockFormDataFn} lookupConfig={mockLookupConfig[0]} />)
+    expect(global.alert.mock.calls.length).toEqual(0)
+  })
+
+  it('displays a browser alert if the lookupConfig is undefined', () => {
+    shallow(<InputListLOC.WrappedComponent {...plProps} handleSelectedChange={mockFormDataFn} lookupConfig={mockLookupConfig[1]} />)
+    expect(global.alert.mock.calls.length).toEqual(1)
+  })
+
+  it('displays a browser alert if the lookupConfig is an array of objects and not a single object', () => {
+    shallow(<InputListLOC.WrappedComponent {...plProps} handleSelectedChange={mockFormDataFn} lookupConfig={mockLookupConfig} />)
+    expect(global.alert.mock.calls.length).toEqual(1)
+  })
+
+})
+
+describe('<Typeahead /> component', () => {
+  // our mock formData function to replace the one provided by mapDispatchToProps
+  const mockFormDataFn = jest.fn()
+  const wrapper = shallow(<InputListLOC.WrappedComponent {...plProps} handleSelectedChange={mockFormDataFn} lookupConfig={mockLookupConfig[0]} />)
 
   it('contains a placeholder with the value of propertyLabel', () => {
     expect(wrapper.find(Typeahead).props().placeholder).toMatch("Frequency (RDA 2.14)")
@@ -75,11 +117,10 @@ describe('<InputList />', () => {
 
     it('sets the default values according to the property template if they exist', () => {
       const defaults = [{
-        id: 'http://id.loc.gov/vocabulary/carriers/nc',
-        uri: 'http://id.loc.gov/vocabulary/carriers/nc',
-        label: 'volume'
+        "defaultLiteral": "volume",
+        "defaultURI": "http://id.loc.gov/vocabulary/carriers/nc"
       }]
-      expect(wrapper.state('defaults')).toEqual(defaults)
+      expect(wrapper.instance().props.propertyTemplate.valueConstraint.defaults).toEqual(defaults)
     })
 
     it('logs an error when no defaults are set', () => {
@@ -108,6 +149,13 @@ describe('<InputList />', () => {
 
       expect(wrapper2.state('defaults')).toEqual([])
       expect(infoSpy).toBeCalledWith(`no defaults defined in property template: ${JSON.stringify(plProps.propertyTemplate)}`)
+// =======
+//       const errorSpy = jest.spyOn(console, 'error').mockReturnValue(null)
+//       const wrapper2 = shallow(<InputListLOC.WrappedComponent {...plProps} handleSelectedChange={mockFormDataFn} />)
+//
+//       expect(wrapper2.instance().props.propertyTemplate.valueConstraint.defaults).toBeUndefined()
+//       expect(errorSpy).toBeCalledWith(`no defaults defined in property template: ${JSON.stringify(plProps.propertyTemplate)}`)
+// >>>>>>> Fix bug where lookup config is returning an array and InputListLOC expects an object
     })
   })
 

--- a/__tests__/components/editor/InputLookupQA.test.js
+++ b/__tests__/components/editor/InputLookupQA.test.js
@@ -14,6 +14,7 @@ const plProps = {
       "type": "lookup",
       "resourceTemplates": [],
       "valueConstraint": {
+        "repeatable": "true",
         "valueTemplateRefs": [],
         "useValuesFrom": [
           'lookupQaLocNames'

--- a/src/Utilities.js
+++ b/src/Utilities.js
@@ -45,3 +45,18 @@ export const templateBoolean = (value) => {
   }
   return Boolean(result)
 }
+
+export const booleanPropertyFromTemplate = (template, key, defaultValue) => {
+  // Use safe navigation for dynamic properties: https://github.com/tc39/proposal-optional-chaining#syntax
+  const propertyValue = template?.[key]
+
+  if (!propertyValue)
+    return defaultValue
+
+  const parsedValue = JSON.parse(propertyValue)
+
+  if (parsedValue !== true && parsedValue !== false)
+    return defaultValue
+
+  return parsedValue
+}

--- a/src/components/editor/InputListLOC.jsx
+++ b/src/components/editor/InputListLOC.jsx
@@ -5,7 +5,7 @@ import { Typeahead } from 'react-bootstrap-typeahead'
 import PropTypes from 'prop-types'
 import PropertyRemark from './PropertyRemark'
 import { connect } from 'react-redux'
-import { changeSelections } from '../../actions/index'
+import { changeSelections  } from '../../actions/index'
 import { defaultValuesFromPropertyTemplate, booleanPropertyFromTemplate } from '../../Utilities'
 import shortid from 'shortid'
 
@@ -14,13 +14,12 @@ class InputListLOC extends Component {
     super(props)
     this.state = {
       isLoading: false,
-      options: []
+      options: [],
+      defaults: defaultValuesFromPropertyTemplate(this.props.propertyTemplate)
     }
 
-    const defaults = defaultValuesFromPropertyTemplate(this.props.propertyTemplate)
-
-    if (defaults.length > 0) {
-      this.setPayLoad(defaults)
+    if (this.state.defaults.length > 0) {
+      this.setPayLoad(this.state.defaults)
     } else {
       // Property templates do not require defaults but we like to know when this happens
       console.info(`no defaults defined in property template: ${JSON.stringify(this.props.propertyTemplate)}`)
@@ -33,6 +32,7 @@ class InputListLOC extends Component {
       items: items,
       reduxPath: this.props.reduxPath
     }
+
     this.props.handleSelectedChange(payload)
   }
 
@@ -112,14 +112,14 @@ InputListLOC.propTypes = {
   }).isRequired
 }
 
-const mapStatetoProps = (state) => {
+const mapStateToProps = (state, props) => {
   return Object.assign({}, state)
 }
 
-const mapDispatchtoProps = dispatch => ({
+const mapDispatchToProps = dispatch => ({
   handleSelectedChange(selected){
     dispatch(changeSelections(selected))
   }
 })
 
-export default connect(mapStatetoProps, mapDispatchtoProps)(InputListLOC)
+export default connect(mapStateToProps, mapDispatchToProps)(InputListLOC)

--- a/src/components/editor/InputListLOC.jsx
+++ b/src/components/editor/InputListLOC.jsx
@@ -6,14 +6,16 @@ import PropTypes from 'prop-types'
 import PropertyRemark from './PropertyRemark'
 import { connect } from 'react-redux'
 import { changeSelections } from '../../actions/index'
-import { defaultValuesFromPropertyTemplate } from '../../Utilities'
+import { defaultValuesFromPropertyTemplate, booleanPropertyFromTemplate } from '../../Utilities'
 import shortid from 'shortid'
 
 class InputListLOC extends Component {
   constructor(props) {
     super(props)
-
-    this.hasPropertyRemark = this.hasPropertyRemark.bind(this)
+    this.state = {
+      isLoading: false,
+      options: []
+    }
 
     const defaults = defaultValuesFromPropertyTemplate(this.props.propertyTemplate)
 
@@ -22,12 +24,6 @@ class InputListLOC extends Component {
     } else {
       // Property templates do not require defaults but we like to know when this happens
       console.info(`no defaults defined in property template: ${JSON.stringify(this.props.propertyTemplate)}`)
-    }
-
-    this.state = {
-      isLoading: false,
-      options: [],
-      defaults: defaults
     }
   }
 
@@ -40,7 +36,7 @@ class InputListLOC extends Component {
     this.props.handleSelectedChange(payload)
   }
 
-  hasPropertyRemark(propertyTemplate) {
+  hasPropertyRemark = (propertyTemplate) => {
     if(propertyTemplate.remark) {
       return <PropertyRemark remark={propertyTemplate.remark}
                              label={propertyTemplate.propertyLabel} />;
@@ -49,14 +45,12 @@ class InputListLOC extends Component {
   }
 
   render() {
-    let lookupUri, isMandatory, isRepeatable
-    try {
-      isMandatory = JSON.parse(this.props.propertyTemplate.mandatory)
-      isRepeatable = JSON.parse(this.props.propertyTemplate.valueConstraint.repeatable)
-      lookupUri = this.props.lookupConfig.uri
-    } catch (error) {
-      console.error(`Some properties were not defined in the json file: ${error}`)
+    if (this.props.lookupConfig?.uri === undefined) {
+      alert(`There is no configured list lookup for ${this.props.propertyTemplate.propertyURI}`)
     }
+
+    const isMandatory = booleanPropertyFromTemplate(this.props.propertyTemplate, 'mandatory', false)
+    const isRepeatable = booleanPropertyFromTemplate(this.props.propertyTemplate.valueConstraint, 'repeatable', true)
 
     var typeaheadProps = {
       id: "targetComponent",
@@ -76,7 +70,7 @@ class InputListLOC extends Component {
         <Typeahead
           onFocus={() => {
             this.setState({isLoading: true})
-            fetch(`${lookupUri}.json`)
+            fetch(`${this.props.lookupConfig.uri}.json`)
               .then(resp => resp.json())
               .then(json => {
                 for(var i in json){

--- a/src/components/editor/InputListLOC.jsx
+++ b/src/components/editor/InputListLOC.jsx
@@ -112,7 +112,7 @@ InputListLOC.propTypes = {
   }).isRequired
 }
 
-const mapStateToProps = (state, props) => {
+const mapStateToProps = (state) => {
   return Object.assign({}, state)
 }
 

--- a/src/components/editor/InputLiteral.jsx
+++ b/src/components/editor/InputLiteral.jsx
@@ -223,7 +223,6 @@ InputLiteral.propTypes = {
   handleMyItemsChange: PropTypes.func,
   handleRemoveItem: PropTypes.func,
   reduxPath: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
-  rtId: PropTypes.string,
   blankNodeForLiteral: PropTypes.object,
   propPredicate: PropTypes.string,
   setDefaultsForLiteralWithPayLoad: PropTypes.func,

--- a/src/components/editor/InputLookupQA.jsx
+++ b/src/components/editor/InputLookupQA.jsx
@@ -6,7 +6,7 @@ import Swagger from 'swagger-client'
 import { connect } from 'react-redux'
 import { getProperty } from '../../reducers/index'
 import { changeSelections } from '../../actions/index'
-import { defaultValuesFromPropertyTemplate } from '../../Utilities'
+import { booleanPropertyFromTemplate, defaultValuesFromPropertyTemplate } from '../../Utilities'
 
 const AsyncTypeahead = asyncContainer(Typeahead)
 
@@ -85,12 +85,8 @@ class InputLookupQA extends Component {
     let authority, subauthority, language
     const lookupConfigs = this.props.lookupConfig
 
-    const isMandatory = this.props.propertyTemplate.mandatory === undefined ?
-          true :
-          JSON.parse(this.props.propertyTemplate.mandatory)
-    const isRepeatable = this.props.propertyTemplate.repeatable === undefined ?
-          true :
-          JSON.parse(this.props.propertyTemplate.repeatable)
+    const isMandatory = booleanPropertyFromTemplate(this.props.propertyTemplate, 'mandatory', false)
+    const isRepeatable = booleanPropertyFromTemplate(this.props.propertyTemplate.valueConstraint, 'repeatable', true)
 
     const typeaheadProps = {
       id: 'lookupComponent',

--- a/src/components/editor/PropertyComponent.jsx
+++ b/src/components/editor/PropertyComponent.jsx
@@ -4,8 +4,8 @@ import React, { Component } from 'react'
 import InputLiteral from './InputLiteral'
 import InputListLOC from './InputListLOC'
 import InputLookupQA from './InputLookupQA'
-import shortid from 'shortid'
 import lookupConfig from '../../../static/spoofedFilesFromServer/fromSinopiaServer/lookupConfig.json'
+import shortid from 'shortid'
 import PropTypes from 'prop-types'
 
 export class PropertyComponent extends Component {
@@ -36,24 +36,25 @@ export class PropertyComponent extends Component {
     } catch {
       // ignore undefined configuration
     }
+
     const reduxPath = Object.assign([], this.props.reduxPath)
     reduxPath.push(property.propertyURI)
     const keyId = shortid.generate()
+
     switch(config) {
       case "lookup":
-        result = (<InputLookupQA key = {keyId} rtId = {this.props.rtId} reduxPath={[this.props.rtId, property.propertyURI]}
+        result = (<InputLookupQA key = {this.props.index} reduxPath={reduxPath}
                                  propertyTemplate = {property} lookupConfig = {this.state.configuration} />)
         break
       case "list":
-        result = (<InputListLOC key = {keyId} reduxPath={[this.props.rtId, property.propertyURI]}
-                                propertyTemplate = {property} lookupConfig = {this.state.configuration}/>)
+        result = (<InputListLOC key = {this.props.index} reduxPath={reduxPath}
+                                propertyTemplate = {property} lookupConfig = {this.state.configuration[0]} />)
         break
       default:
         switch(property.type) {
           case "literal":
             result = (<InputLiteral key={keyId} id={keyId}
                                     propertyTemplate={property}
-                                    rtId={this.props.rtId}
                                     reduxPath={reduxPath} />)
             break
           default:
@@ -88,7 +89,6 @@ PropertyComponent.propTypes = {
     })
   }).isRequired,
   reduxPath: PropTypes.array.isRequired,
-  rtId: PropTypes.string,
   index: PropTypes.number
 }
 

--- a/src/components/editor/PropertyTemplateOutline.jsx
+++ b/src/components/editor/PropertyTemplateOutline.jsx
@@ -106,10 +106,7 @@ export class PropertyTemplateOutline extends Component {
                                       addButtonDisabled={isAddDisabled}
                                       handleMintUri={this.props.handleMintUri} />
     } else {
-      propertyJsx = <PropertyComponent index={0}
-                                       rtId={this.props.rtId}
-                                       reduxPath={this.props.reduxPath}
-                                       propertyTemplate={property} />
+      propertyJsx = <PropertyComponent index={0} propertyTemplate={property} reduxPath={this.props.reduxPath} />
     }
 
     newOutput.forEach((propertyJsx) => {


### PR DESCRIPTION
Fixed bug where lookup config is returning an array of objects and InputListLOC expects just a single object.

Also, removes annoying console logging which we do not really need

Also, makes sure that the lack of a setting for one property variable does not break the other variables where the property is actually set.

Adds a test for the presence of a lookupConfig URI.