### PR TITLE
Add reduxPath to PropertyComponent

### DIFF
--- a/__tests__/components/editor/PropertyComponent.test.js
+++ b/__tests__/components/editor/PropertyComponent.test.js
@@ -17,7 +17,7 @@ describe('<PropertyComponent />', () => {
         }
       }
 
-      const wrapper = shallow(<PropertyComponent propertyTemplate={template} />)
+      const wrapper = shallow(<PropertyComponent propertyTemplate={template} reduxPath={["http://id.loc.gov/ontologies/bibframe/issuance"]} />)
 
       it('should find a configuration object in the lookup config', () => {
         expect(typeof wrapper.state('configuration')).toEqual("object")
@@ -46,7 +46,7 @@ describe('<PropertyComponent />', () => {
         }
       }
 
-      const wrapper = shallow(<PropertyComponent propertyTemplate={template} />)
+      const wrapper = shallow(<PropertyComponent propertyTemplate={template} reduxPath={["http://id.loc.gov/ontologies/bibframe/contribution"]}/>)
 
       it('finds a configuration object in the lookup config', () => {
         expect(typeof wrapper.state('configuration')).toEqual("object")
@@ -70,7 +70,8 @@ describe('<PropertyComponent />', () => {
         "type": "literal"
       }
 
-      const wrapper = shallow(<PropertyComponent propertyTemplate={template} />)
+      const wrapper = shallow(<PropertyComponent propertyTemplate={template}
+                                reduxPath={["http://id.loc.gov/ontologies/bibframe/heldBy"]} />)
 
       it('returns an empty array', () => {
         expect(wrapper.state('configuration').length).toEqual(0)
@@ -93,7 +94,8 @@ describe('<PropertyComponent />', () => {
         }
       }
 
-      const wrapper = shallow(<PropertyComponent propertyTemplate={template} />)
+      const wrapper = shallow(<PropertyComponent propertyTemplate={template}
+                               reduxPath={["http://id.loc.gov/ontologies/bibframe/note"]}/>)
       expect(wrapper.find('Connect(InputListLOC)').length).toEqual(0)
       expect(wrapper.find('Connect(InputLookupQA)').length).toEqual(0)
       expect(wrapper.find('Connect(InputLiteral)').length).toEqual(0)

--- a/__tests__/components/editor/PropertyComponent.test.js
+++ b/__tests__/components/editor/PropertyComponent.test.js
@@ -152,7 +152,7 @@ describe('<PropertyComponent />', () => {
     })
   })
 
-  it('error if <PropertyComponent /> is missing reduxPath props', () => {
+  it('logs an error if <PropertyComponent /> is missing reduxPath props', () => {
     const template = {
       "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
       "type": "resource",
@@ -163,12 +163,12 @@ describe('<PropertyComponent />', () => {
         "useValuesFrom": []
       }
     }
+    const originalError = console.error
     console.error = jest.fn()
-    const wrapper = shallow(<PropertyComponent index={1}
+    shallow(<PropertyComponent index={1}
                               propertyTemplate={template}
                               rtId={'resourceTemplate:test'} />)
-    expect(wrapper).toBeTruthy() // Needed to pass eslint
     expect(console.error).toHaveBeenCalledTimes(1)
-
+    console.error = originalError
   })
 })

--- a/__tests__/components/editor/PropertyComponent.test.js
+++ b/__tests__/components/editor/PropertyComponent.test.js
@@ -105,7 +105,7 @@ describe('<PropertyComponent />', () => {
   describe('getLookupConfigItems()', () => {
    it('returns an empty array if passed any value that fails to define a `valueConstraint.useValuesFrom` array', () => {
      const template = {}
-     const wrapper = shallow(<PropertyComponent propertyTemplate={template} />)
+     const wrapper = shallow(<PropertyComponent propertyTemplate={template} reduxPath={['nothing']}/>)
 
      expect(wrapper.instance().getLookupConfigItems(template)).toEqual([])
     })
@@ -116,7 +116,7 @@ describe('<PropertyComponent />', () => {
           useValuseFrom: []
         }
       }
-      const wrapper = shallow(<PropertyComponent propertyTemplate={template} />)
+      const wrapper = shallow(<PropertyComponent propertyTemplate={template} reduxPath={['nothing']}/>)
 
       expect(wrapper.instance().getLookupConfigItems(template)).toEqual([])
     })
@@ -132,7 +132,7 @@ describe('<PropertyComponent />', () => {
           ]
         }
       }
-      const wrapper = shallow(<PropertyComponent propertyTemplate={template} />)
+      const wrapper = shallow(<PropertyComponent propertyTemplate={template} reduxPath={['']}/>)
 
       expect(wrapper.instance().getLookupConfigItems(template)).toEqual([
         {
@@ -150,5 +150,25 @@ describe('<PropertyComponent />', () => {
         }
       ])
     })
+  })
+
+  it('error if <PropertyComponent /> is missing reduxPath props', () => {
+    const template = {
+      "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+      "type": "resource",
+      "valueConstraint": {
+        "valueTemplateRefs": [
+          "resourceTemplate:bf2:Note"
+        ],
+        "useValuesFrom": []
+      }
+    }
+    console.error = jest.fn()
+    const wrapper = shallow(<PropertyComponent index={1}
+                              propertyTemplate={template}
+                              rtId={'resourceTemplate:test'} />)
+    expect(wrapper).toBeTruthy() // Needed to pass eslint
+    expect(console.error).toHaveBeenCalledTimes(1)
+
   })
 })

--- a/__tests__/components/editor/PropertyTemplateOutline.test.js
+++ b/__tests__/components/editor/PropertyTemplateOutline.test.js
@@ -131,7 +131,8 @@ describe('<PropertyTemplateOutline />', () => {
         }
       }
 
-      const wrapper = shallow(<PropertyTemplateOutline {...propertyRtPropsLiteral} />)
+      const wrapper = shallow(<PropertyTemplateOutline {...propertyRtPropsLiteral}
+                               reduxPath={["http://id.loc.gov/ontologies/bibframe/heldBy"]} />)
 
       wrapper.setState({collapsed: false})
       wrapper.instance().outlineRowClass()

--- a/package-lock.json
+++ b/package-lock.json
@@ -8175,6 +8175,12 @@
       "integrity": "sha512-pgFw2tm54fzgYvc/OHrnysABEObZCUNFnhjoRjaVOCN8NYc032/gVjPaHD4Aq6ApkSieWtfKAFQtmDKAmhupnQ==",
       "dev": true
     },
+    "jest-prop-type-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jest-prop-type-error/-/jest-prop-type-error-1.1.0.tgz",
+      "integrity": "sha512-i/4hdbKSp6cFJc2z3Blu2WEOGjxbQ76pShhtDFIqUfdC8ruMGT57EOsBtBq69FVg915MUMwENNc185ejs7mmtg==",
+      "dev": true
+    },
     "jest-puppeteer": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/jest-puppeteer/-/jest-puppeteer-4.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "jest": "^24.7.1",
     "jest-junit": "^6.3.0",
     "jest-localstorage-mock": "^2.4.0",
+    "jest-prop-type-error": "^1.1.0",
     "jest-puppeteer": "^4.1.1",
     "jsdom": "15.0.0",
     "jsdom-global": "3.0.2",
@@ -134,7 +135,8 @@
       "/node_modules/"
     ],
     "setupFiles": [
-      "jest-localstorage-mock"
+      "jest-localstorage-mock",
+      "jest-prop-type-error"
     ]
   }
 }

--- a/src/components/editor/PropertyComponent.jsx
+++ b/src/components/editor/PropertyComponent.jsx
@@ -87,7 +87,7 @@ PropertyComponent.propTypes = {
       useValuesFrom: PropTypes.oneOfType([ PropTypes.string, PropTypes.array])
     })
   }).isRequired,
-  reduxPath: PropTypes.array,
+  reduxPath: PropTypes.array.isRequired,
   rtId: PropTypes.string,
   index: PropTypes.number
 }

--- a/src/components/editor/ResourceTemplateForm.jsx
+++ b/src/components/editor/ResourceTemplateForm.jsx
@@ -132,7 +132,7 @@ export class ResourceTemplateForm extends Component {
               } else {
                 return (
                   <PropertyPanel pt={pt} key={index} float={index} rtId={this.props.rtId}>
-                    <PropertyComponent index={index} rtId={this.props.rtId} propertyTemplate={pt} />
+                    <PropertyComponent index={index} reduxPath={[this.props.rtId]} rtId={this.props.rtId} propertyTemplate={pt} />
                   </PropertyPanel>
                 )
               }


### PR DESCRIPTION
As @michelleif noted in #575, the defaults were not showing up because the `reduxPath` was not set  in the PropertyComponent component. 

Fixes #575