### PR TITLE
Fix Getty AAT QA lookups

### DIFF
--- a/__tests__/components/editor/InputListLOC.test.js
+++ b/__tests__/components/editor/InputListLOC.test.js
@@ -103,11 +103,11 @@ describe('<InputList />', () => {
           }
         }
       }
-      const errorSpy = jest.spyOn(console, 'error').mockReturnValue(null)
+      const infoSpy = jest.spyOn(console, 'info').mockReturnValue(null)
       const wrapper2 = shallow(<InputList.WrappedComponent {...plProps} handleSelectedChange={mockFormDataFn} />)
 
       expect(wrapper2.state('defaults')).toEqual([])
-      expect(errorSpy).toBeCalledWith(`no defaults defined in property template: ${JSON.stringify(plProps.propertyTemplate)}`)
+      expect(infoSpy).toBeCalledWith(`no defaults defined in property template: ${JSON.stringify(plProps.propertyTemplate)}`)
     })
   })
 

--- a/__tests__/components/editor/InputLookupQA.test.js
+++ b/__tests__/components/editor/InputLookupQA.test.js
@@ -71,6 +71,11 @@ describe('<InputLookupQA />', () => {
   const mockFormDataFn = jest.fn()
   const wrapper = shallow(<InputLookupQA.WrappedComponent {...plProps} handleSelectedChange={mockFormDataFn} />)
 
+  it('has a lookupClient', () => {
+    // The Swagger constructor returns a promise
+    expect(wrapper.instance().lookupClient).toBeInstanceOf(Promise)
+  })
+
   it('uses the propertyLabel from the template as the form control label', () => {
     expect(wrapper.find('#lookupComponent').props().placeholder).toMatch('Name Lookup')
   })
@@ -125,11 +130,11 @@ describe('<InputLookupQA />', () => {
         }
       }
 
-      const errorSpy = jest.spyOn(console, 'error').mockReturnValue(null)
+      const infoSpy = jest.spyOn(console, 'info').mockReturnValue(null)
       const wrapper2 = shallow(<InputLookupQA.WrappedComponent {...plProps} handleSelectedChange={mockFormDataFn} />)
 
       expect(wrapper2.state('defaults')).toEqual([])
-      expect(errorSpy).toBeCalledWith(`no defaults defined in property template: ${JSON.stringify(plProps.propertyTemplate)}`)
+      expect(infoSpy).toBeCalledWith(`no defaults defined in property template: ${JSON.stringify(plProps.propertyTemplate)}`)
     })
 
     it('sets the async typeahead component defaultSelected attribute', () => {

--- a/src/components/editor/InputListLOC.jsx
+++ b/src/components/editor/InputListLOC.jsx
@@ -20,7 +20,8 @@ class InputListLOC extends Component {
     if (defaults.length > 0) {
       this.setPayLoad(defaults)
     } else {
-      console.error(`no defaults defined in property template: ${JSON.stringify(this.props.propertyTemplate)}`)
+      // Property templates do not require defaults but we like to know when this happens
+      console.info(`no defaults defined in property template: ${JSON.stringify(this.props.propertyTemplate)}`)
     }
 
     this.state = {

--- a/src/components/editor/InputLookupQA.jsx
+++ b/src/components/editor/InputLookupQA.jsx
@@ -17,12 +17,14 @@ class InputLookupQA extends Component {
     const defaults = defaultValuesFromPropertyTemplate(this.props.propertyTemplate)
 
     if (defaults.length === 0)
-      console.error(`no defaults defined in property template: ${JSON.stringify(this.props.propertyTemplate)}`)
+      // Property templates do not require defaults but we like to know when this happens
+      console.info(`no defaults defined in property template: ${JSON.stringify(this.props.propertyTemplate)}`)
 
     this.state = {
       isLoading: false,
       defaults: defaults
     }
+    this.lookupClient = Swagger({ url: 'src/lib/apidoc.json' })
   }
 
   // Render menu function to be used by typeahead
@@ -91,10 +93,12 @@ class InputLookupQA extends Component {
           JSON.parse(this.props.propertyTemplate.repeatable)
 
     const typeaheadProps = {
+      id: 'lookupComponent',
       required: isMandatory,
       multiple: isRepeatable,
       placeholder: this.props.propertyTemplate.propertyLabel,
       useCache: true,
+      selectHintOnEnter: true,
       isLoading: this.state.isLoading,
       options: this.state.options,
       selected: this.state.selected,
@@ -104,17 +108,15 @@ class InputLookupQA extends Component {
 
     return (
       <div>
-        <AsyncTypeahead id="lookupComponent"
-
-                        renderMenu={(results, menuProps) => this.renderMenuFunc(results, menuProps)}
+        <AsyncTypeahead renderMenu={(results, menuProps) => this.renderMenuFunc(results, menuProps)}
 
                         onSearch={query => {
                           this.setState({ isLoading: true })
-                          Swagger({ url: "src/lib/apidoc.json" }).then(client => {
+                          this.lookupClient.then(client => {
                             //create array of promises based on the lookup config array that is sent in
                             const lookupPromises = lookupConfigs.map(lookupConfig => {
                               authority = lookupConfig.authority
-                              subauthority = lookupConfig.authority
+                              subauthority = lookupConfig.subauthority
                               language = lookupConfig.language
                               //return the 'promise'
                               //Since we don't want promise.all to fail if
@@ -138,13 +140,12 @@ class InputLookupQA extends Component {
                             })
 
                             Promise.all(lookupPromises).then(values => {
-                              let i
-                              for (i = 0; i < values.length; i++) {
+                              for (let i = 0; i < values.length; i++) {
                                 //If undefined, add info - note if error, error object returned in object
                                 //which allows attaching label and uri for authority
                                 if (values[i]) {
-                                  values[i]["authLabel"] = lookupConfigs[i].label
-                                  values[i]["authURI"] = lookupConfigs[i].uri
+                                  values[i].authLabel = lookupConfigs[i].label
+                                  values[i].authURI = lookupConfigs[i].uri
                                 }
                               }
 
@@ -163,8 +164,7 @@ class InputLookupQA extends Component {
                             reduxPath: this.props.reduxPath
                           }
                           this.props.handleSelectedChange(payload)
-                        }
-                                 }
+                        }}
 
                         {...typeaheadProps}
 

--- a/static/spoofedFilesFromServer/fromSinopiaServer/lookupConfig.json
+++ b/static/spoofedFilesFromServer/fromSinopiaServer/lookupConfig.json
@@ -106,7 +106,7 @@
   {
     "label": "GETTY_AAT all terms (QA)",
     "uri": "urn:ld4p:qa:gettyaat",
-    "authority": "getty_att_ld4l_cache",
+    "authority": "getty_aat_ld4l_cache",
     "subauthority": "",
     "language": "en",
     "component": "lookup"
@@ -114,7 +114,7 @@
   {
     "label": "GETTY_AAT Activities (QA)",
     "uri": "urn:ld4p:qa:gettyaat:Activities",
-    "authority": "getty_att_ld4l_cache",
+    "authority": "getty_aat_ld4l_cache",
     "subauthority": "Activities",
     "language": "en",
     "component": "lookup"
@@ -122,7 +122,7 @@
   {
     "label": "GETTY_AAT Activities__Disciplines (QA)",
     "uri": "urn:ld4p:qa:gettyaat:Activities__Disciplines",
-    "authority": "getty_att_ld4l_cache",
+    "authority": "getty_aat_ld4l_cache",
     "subauthority": "Activities__Disciplines",
     "language": "en",
     "component": "lookup"
@@ -130,7 +130,7 @@
   {
     "label": "GETTY_AAT Activities__Events (QA)",
     "uri": "urn:ld4p:qa:gettyaat:Activities__Events",
-    "authority": "getty_att_ld4l_cache",
+    "authority": "getty_aat_ld4l_cache",
     "subauthority": "Activities__Events",
     "language": "en",
     "component": "lookup"
@@ -138,7 +138,7 @@
   {
     "label": "GETTY_AAT Activities__Functions (QA)",
     "uri": "urn:ld4p:qa:gettyaat:Activities__Functions",
-    "authority": "getty_att_ld4l_cache",
+    "authority": "getty_aat_ld4l_cache",
     "subauthority": "Activities__Functions",
     "language": "en",
     "component": "lookup"
@@ -146,7 +146,7 @@
   {
     "label": "GETTY_AAT Activities__Physical_and_Mental (QA)",
     "uri": "urn:ld4p:qa:gettyaat:Activities__Physical_and_Mental",
-    "authority": "getty_att_ld4l_cache",
+    "authority": "getty_aat_ld4l_cache",
     "subauthority": "Activities__Physical_and_Mental",
     "language": "en",
     "component": "lookup"
@@ -154,7 +154,7 @@
   {
     "label": "GETTY_AAT Activities__Processes_and_Techniques (QA)",
     "uri": "urn:ld4p:qa:gettyaat:Activities__Processes_and_Techniques",
-    "authority": "getty_att_ld4l_cache",
+    "authority": "getty_aat_ld4l_cache",
     "subauthority": "Activities__Processes_and_Techniques",
     "language": "en",
     "component": "lookup"
@@ -162,7 +162,7 @@
   {
     "label": "GETTY_AAT Agents (QA)",
     "uri": "urn:ld4p:qa:gettyaat:Agents",
-    "authority": "getty_att_ld4l_cache",
+    "authority": "getty_aat_ld4l_cache",
     "subauthority": "Agents",
     "language": "en",
     "component": "lookup"
@@ -170,7 +170,7 @@
   {
     "label": "GETTY_AAT Agents__Living_Organisms (QA)",
     "uri": "urn:ld4p:qa:gettyaat:Agents__Living_Organisms",
-    "authority": "getty_att_ld4l_cache",
+    "authority": "getty_aat_ld4l_cache",
     "subauthority": "Agents__Living_Organisms",
     "language": "en",
     "component": "lookup"
@@ -178,7 +178,7 @@
   {
     "label": "GETTY_AAT Agents__Organizations (QA)",
     "uri": "urn:ld4p:qa:gettyaat:Agents__Organizations",
-    "authority": "getty_att_ld4l_cache",
+    "authority": "getty_aat_ld4l_cache",
     "subauthority": "Agents__Organizations",
     "language": "en",
     "component": "lookup"
@@ -186,7 +186,7 @@
   {
     "label": "GETTY_AAT Agents__People (QA)",
     "uri": "urn:ld4p:qa:gettyaat:Agents__People",
-    "authority": "getty_att_ld4l_cache",
+    "authority": "getty_aat_ld4l_cache",
     "subauthority": "Agents__People",
     "language": "en",
     "component": "lookup"
@@ -194,7 +194,7 @@
   {
     "label": "GETTY_AAT Associated_Concepts (QA)",
     "uri": "urn:ld4p:qa:gettyaat:Associated_Concepts",
-    "authority": "getty_att_ld4l_cache",
+    "authority": "getty_aat_ld4l_cache",
     "subauthority": "Associated_Concepts",
     "language": "en",
     "component": "lookup"
@@ -202,7 +202,7 @@
   {
     "label": "GETTY_AAT Associated_Concepts__Associated_Concepts (QA)",
     "uri": "urn:ld4p:qa:gettyaat:Associated_Concepts__Associated_Concepts",
-    "authority": "getty_att_ld4l_cache",
+    "authority": "getty_aat_ld4l_cache",
     "subauthority": "Associated_Concepts__Associated_Concepts",
     "language": "en",
     "component": "lookup"
@@ -210,7 +210,7 @@
   {
     "label": "GETTY_AAT Brand_Names (QA)",
     "uri": "urn:ld4p:qa:gettyaat:Brand_Names",
-    "authority": "getty_att_ld4l_cache",
+    "authority": "getty_aat_ld4l_cache",
     "subauthority": "Brand_Names",
     "language": "en",
     "component": "lookup"
@@ -218,7 +218,7 @@
   {
     "label": "GETTY_AAT Brand_Names__Brand_Names (QA)",
     "uri": "urn:ld4p:qa:gettyaat:Brand_Names__Brand_Names",
-    "authority": "getty_att_ld4l_cache",
+    "authority": "getty_aat_ld4l_cache",
     "subauthority": "Brand_Names__Brand_Names",
     "language": "en",
     "component": "lookup"
@@ -226,7 +226,7 @@
   {
     "label": "GETTY_AAT Materials (QA)",
     "uri": "urn:ld4p:qa:gettyaat:Materials",
-    "authority": "getty_att_ld4l_cache",
+    "authority": "getty_aat_ld4l_cache",
     "subauthority": "Materials",
     "language": "en",
     "component": "lookup"
@@ -234,7 +234,7 @@
   {
     "label": "GETTY_AAT Materials__Materials (QA)",
     "uri": "urn:ld4p:qa:gettyaat:Materials__Materials",
-    "authority": "getty_att_ld4l_cache",
+    "authority": "getty_aat_ld4l_cache",
     "subauthority": "Materials__Materials",
     "language": "en",
     "component": "lookup"
@@ -242,7 +242,7 @@
   {
     "label": "GETTY_AAT Objects (QA)",
     "uri": "urn:ld4p:qa:gettyaat:Objects",
-    "authority": "getty_att_ld4l_cache",
+    "authority": "getty_aat_ld4l_cache",
     "subauthority": "Objects",
     "language": "en",
     "component": "lookup"
@@ -250,7 +250,7 @@
   {
     "label": "GETTY_AAT Objects__Built_Environment (QA)",
     "uri": "urn:ld4p:qa:gettyaat:Objects__Built_Environment",
-    "authority": "getty_att_ld4l_cache",
+    "authority": "getty_aat_ld4l_cache",
     "subauthority": "Objects__Built_Environment",
     "language": "en",
     "component": "lookup"
@@ -258,7 +258,7 @@
   {
     "label": "GETTY_AAT Objects__Components (QA)",
     "uri": "urn:ld4p:qa:gettyaat:Objects__Components",
-    "authority": "getty_att_ld4l_cache",
+    "authority": "getty_aat_ld4l_cache",
     "subauthority": "Objects__Components",
     "language": "en",
     "component": "lookup"
@@ -266,7 +266,7 @@
   {
     "label": "GETTY_AAT Objects__Furnishings_and_Equipment (QA)",
     "uri": "urn:ld4p:qa:gettyaat:Objects__Furnishings_and_Equipment",
-    "authority": "getty_att_ld4l_cache",
+    "authority": "getty_aat_ld4l_cache",
     "subauthority": "Objects__Furnishings_and_Equipment",
     "language": "en",
     "component": "lookup"
@@ -274,7 +274,7 @@
   {
     "label": "GETTY_AAT Objects__Object_Genres (QA)",
     "uri": "urn:ld4p:qa:gettyaat:Objects__Object_Genres",
-    "authority": "getty_att_ld4l_cache",
+    "authority": "getty_aat_ld4l_cache",
     "subauthority": "Objects__Object_Genres",
     "language": "en",
     "component": "lookup"
@@ -282,7 +282,7 @@
   {
     "label": "GETTY_AAT Objects__Object_Groupings and Systems (QA)",
     "uri": "urn:ld4p:qa:gettyaat:Objects__Object_Groupings and Systems",
-    "authority": "getty_att_ld4l_cache",
+    "authority": "getty_aat_ld4l_cache",
     "subauthority": "Objects__Object_Groupings and Systems",
     "language": "en",
     "component": "lookup"
@@ -290,7 +290,7 @@
   {
     "label": "GETTY_AAT Objects__Visual_and_Verbal_Communication (QA)",
     "uri": "urn:ld4p:qa:gettyaat:Objects__Visual_and_Verbal_Communication",
-    "authority": "getty_att_ld4l_cache",
+    "authority": "getty_aat_ld4l_cache",
     "subauthority": "Objects__Visual_and_Verbal_Communication",
     "language": "en",
     "component": "lookup"
@@ -298,7 +298,7 @@
   {
     "label": "GETTY_AAT Physical_Attributes (QA)",
     "uri": "urn:ld4p:qa:gettyaat:Physical_Attributes",
-    "authority": "getty_att_ld4l_cache",
+    "authority": "getty_aat_ld4l_cache",
     "subauthority": "Physical_Attributes",
     "language": "en",
     "component": "lookup"
@@ -306,7 +306,7 @@
   {
     "label": "GETTY_AAT Physical_Attributes__Attributes_and_Properties (QA)",
     "uri": "urn:ld4p:qa:gettyaat:Physical_Attributes__Attributes_and_Properties",
-    "authority": "getty_att_ld4l_cache",
+    "authority": "getty_aat_ld4l_cache",
     "subauthority": "Physical_Attributes__Attributes_and_Properties",
     "language": "en",
     "component": "lookup"
@@ -314,7 +314,7 @@
   {
     "label": "GETTY_AAT Physical_Attributes__Color (QA)",
     "uri": "urn:ld4p:qa:gettyaat:Physical_Attributes__Color",
-    "authority": "getty_att_ld4l_cache",
+    "authority": "getty_aat_ld4l_cache",
     "subauthority": "Physical_Attributes__Color",
     "language": "en",
     "component": "lookup"
@@ -322,7 +322,7 @@
   {
     "label": "GETTY_AAT Physical_Attributes__Conditions_and_Effects (QA)",
     "uri": "urn:ld4p:qa:gettyaat:Physical_Attributes__Conditions_and_Effects",
-    "authority": "getty_att_ld4l_cache",
+    "authority": "getty_aat_ld4l_cache",
     "subauthority": "Physical_Attributes__Conditions_and_Effects",
     "language": "en",
     "component": "lookup"
@@ -330,7 +330,7 @@
   {
     "label": "GETTY_AAT Physical_Attributes__Design_Elements (QA)",
     "uri": "urn:ld4p:qa:gettyaat:Physical_Attributes__Design_Elements",
-    "authority": "getty_att_ld4l_cache",
+    "authority": "getty_aat_ld4l_cache",
     "subauthority": "Physical_Attributes__Design_Elements",
     "language": "en",
     "component": "lookup"
@@ -338,7 +338,7 @@
   {
     "label": "GETTY_AAT  (QA)",
     "uri": "urn:ld4p:qa:gettyaat",
-    "authority": "getty_att_ld4l_cache",
+    "authority": "getty_aat_ld4l_cache",
     "subauthority": "",
     "language": "en",
     "component": "lookup"
@@ -346,7 +346,7 @@
   {
     "label": "GETTY_AAT Styles_and_Periods (QA)",
     "uri": "urn:ld4p:qa:gettyaat:Styles_and_Periods",
-    "authority": "getty_att_ld4l_cache",
+    "authority": "getty_aat_ld4l_cache",
     "subauthority": "Styles_and_Periods",
     "language": "en",
     "component": "lookup"
@@ -354,7 +354,7 @@
   {
     "label": "GETTY_AAT Styles_and_Periods__Styles_and_Periods (QA)",
     "uri": "urn:ld4p:qa:gettyaat:Styles_and_Periods__Styles_and_Periods",
-    "authority": "getty_att_ld4l_cache",
+    "authority": "getty_aat_ld4l_cache",
     "subauthority": "Styles_and_Periods__Styles_and_Periods",
     "language": "en",
     "component": "lookup"
@@ -362,7 +362,7 @@
   {
     "label": "GETTY_TGN (QA)",
     "uri": "urn:ld4p:qa:gettytgn",
-    "authority": "getty_att_ld4l_cache",
+    "authority": "getty_aat_ld4l_cache",
     "subauthority": "",
     "language": "en",
     "component": "lookup"
@@ -370,7 +370,7 @@
   {
     "label": "GETTY_ULAN (QA)",
     "uri": "urn:ld4p:qa:gettyulan",
-    "authority": "getty_att_ld4l_cache",
+    "authority": "getty_aat_ld4l_cache",
     "subauthority": "",
     "language": "en",
     "component": "lookup"
@@ -378,7 +378,7 @@
   {
     "label": "GETTY_ULAN person (QA)",
     "uri": "urn:ld4p:qa:gettyulan:person",
-    "authority": "getty_att_ld4l_cache",
+    "authority": "getty_aat_ld4l_cache",
     "subauthority": "person",
     "language": "en",
     "component": "lookup"
@@ -386,7 +386,7 @@
   {
     "label": "GETTY_ULAN organization (QA)",
     "uri": "urn:ld4p:qa:gettyulan:organization",
-    "authority": "getty_att_ld4l_cache",
+    "authority": "getty_aat_ld4l_cache",
     "subauthority": "organization",
     "language": "en",
     "component": "lookup"


### PR DESCRIPTION
Fixes #576

Includes:
* Fix a couple dozen typos in the lookup config (`getty_att*` to `getty_aat*`)
* Log info, rather than error, messages to the console when lookups lack defaults. Defaults are not required so these are not errors.
* Avoid creating a new Swagger client on every QA request; instead create the client in the component constructor.
* Increase parity/decrease drift between `InputLookupQA` and `InputListLOC` components by including `id` and `selectHintOnEnter` in the typeahead properties.
* Fix typo in `InputLookupQA` component that was setting the subauthority to the same value as the authority.
