### PR TITLE
Property label links open new window/tab.

### DIFF
--- a/src/components/editor/PropertyLabel.jsx
+++ b/src/components/editor/PropertyLabel.jsx
@@ -31,7 +31,8 @@ export class PropertyLabel extends Component {
     }
 
     const urlLabel = (
-      <a href={url} className="prop-remark" alt={property.remark} key={key} >
+      <a href={url} className="prop-remark" alt={property.remark} key={key}
+         target="_blank" rel="noopener noreferrer">
         <span className="prop-remark">{property.propertyLabel}</span>
       </a>
     )


### PR DESCRIPTION
If you click the link in the property label you are taken out of the editor. If you then use the back button, the state is lost.