### PR TITLE
Create a modal to get user input for choosing a sinopia group

### DIFF
--- a/__tests__/components/editor/GroupChoiceModal.test.js
+++ b/__tests__/components/editor/GroupChoiceModal.test.js
@@ -1,0 +1,82 @@
+// Copyright 2019 Stanford University see LICENSE for license
+
+import React from 'react'
+import Modal from 'react-bootstrap/lib/Modal'
+import Button from 'react-bootstrap/lib/Button'
+import { shallow } from 'enzyme'
+import GroupChoiceModal from '../../../src/components/editor/GroupChoiceModal'
+
+describe('<GroupChoiceModal />', () => {
+  const saveFunc = jest.fn()
+
+  const closeFunc = jest.fn()
+
+  const wrapper = shallow(<GroupChoiceModal show={true} rdf="<>" save={saveFunc} close={closeFunc} />)
+
+  it('renders the <GroupChoiceModal /> component as a Modal', () => {
+    expect(wrapper.find(Modal).length).toBe(1)
+  })
+  describe('header', () => {
+    it('has a Modal.Header', () => {
+      expect(wrapper.find(Modal.Header).length).toBe(1)
+    })
+    it('has a Modal.Title', () => {
+      expect(wrapper.find(Modal.Title)
+        .childAt(0)
+        .text()).toEqual('Which group do you want to save to?')
+    })
+    it('has text asking the user to choose a group from the select options', () => {
+      expect(wrapper.find(Modal.Body).find('div')
+        .first()
+        .childAt(0)
+        .text()).toEqual('Which group do you want to associate this record to?')
+    })
+    it('has a select option dropdown', () => {
+      expect(wrapper.find(Modal.Body).find('form').find('select').length).toEqual(1)
+    })
+    it('has the first select option as "LD4P"', () => {
+      expect(wrapper.find(Modal.Body).find('form').find('select').find('option')
+        .first()
+        .childAt(0)
+        .text()).toEqual('LD4P')
+      expect(wrapper.find(Modal.Body).find('form').find('select').find('option')
+        .first()
+        .prop('value')).toEqual('ld4p')
+    })
+    it('has the last select option as "University of Washington"', () => {
+      expect(wrapper.find(Modal.Body).find('form').find('select').find('option')
+        .last()
+        .childAt(0)
+        .text()).toEqual('University of Washington')
+      expect(wrapper.find(Modal.Body).find('form').find('select').find('option')
+        .last()
+        .prop('value')).toEqual('wau')
+    })
+    it('has a Cancel link', () => {
+      expect(wrapper.find(Modal.Body).find(Button)
+        .first()
+        .childAt(0)
+        .text()).toEqual('Cancel')
+    })
+    it('has a save button', () => {
+      expect(wrapper.find(Modal.Body).find('form').find(Button)
+        .last()
+        .childAt(0)
+        .text()).toEqual('Save')
+    })
+  })
+  describe('save and close buttons', () => {
+    it('attenmplts to save the RDF content with group choice when save is clicked and closes the modal', () => {
+      wrapper.find('.btn-primary', { text: 'Save' }).simulate('click')
+      expect(saveFunc).toHaveBeenCalled()
+    })
+    it('closes the modal when the Cancel link is clicked', () => {
+      wrapper.find('.btn-link', { text: 'Cancel' }).simulate('click')
+      expect(closeFunc).toHaveBeenCalled()
+    })
+    it('closes the modal when the heade "X" entity is clicked', () => {
+      wrapper.find('.btn-primary', { text: '&times;' }).simulate('click')
+      expect(closeFunc).toHaveBeenCalled()
+    })
+  })
+})

--- a/__tests__/components/editor/RDFModal.test.js
+++ b/__tests__/components/editor/RDFModal.test.js
@@ -7,18 +7,11 @@ import { shallow } from 'enzyme'
 import RDFModal from '../../../src/components/editor/RDFModal'
 
 describe('<RDFModal />', () => {
-  /*
-   * leaving this here in the unlikely event it's useful for #481 - have reducer produce correct RDF
-   * const data = '{"@context": {"bf": "http://id.loc.gov/ontologies/bibframe/"}, "@graph": [{"@id": "n3-0", "@type": "http://id.loc.gov/ontologies/bibframe/Instance"}]}'
-   */
   const closeFunc = jest.fn()
 
   const saveFunc = jest.fn()
 
-  const wrapper = shallow(<RDFModal.WrappedComponent show={true}
-                                                     rtId="a:b:c"
-                                                     close={closeFunc}
-                                                     save={saveFunc} />)
+  const wrapper = shallow(<RDFModal show={true} rdf="<>" close={closeFunc} save={saveFunc} />)
 
   it('renders the <RDFModal /> component as a Modal', () => {
     expect(wrapper.find(Modal).length).toBe(1)
@@ -28,7 +21,9 @@ describe('<RDFModal />', () => {
       expect(wrapper.find(Modal.Header).length).toBe(1)
     })
     it('has a Cancel link', () => {
-      expect(wrapper.find(Modal.Header).find('a').childAt(0)
+      expect(wrapper.find(Modal.Header).find(Button)
+        .first()
+        .childAt(0)
         .text()).toEqual('Cancel')
     })
     it('has some instructions', () => {
@@ -36,7 +31,9 @@ describe('<RDFModal />', () => {
         .text()).toEqual('If this looks good, then click Save and Publish')
     })
     it('has a save and publish button', () => {
-      expect(wrapper.find(Modal.Header).find(Button).childAt(0)
+      expect(wrapper.find(Modal.Header).find(Button)
+        .last()
+        .childAt(0)
         .text()).toEqual('Save & Publish')
     })
     it('has a Modal.Title inside the Modal.Header', () => {
@@ -46,7 +43,6 @@ describe('<RDFModal />', () => {
       const title = wrapper.find(Modal.Header).find(Modal.Title)
 
       expect(title.childAt(0).text()).toMatch(/RDF Preview/)
-      expect(title.childAt(1).text()).toMatch(/a:b:c/)
     })
   })
   describe('body', () => {
@@ -56,11 +52,11 @@ describe('<RDFModal />', () => {
   })
   describe('save and close buttons', () => {
     it('attenmplts to save the RDF content when save is clicked', () => {
-      wrapper.find(Button, { text: 'Save &amp; Publish' }).simulate('click')
+      wrapper.find('.btn-primary', { text: 'Save &amp; Publish' }).simulate('click')
       expect(saveFunc).toHaveBeenCalled()
     })
     it('closes the modal when the Cancel link is clicked', () => {
-      wrapper.find('a', { text: 'Cancel' }).simulate('click')
+      wrapper.find('.btn-link', { text: 'Cancel' }).simulate('click')
       expect(closeFunc).toHaveBeenCalled()
     })
   })

--- a/__tests__/integration/previewSaveRDF.test.js
+++ b/__tests__/integration/previewSaveRDF.test.js
@@ -1,0 +1,57 @@
+// Copyright 2019 Stanford University see LICENSE for license
+
+import pupExpect from 'expect-puppeteer'
+import Config from '../../src/Config'
+
+describe('Expanding a resource property in a property panel', () => {
+  beforeAll(async () => {
+    jest.setTimeout(60000) // this seems to take around 10s in practice, but be generous, just in case
+    await page.goto('http://127.0.0.1:8888/templates')
+
+    // attempt to enter and submit login info
+    try {
+      await page.waitForSelector('form.login-form')
+      await page.type('form.login-form input[name=username]', Config.cognitoTestUserName)
+      await page.type('form.login-form input[name=password]', Config.cognitoTestUserPass)
+      await page.click('form.login-form button[type=submit]')
+    } catch (error) {
+      console.info(error)
+    }
+
+    // sign out button should only show up after successful login
+    await page.waitForSelector('button.signout-btn')
+  })
+
+  it('loads up a resource template from the list of loaded templates', async () => {
+    await pupExpect(page).toClick('a', { text: 'BIBFRAME Instance' })
+    await pupExpect(page).toMatch('BIBFRAME Instance')
+  })
+
+  it('clicks on one of the property type rows to expand a nested resource', async () => {
+    await pupExpect(page).toClick('a[data-id=\'hasInstance\']')
+    await pupExpect(page).toMatchElement('h5', { text: 'BIBFRAME Instance' })
+  })
+
+  it('clicks on the PreviewRDF button and a modal appears', async () => {
+    await pupExpect(page).toClick('button', { text: 'Preview RDF' })
+    await pupExpect(page).toMatch('RDF Preview')
+    await pupExpect(page).toMatch('If this looks good, then click Save and Publish')
+  })
+
+  it('presents a choice of group to save to', async () => {
+    await pupExpect(page).toClick('button', { text: 'Save & Publish' })
+    await pupExpect(page).toMatch('Which group do you want to save to?')
+    await pupExpect(page).toMatch('Which group do you want to associate this record to?')
+  })
+
+  it('can click on the select menu to choose a group', async () => {
+    await page.select('.group-select-options select', 'stanford')
+    await pupExpect(page).toClick('button', { text: 'Save' })
+  })
+
+  it('for now has a dialog confirming the save function that can be dismissed', async () => {
+    await pupExpect(page.on('dialog', (dialog) => {
+      dialog.dismiss()
+    }))
+  })
+})

--- a/__tests__/sinopiaServer.test.js
+++ b/__tests__/sinopiaServer.test.js
@@ -53,7 +53,7 @@ describe('sinopiaServer', () => {
 
     it('currently just puts up an alert and returns the rdf', () => {
       global.alert = jest.fn()
-      const create = sinopiaServer.publishRDFResource(mockCurrentUser, undefined, rdf)
+      const create = sinopiaServer.publishRDFResource(mockCurrentUser, rdf, undefined)
 
       expect(create).toEqual(rdf)
       expect(global.alert.mock.calls.length).toEqual(1)

--- a/src/Config.js
+++ b/src/Config.js
@@ -71,6 +71,22 @@ class Config {
   static get maxRecordsForQALookups() {
     return process.env.MAX_RECORDS_FOR_QA_LOOKUPS || 8
   }
+
+  static get groupsInSinopia() {
+    return [
+      ['ld4p', 'LD4P'],
+      ['pcc', 'PCC'],
+      ['cub', 'University of Colorado Boulder'],
+      ['cornell', 'Cornell University'],
+      ['harvard', 'Harvard University'],
+      ['nlm', 'National Library of Medicine'],
+      ['stanford', 'Stanford University'],
+      ['ucsd', 'University of California, San Diego'],
+      ['penn', 'University of Pennsylvania'],
+      ['hrc', 'Harry Ransom Center, University of Texas at Austin'],
+      ['wau', 'University of Washington'],
+    ]
+  }
 }
 
 export default Config

--- a/src/components/editor/GroupChoiceModal.jsx
+++ b/src/components/editor/GroupChoiceModal.jsx
@@ -1,0 +1,69 @@
+// Copyright 2018 Stanford University see LICENSE for license
+
+import React, { Component } from 'react'
+import Button from 'react-bootstrap/lib/Button'
+import Modal from 'react-bootstrap/lib/Modal'
+import PropTypes from 'prop-types'
+import Config from '../../Config'
+
+class GroupChoiceModal extends Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      selectedValue: 'ld4p',
+    }
+  }
+
+  updateSelectedValue = (event) => {
+    this.setState({ selectedValue: event.target.value })
+  }
+
+  saveAndClose = () => {
+    this.props.save(this.props.rdf, this.state.selectedValue)
+  }
+
+  render() {
+    return (
+      <div>
+        <Modal show={ this.props.show } bsSize="lg">
+          <Modal.Header className="prop-heading">
+            <button className="close" data-dismiss="alert" aria-label="close" onClick={this.props.close}>&times;</button>
+            <Modal.Title>
+              Which group do you want to save to?
+            </Modal.Title>
+          </Modal.Header>
+          <Modal.Body className="group-panel">
+            <div className="group-select-label">
+              Which group do you want to associate this record to?
+            </div>
+            <div>
+              <form className="group-select-options" >
+                <select defaultValue={ this.state.selectedValue } onBlur={ event => this.updateSelectedValue(event)} >
+                  { Config.groupsInSinopia.map((group, index) => <option key={index} value={ group[0] }>{ group[1] }</option>) }
+                </select>
+                <div className="group-choose-buttons">
+                  <Button className="btn-link" style={{ paddingRight: '20px' }} onClick={ this.props.close }>
+                    Cancel
+                  </Button>
+                  <Button className="btn btn-primary btn-sm" onClick={ this.saveAndClose }>
+                    Save
+                  </Button>
+                </div>
+              </form>
+            </div>
+          </Modal.Body>
+        </Modal>
+      </div>
+    )
+  }
+}
+
+GroupChoiceModal.propTypes = {
+  close: PropTypes.func,
+  save: PropTypes.func,
+  choose: PropTypes.func,
+  show: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+  rdf: PropTypes.string,
+}
+
+export default GroupChoiceModal

--- a/src/components/editor/RDFModal.jsx
+++ b/src/components/editor/RDFModal.jsx
@@ -4,12 +4,13 @@ import React, { Component } from 'react'
 import Button from 'react-bootstrap/lib/Button'
 import Modal from 'react-bootstrap/lib/Modal'
 import PropTypes from 'prop-types'
-import { getAllRdf } from '../../reducers/index'
-import { connect } from 'react-redux'
 
 class RDFModal extends Component {
   constructor(props) {
     super(props)
+    this.state = {
+      showGroupChooser: false,
+    }
   }
 
   render() {
@@ -17,20 +18,20 @@ class RDFModal extends Component {
       <div>
         <Modal show={this.props.show} bsSize="lg">
           <Modal.Header>
-            <div style={{ padding: '20px 0 20px 0' }}>
+            <Modal.Title>
+              RDF Preview
+            </Modal.Title>
+            <div>
               If this looks good, then click Save and Publish
             </div>
             <div style={{ float: 'right', marginTop: '-47px' }}>
-              <a style={{ paddingRight: '20px' }} href="#" onClick={this.props.close}>
+              <Button className="btn-link" style={{ paddingRight: '20px' }} onClick={this.props.close}>
                 Cancel
-              </a>
-              <Button className="btn btn-primary btn-sm" onClick={() => this.props.save(this.props.rdf)}>
+              </Button>
+              <Button className="btn btn-primary btn-sm" onClick={ this.props.save }>
                 Save & Publish
               </Button>
             </div>
-            <Modal.Title>
-              RDF Preview ({this.props.rtId})
-            </Modal.Title>
           </Modal.Header>
           <Modal.Body bsClass={'rdf-modal-content'}>
             <pre>{this.props.rdf}</pre>
@@ -49,11 +50,4 @@ RDFModal.propTypes = {
   rdf: PropTypes.string,
 }
 
-const mapStateToProps = (state, props) => {
-  const result = getAllRdf(state, props)
-
-
-  return { rdf: result }
-}
-
-export default connect(mapStateToProps, null)(RDFModal)
+export default RDFModal

--- a/src/sinopiaServer.js
+++ b/src/sinopiaServer.js
@@ -79,11 +79,16 @@ export const updateResourceTemplate = async (templateObject, group, currentUser)
   return await instance.updateResourceWithHttpInfo(group, templateObject.id, templateObject, { contentType: 'application/json' })
 }
 
-export const publishRDFResource = (currentUser, group, rdf) => {
-  alert(`Your data would be saved in the ${group || 'group'} container, if we supported that yet!`)
+export const publishRDFResource = (currentUser, rdf, group) => {
+  alert(`Your data would be saved in the "${group}" group container, if we supported that yet!`)
 
-  // we will have to transform the rdf to jsonLD somewhere
   const jsonLD = rdf
+
+  /*
+   * we will have to transform the rdf to jsonLD somewhere
+   * just to prove that the rdf gets here...
+   */
+  console.log('RDF is Here!', jsonLD)
 
   /*
    * Right now just return the fake data; eventually this will be the server response below...

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -8,6 +8,11 @@ body {
   background-size: cover;
   background-image: url("home-background.png");
 }
+
+.btn-link {
+  border-color: transparent !important;
+}
+
 .homepage-navbar {
   padding-bottom: 2% ;
   padding-top:2%;
@@ -66,6 +71,33 @@ body {
   border-style: solid;
   border-width: 1px;
   background-color: #F8F6EF;
+}
+
+.group-panel {
+  border-color: #8C8A83;
+  border-style: solid;
+  border-width: 1px;
+  background-color: #F8F6EF;
+  min-height: 200px;
+  padding: 80px;
+}
+
+.group-choose-buttons {
+  float: right;
+  position: relative;
+  top: 40px;
+}
+
+.group-select-label {
+  float: left;
+  padding-right: 20px;
+  position: relative;
+  /*top: 58px;*/
+}
+
+.group-select-options {
+  position: relative;
+  /*top: 70px;*/
 }
 
 .menu-item{


### PR DESCRIPTION
Fixes #597 

![Screen Shot 2019-06-04 at 1 34 03 PM](https://user-images.githubusercontent.com/3093850/58911851-a53a7480-86cd-11e9-98ed-c944a119d1b9.png)
![Screen Shot 2019-06-04 at 1 34 15 PM](https://user-images.githubusercontent.com/3093850/58911852-a53a7480-86cd-11e9-8592-15d07d1d9e33.png)
![Screen Shot 2019-06-04 at 1 34 36 PM](https://user-images.githubusercontent.com/3093850/58911853-a5d30b00-86cd-11e9-82a8-de312f792fdd.png)
![Screen Shot 2019-06-04 at 1 34 54 PM](https://user-images.githubusercontent.com/3093850/58911854-a5d30b00-86cd-11e9-895c-67c93618937d.png)

Granted, on the original design, the Preview RDF was a full page instead of a modal.