### PR TITLE
Fix issue when clicking templates that reference missing templates

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -137,6 +137,13 @@ module.exports = {
   },
   overrides: [
     {
+      // Allow tests to include block statements (idiomatic Jest style)
+      "files": ["__tests__/**"],
+      "rules": {
+        "arrow-body-style": "off"
+      }
+    },
+    {
       // Allow integration tests to use `page` global variable defined by puppeteer
       "files": ["__tests__/integration/**"],
       "rules": {

--- a/__tests__/reducers/index.test.js
+++ b/__tests__/reducers/index.test.js
@@ -74,6 +74,17 @@ describe('Takes a resource template ID and populates the global state', () => {
     },
   ]
 
+  const propertyTemplateWithoutConstraint = [
+    {
+      propertyLabel: 'LITERAL WITH DEFAULT',
+      propertyURI: 'http://id.loc.gov/ontologies/bibframe/heldBy',
+      resourceTemplates: [],
+      type: 'literal',
+      mandatory: 'false',
+      repeatable: 'true',
+    },
+  ]
+
   it('handles the initial state', () => {
     expect(
       selectorReducer(undefined, {}),
@@ -125,6 +136,28 @@ describe('Takes a resource template ID and populates the global state', () => {
       },
     })
   })
+
+  it('allows SET_RESOURCE_TEMPLATE on templates without valueConstraint', () => {
+    shortid.generate = jest.fn().mockReturnValue(0)
+    const result = selectorReducer({
+      selectorReducer: {},
+    }, {
+      type: 'SET_RESOURCE_TEMPLATE',
+      payload: {
+        id: 'resourceTemplate:bf2:Monograph:Instance',
+        propertyTemplates: propertyTemplateWithoutConstraint,
+      },
+    })
+
+    expect(result.selectorReducer).toMatchObject({
+      'resourceTemplate:bf2:Monograph:Instance':
+      {
+        'http://id.loc.gov/ontologies/bibframe/heldBy':
+          {},
+      },
+    })
+  })
+
 
   it('passing a payload to an empty state', () => {
     const emptyStateResult = refreshResourceTemplate({}, {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4655,7 +4655,7 @@
         },
         "eslint-plugin-react": {
           "version": "7.7.0",
-          "resolved": "http://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.7.0.tgz",
+          "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.7.0.tgz",
           "integrity": "sha512-KC7Snr4YsWZD5flu6A5c0AcIZidzW3Exbqp7OT67OaD2AppJtlBr/GuPrW/vaQM/yfZotEvKAdrxrO+v8vwYJA==",
           "dev": true,
           "requires": {
@@ -8811,6 +8811,11 @@
       "requires": {
         "graceful-fs": "^4.1.6"
       }
+    },
+    "jsonpath-plus": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-0.19.0.tgz",
+      "integrity": "sha512-GSVwsrzW9LsA5lzsqe4CkuZ9wp+kxBb2GwNniaWzI2YFn5Ig42rSW8ZxVpWXaAfakXNrx5pgY5AbQq7kzX29kg=="
     },
     "jsprim": {
       "version": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "event-stream": "^4.0.1",
     "express": "^4.16.4",
     "identity-obj-proxy": "^3.0.0",
+    "jsonpath-plus": "^0.19.0",
     "lodash": "^4.17.11",
     "merge": "^1.2.1",
     "n3": "^1.1.1",

--- a/src/components/editor/ImportResourceTemplate.jsx
+++ b/src/components/editor/ImportResourceTemplate.jsx
@@ -50,7 +50,6 @@ class ImportResourceTemplate extends Component {
     try {
       const response = await createResourceTemplate(content, group, this.props.currentUser)
 
-
       return response.response
     } catch (error) {
       this.setState({
@@ -64,7 +63,6 @@ class ImportResourceTemplate extends Component {
   updateResource = async (content, group) => {
     try {
       const response = await updateResourceTemplate(content, group, this.props.currentUser)
-
 
       return response.response
     } catch (error) {

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -21,13 +21,12 @@ const inputPropertySelector = (state, props) => {
 }
 
 /*
- * TODO: Renable use of reselect's createSelector, will need to adjust
+ * TODO: Re-enable use of reselect's createSelector, will need to adjust
  * individual components InputLiteral, InputLookupQA, InputListLOC, etc.,
  * see https://github.com/reduxjs/reselect#sharing-selectors-with-props-across-multiple-component-instances
  */
 export const getProperty = (state, props) => {
   const result = inputPropertySelector(state, props)
-
 
   return result.items || []
 }
@@ -56,7 +55,7 @@ export const populatePropertyDefaults = (propertyTemplate) => {
   if (propertyTemplate === undefined || propertyTemplate === null || Object.keys(propertyTemplate).length < 1) {
     return defaults
   }
-  if (propertyTemplate.valueConstraint.defaults && propertyTemplate.valueConstraint.defaults.length > 0) {
+  if (propertyTemplate?.valueConstraint?.defaults && propertyTemplate.valueConstraint.defaults.length > 0) {
     propertyTemplate.valueConstraint.defaults.map((row) => {
       defaults.push({
         id: makeShortID(),

--- a/src/sinopiaServer.js
+++ b/src/sinopiaServer.js
@@ -24,6 +24,17 @@ const getResourceTemplateFromServer = (templateId, group) => {
   return instance.getResourceWithHttpInfo(group, templateId, { accept: 'application/json' })
 }
 
+export const resourceTemplateExists = async (templateId, group = Config.defaultSinopiaGroupId) => {
+  try {
+    const result = await instance.headResourceWithHttpInfo(group, templateId)
+
+    return result.response.ok
+  } catch (error) {
+    console.error(`error checking if ${templateId} exists: ${error}; returning true to be safe`)
+    return false
+  }
+}
+
 export const getResourceTemplate = (templateId, group) => {
   if (Config.spoofSinopiaServer) return spoofedGetResourceTemplate(templateId)
 
@@ -44,7 +55,6 @@ export const listResourcesInGroupContainer = (group) => {
 
 export const getEntityTagFromGroupContainer = async (group) => {
   const result = await instance.headGroupWithHttpInfo(group)
-
 
   return result.response.header.etag
 }


### PR DESCRIPTION
Fixes #602

Includes:
* Make `ImportFileZone` component validate that all referenced identifiers in an imported resource template are either 1) defined within the resource template, or 2) available via the Sinopia server. Else bubble up an error message about using an undefined resource tempalte.
* Fix assumption in reducer that all property templates have `.valueConstraint.defaults` defined; some resource templates lack a `valueConstraint`
* Add new Sinopia server function to check if an identified RT exists
* Add `jsonpath-plus` dependency to quickly gather up nodes in a JSON document
* Allow `arrow-body-style` ESLint violations in tests to permit Jest idiomatic style