### PR TITLE
Render a warning when expanding a template w/ missing RT

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -137,6 +137,13 @@ module.exports = {
   },
   overrides: [
     {
+      // Allow tests to include block statements (idiomatic Jest style)
+      "files": ["__tests__/**"],
+      "rules": {
+        "arrow-body-style": "off"
+      }
+    },
+    {
       // Allow integration tests to use `page` global variable defined by puppeteer
       "files": ["__tests__/integration/**"],
       "rules": {

--- a/__tests__/components/editor/ImportFileZone.test.js
+++ b/__tests__/components/editor/ImportFileZone.test.js
@@ -19,8 +19,8 @@ describe('<ImportFileZone />', () => {
   describe('schema valid', () => {
     describe('schema url in JSON', () => {
       const wrapper = shallow(<ImportFileZone />)
-      let schemaUrl; let
-        template
+      let schemaUrl
+      let template
 
       it('gets the schemaUrl from the resource-template', () => {
         template = require('../../__fixtures__/lcc_v0.2.0.json')
@@ -28,9 +28,12 @@ describe('<ImportFileZone />', () => {
         expect(schemaUrl).toEqual('https://ld4p.github.io/sinopia/schemas/0.2.0/resource-template.json')
       })
 
-      it('displays resource template passing validation', async () => {
-        await wrapper.instance().promiseTemplateValidated(template, schemaUrl)
-        expect(wrapper.state().validTemplate).toBeTruthy()
+      it('resolves the passing RT validation, returning undefined', async () => {
+        template = require('../../__fixtures__/lcc_v0.2.0.json')
+        schemaUrl = wrapper.instance().schemaUrl(template)
+        const resolution = await wrapper.instance().promiseTemplateValidated(template, schemaUrl)
+
+        expect(resolution).toBeUndefined()
       })
 
       it('gets the schemaUrl from the profile', () => {
@@ -39,16 +42,19 @@ describe('<ImportFileZone />', () => {
         expect(schemaUrl).toEqual('https://ld4p.github.io/sinopia/schemas/0.2.0/profile.json')
       })
 
-      it('displays profile passing validation', async () => {
-        await wrapper.instance().promiseTemplateValidated(template, schemaUrl)
-        expect(wrapper.state().validTemplate).toBeTruthy()
+      it('resolves the passing profile validation, returning undefined', async () => {
+        template = require('../../__fixtures__/place_profile_v0.2.0.json')
+        schemaUrl = wrapper.instance().schemaUrl(template)
+        const resolution = await wrapper.instance().promiseTemplateValidated(template, schemaUrl)
+
+        expect(resolution).toBeUndefined()
       })
     })
 
     describe('schema url not in JSON - default schemas used', () => {
       const wrapper = shallow(<ImportFileZone />)
-      let schemaUrl; let
-        template
+      let schemaUrl
+      let template
 
       it('gets the schemaUrl from the resource-template', () => {
         template = require('../../__fixtures__/lcc_no_schema_specified.json')
@@ -56,9 +62,12 @@ describe('<ImportFileZone />', () => {
         expect(schemaUrl).toEqual(`https://ld4p.github.io/sinopia/schemas/${Config.defaultProfileSchemaVersion}/resource-template.json`)
       })
 
-      it('displays resource template passing validation', async () => {
-        await wrapper.instance().promiseTemplateValidated(template, schemaUrl)
-        expect(wrapper.state().validTemplate).toBeTruthy()
+      it('resolves the passing RT validation, returning undefined', async () => {
+        template = require('../../__fixtures__/lcc_no_schema_specified.json')
+        schemaUrl = wrapper.instance().schemaUrl(template)
+        const resolution = await wrapper.instance().promiseTemplateValidated(template, schemaUrl)
+
+        expect(resolution).toBeUndefined()
       })
 
       it('gets the schemaUrl from the profile', () => {
@@ -67,17 +76,20 @@ describe('<ImportFileZone />', () => {
         expect(schemaUrl).toEqual(`https://ld4p.github.io/sinopia/schemas/${Config.defaultProfileSchemaVersion}/profile.json`)
       })
 
-      it('displays profile passing validation', async () => {
-        await wrapper.instance().promiseTemplateValidated(template, schemaUrl)
-        expect(wrapper.state().validTemplate).toBeTruthy()
+      it('resolves the passing profile validation, returning undefined', async () => {
+        template = require('../../__fixtures__/place_profile_no_schema_specified.json')
+        schemaUrl = wrapper.instance().schemaUrl(template)
+        const resolution = await wrapper.instance().promiseTemplateValidated(template, schemaUrl)
+
+        expect(resolution).toBeUndefined()
       })
     })
   })
 
   describe('not schema valid', () => {
     const wrapper = shallow(<ImportFileZone />)
-    let schemaUrl; let
-      template
+    let schemaUrl
+    let template
 
     it('gets the schemaUrl from the resource-template', () => {
       template = require('../../__fixtures__/lcc_v0.2.0_invalid.json')
@@ -85,10 +97,11 @@ describe('<ImportFileZone />', () => {
       expect(schemaUrl).toEqual('https://ld4p.github.io/sinopia/schemas/0.2.0/resource-template.json')
     })
 
-    it('displays an error message when missing required property', async () => {
-      await wrapper.instance().promiseTemplateValidated(template, schemaUrl).catch((err) => {
-        expect(wrapper.state().validTemplate).toBeFalsy()
-        expect(err.toString()).toMatch('should have required property')
+    it('displays an error message when missing required property', () => {
+      template = require('../../__fixtures__/lcc_v0.2.0_invalid.json')
+      schemaUrl = wrapper.instance().schemaUrl(template)
+      return wrapper.instance().promiseTemplateValidated(template, schemaUrl).catch((err) => {
+        return expect(err.toString()).toMatch('should have required property')
       })
     })
 
@@ -98,18 +111,19 @@ describe('<ImportFileZone />', () => {
       expect(schemaUrl).toEqual('https://ld4p.github.io/sinopia/schemas/0.2.0/resource-template.json')
     })
 
-    it('displays an error message when the id is invalid', async () => {
-      await wrapper.instance().promiseTemplateValidated(template, schemaUrl).catch((err) => {
-        expect(wrapper.state().validTemplate).toBeFalsy()
-        expect(err.toString()).toMatch('should match pattern')
+    it('displays an error message when the id is invalid', () => {
+      template = require('../../__fixtures__/lcc_v0.2.0_bad_id.json')
+      schemaUrl = wrapper.instance().schemaUrl(template)
+      return wrapper.instance().promiseTemplateValidated(template, schemaUrl).catch((err) => {
+        return expect(err.toString()).toMatch('should match pattern')
       })
     })
   })
 
   describe('unfindable schema', () => {
     const wrapper = shallow(<ImportFileZone />)
-    let schemaUrl; let
-      template
+    let schemaUrl
+    let template
 
     it('gets the schemaUrl from the resource-template', () => {
       template = require('../../__fixtures__/edition_bad_schema.json')
@@ -117,10 +131,9 @@ describe('<ImportFileZone />', () => {
       expect(schemaUrl).toEqual('https://ld4p.github.io/sinopia/schemas/not-there.json')
     })
 
-    it('displays an error message', async () => {
-      await wrapper.instance().promiseTemplateValidated(template, schemaUrl).catch((err) => {
-        expect(wrapper.state().validTemplate).toBeFalsy()
-        expect(err.toString()).toMatch('Error: error getting json schemas')
+    it('displays an error message', () => {
+      return wrapper.instance().promiseTemplateValidated(template, schemaUrl).catch((err) => {
+        return expect(err.toString()).toMatch('Error: error getting json schemas')
       })
     })
   })

--- a/__tests__/components/editor/ResourceProperty.test.js
+++ b/__tests__/components/editor/ResourceProperty.test.js
@@ -7,58 +7,123 @@ import PropertyActionButtons from '../../../src/components/editor/PropertyAction
 import PropertyTemplateOutline from '../../../src/components/editor/PropertyTemplateOutline'
 
 describe('<ResourceProperty />', () => {
-  const mockInitNewResourceTemplate = jest.fn()
+  describe('happy path', () => {
+    const mockInitNewResourceTemplate = jest.fn()
 
-  const property = {
-    propertyLabel: 'Notes about the Instance',
-    remark: 'This is a great note',
-    propertyURI: 'http://id.loc.gov/ontologies/bibframe/note',
-    type: 'resource',
-    valueConstraint: {
-      valueTemplateRefs: [
-        'resourceTemplate:bf2:Note',
-      ],
-    },
-  }
-
-  const nestedRTs = [{
-    id: 'resourceTemplate:bf2:Note',
-    resourceURI: 'http://id.loc.gov/ontologies/bibframe/Note',
-    resourceLabel: 'Note',
-    propertyTemplates: [
-      {
-        propertyURI: 'http://www.w3.org/2000/01/rdf-schema#label',
-        propertyLabel: 'Note',
-        type: 'literal',
+    const property = {
+      propertyLabel: 'Notes about the Instance',
+      remark: 'This is a great note',
+      propertyURI: 'http://id.loc.gov/ontologies/bibframe/note',
+      type: 'resource',
+      valueConstraint: {
+        valueTemplateRefs: [
+          'resourceTemplate:bf2:Note',
+        ],
       },
-    ],
-  }]
+    }
 
-  const wrapper = shallow(<ResourceProperty.WrappedComponent
-                              propertyTemplate={property}
+    const nestedRTs = [{
+      id: 'resourceTemplate:bf2:Note',
+      resourceURI: 'http://id.loc.gov/ontologies/bibframe/Note',
+      resourceLabel: 'Note',
+      propertyTemplates: [
+        {
+          propertyURI: 'http://www.w3.org/2000/01/rdf-schema#label',
+          propertyLabel: 'Note',
+          type: 'literal',
+        },
+      ],
+    }]
+
+    const wrapper = shallow(<ResourceProperty.WrappedComponent
+              propertyTemplate={property}
+              reduxPath={[]}
+              nestedResourceTemplates={nestedRTs}
+              initNewResourceTemplate={mockInitNewResourceTemplate}
+              handleAddClick={jest.fn()} />)
+
+    it('creates a header section with the resource label', () => {
+      expect(wrapper.find('section h5').text()).toEqual('Note')
+    })
+
+    it('creates a section with the <PropertyActionButtons /> for the resource', () => {
+      expect(wrapper.find(PropertyActionButtons).length).toEqual(1)
+    })
+
+    it('creates a <PropertyTemplateOutline /> for the resource', () => {
+      const propertyTemplateOutline = wrapper.find(PropertyTemplateOutline)
+
+      expect(propertyTemplateOutline.length).toEqual(1)
+      expect(propertyTemplateOutline.props().propertyTemplate).toEqual(nestedRTs[0].propertyTemplates[0])
+      expect(propertyTemplateOutline.props().reduxPath).toEqual(['resourceTemplate:bf2:Note', 'http://www.w3.org/2000/01/rdf-schema#label'])
+      expect(propertyTemplateOutline.props().resourceTemplate).toEqual(nestedRTs[0])
+    })
+
+    it('calls redux to initialize the state with the nested resource', () => {
+      expect(mockInitNewResourceTemplate).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('with a missing nested ref', () => {
+    const mockInitNewResourceTemplate2 = jest.fn()
+
+    const propertyWithMissingRef = {
+      propertyLabel: 'Notes about the Instance',
+      remark: 'This is a great note',
+      propertyURI: 'http://id.loc.gov/ontologies/bibframe/note',
+      type: 'resource',
+      valueConstraint: {
+        valueTemplateRefs: [
+          'resourceTemplate:bf2:Note',
+          'resourceTemplate:bf2:Cruft',
+        ],
+      },
+    }
+
+    const nestedRTsWithoutMissingRef = [{
+      id: 'resourceTemplate:bf2:Note',
+      resourceURI: 'http://id.loc.gov/ontologies/bibframe/Note',
+      resourceLabel: 'Note',
+      propertyTemplates: [
+        {
+          propertyURI: 'http://www.w3.org/2000/01/rdf-schema#label',
+          propertyLabel: 'Note',
+          type: 'literal',
+        },
+      ],
+    }]
+
+    const wrapper = shallow(<ResourceProperty.WrappedComponent
+                              propertyTemplate={propertyWithMissingRef}
                               reduxPath={[]}
-                              nestedResourceTemplates={nestedRTs}
-                              initNewResourceTemplate={mockInitNewResourceTemplate}
+                              nestedResourceTemplates={nestedRTsWithoutMissingRef}
+                              initNewResourceTemplate={mockInitNewResourceTemplate2}
                               handleAddClick={jest.fn()} />)
 
-  it('creates a header section with the resource label', () => {
-    expect(wrapper.find('section h5').text()).toEqual('Note')
-  })
+    it('creates a header section with the resource label', () => {
+      expect(wrapper.find('section h5').text()).toEqual('Note')
+    })
 
-  it('creates a section with the <PropertyActionButtons /> for the resource', () => {
-    expect(wrapper.find(PropertyActionButtons).length).toEqual(1)
-  })
+    it('creates a section with the <PropertyActionButtons /> for the resource', () => {
+      expect(wrapper.find(PropertyActionButtons).length).toEqual(1)
+    })
 
-  it('creates a <PropertyTemplateOutline /> for the resource', () => {
-    const propertyTemplateOutline = wrapper.find(PropertyTemplateOutline)
+    it('creates a <PropertyTemplateOutline /> for the one non-missing resource', () => {
+      const propertyTemplateOutline = wrapper.find(PropertyTemplateOutline)
 
-    expect(propertyTemplateOutline.length).toEqual(1)
-    expect(propertyTemplateOutline.props().propertyTemplate).toEqual(nestedRTs[0].propertyTemplates[0])
-    expect(propertyTemplateOutline.props().reduxPath).toEqual(['resourceTemplate:bf2:Note', 'http://www.w3.org/2000/01/rdf-schema#label'])
-    expect(propertyTemplateOutline.props().resourceTemplate).toEqual(nestedRTs[0])
-  })
+      expect(propertyTemplateOutline.length).toEqual(1)
+      expect(propertyTemplateOutline.props().propertyTemplate).toEqual(nestedRTsWithoutMissingRef[0].propertyTemplates[0])
+      expect(propertyTemplateOutline.props().reduxPath).toEqual(['resourceTemplate:bf2:Note', 'http://www.w3.org/2000/01/rdf-schema#label'])
+      expect(propertyTemplateOutline.props().resourceTemplate).toEqual(nestedRTsWithoutMissingRef[0])
+    })
 
-  it('calls redux to initialize the state with the nested resource', () => {
-    expect(mockInitNewResourceTemplate).toHaveBeenCalledTimes(1)
+    it('renders a warning for the missing resource', () => {
+      expect(wrapper.find('div.alert-warning').text())
+        .toEqual('Warning: this property refers to a missing Resource Template. You cannot edit it until a Resource Template with an ID of resourceTemplate:bf2:Cruft has been imported into the Sinopia Linked Data Editor.')
+    })
+
+    it('calls redux to initialize the state with the nested resource', () => {
+      expect(mockInitNewResourceTemplate2).toHaveBeenCalledTimes(1)
+    })
   })
 })

--- a/__tests__/reducers/index.test.js
+++ b/__tests__/reducers/index.test.js
@@ -74,6 +74,17 @@ describe('Takes a resource template ID and populates the global state', () => {
     },
   ]
 
+  const propertyTemplateWithoutConstraint = [
+    {
+      propertyLabel: 'LITERAL WITH DEFAULT',
+      propertyURI: 'http://id.loc.gov/ontologies/bibframe/heldBy',
+      resourceTemplates: [],
+      type: 'literal',
+      mandatory: 'false',
+      repeatable: 'true',
+    },
+  ]
+
   it('handles the initial state', () => {
     expect(
       selectorReducer(undefined, {}),
@@ -127,6 +138,28 @@ describe('Takes a resource template ID and populates the global state', () => {
       },
     })
   })
+
+  it('allows SET_RESOURCE_TEMPLATE on templates without valueConstraint', () => {
+    shortid.generate = jest.fn().mockReturnValue(0)
+    const result = selectorReducer({
+      selectorReducer: {},
+    }, {
+      type: 'SET_RESOURCE_TEMPLATE',
+      payload: {
+        id: 'resourceTemplate:bf2:Monograph:Instance',
+        propertyTemplates: propertyTemplateWithoutConstraint,
+      },
+    })
+
+    expect(result.selectorReducer).toMatchObject({
+      'resourceTemplate:bf2:Monograph:Instance':
+      {
+        'http://id.loc.gov/ontologies/bibframe/heldBy':
+          {},
+      },
+    })
+  })
+
 
   it('passing a payload to an empty state', () => {
     const emptyStateResult = refreshResourceTemplate({}, {

--- a/src/components/editor/ImportFileZone.jsx
+++ b/src/components/editor/ImportFileZone.jsx
@@ -86,21 +86,17 @@ class ImportFileZone extends Component {
     return schemaUrl
   }
 
-  promiseTemplateValidated = (template, schemaUrl) => new Promise((resolve, reject) => {
-    this.promiseSchemasLoaded(schemaUrl)
-      .then(() => {
-        this.setState({ validTemplate: this.ajv.validate(schemaUrl, template) })
+  promiseTemplateValidated = (template, schemaUrl) => new Promise((resolve, reject) => this.promiseSchemasLoaded(schemaUrl)
+    .then(async () => {
+      const isValid = this.ajv.validate(schemaUrl, template)
 
-        if (!this.state.validTemplate) {
-          reject(new Error(`${util.inspect(this.ajv.errors)}`))
-        }
+      if (!isValid) {
+        return reject(new Error(`${util.inspect(this.ajv.errors)}`))
+      }
 
-        resolve() // w00t!
-      })
-      .catch((err) => {
-        reject(err)
-      })
-  })
+      return resolve() // w00t!
+    })
+    .catch(err => reject(err)))
 
   promiseSchemasLoaded = schemaUrl => new Promise((resolve, reject) => {
     try {

--- a/src/components/editor/ResourceProperty.jsx
+++ b/src/components/editor/ResourceProperty.jsx
@@ -22,6 +22,14 @@ export class ResourceProperty extends Component {
     this.props.propertyTemplate.valueConstraint.valueTemplateRefs.map((rtId) => {
       const resourceTemplate = _.find(this.props.nestedResourceTemplates, ['id', rtId])
 
+      if (resourceTemplate === undefined) {
+        return jsx.push(
+          <div className="alert alert-warning" key={rtId}>
+            <strong>Warning:</strong> this property refers to a missing Resource Template. You cannot edit it until a Resource Template with an ID of <em>{ rtId }</em> has been <a href="/templates">imported</a> into the Sinopia Linked Data Editor.
+          </div>,
+        )
+      }
+
       jsx.push(
         <div className="row" key={shortid.generate()}>
           <section className="col-sm-8">

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -21,13 +21,12 @@ const inputPropertySelector = (state, props) => {
 }
 
 /*
- * TODO: Renable use of reselect's createSelector, will need to adjust
+ * TODO: Re-enable use of reselect's createSelector, will need to adjust
  * individual components InputLiteral, InputLookupQA, InputListLOC, etc.,
  * see https://github.com/reduxjs/reselect#sharing-selectors-with-props-across-multiple-component-instances
  */
 export const getProperty = (state, props) => {
   const result = inputPropertySelector(state, props)
-
 
   return result.items || []
 }
@@ -56,7 +55,7 @@ export const populatePropertyDefaults = (propertyTemplate) => {
   if (propertyTemplate === undefined || propertyTemplate === null || Object.keys(propertyTemplate).length < 1) {
     return defaults
   }
-  if (propertyTemplate.valueConstraint.defaults && propertyTemplate.valueConstraint.defaults.length > 0) {
+  if (propertyTemplate?.valueConstraint?.defaults && propertyTemplate.valueConstraint.defaults.length > 0) {
     propertyTemplate.valueConstraint.defaults.map((row) => {
       defaults.push({
         id: makeShortID(),


### PR DESCRIPTION
Fixes #602

This PR fixes two errors referenced in #602 and supersedes #613.

First, it fixes the assumption made in `src/reducers/index.js` that all property templates have `.valueConstraint.defaults` defined; some resource templates lack a valueConstraint` so this is not true.

Second, in the `ResourceProperty` component, if a referenced resource template is undefined, render a warning message instead of throwing an error. (Sinopia users expect to be able to import resource templates referencing other resource templates which have not yet been created.) @michelleif Here's what the UI change looks like:

![Screenshot from 2019-06-04 13-09-41](https://user-images.githubusercontent.com/131982/58912427-dcf5ec00-86ce-11e9-942e-f053a41ee1ed.png)

Also includes these maintenance bits, added opportunistically:

* Avoid stashing values in `ImportFileZone` component state when not necessary. This also follows a React guideline of not calling `this.state` immediately after `this.setState()` with the same value since there may be a delay in state updating
* Tweak `ImportFileZone` test so that it does not assume sequential test runs and break `let` statements onto their own lines
* Allow `arrow-body-style` ESLint violations in tests to permit Jest idiomatic style

