### PR TITLE
revised text for new release

### DIFF
--- a/src/components/NewsItem.jsx
+++ b/src/components/NewsItem.jsx
@@ -6,14 +6,16 @@ const NewsItem = () => (
   <div className="news-item">
     <h1> What&#8217;s New </h1>
     <ul>
-      <li>Release 0.2.0 is live, including these features</li>
+      <li>Release 0.3.0 is live, including these features</li>
       <ul>
-        <li>Create profiles in Profile Editor and load into Linked Data Editor.
+        <li>User login.
         </li>
-        <li>Specify lookups via Questioning Authority in Profile Editor, and do lookups in the Linked Data Editor.
+        <li>Adding and updating Resource Templates.
+        </li>
+        <li>Opening Resource Templates to see how they behave in cataloging.
         </li>
       </ul>
-      <li> <a href="https://github.com/LD4P/sinopia/wiki/">User support page is live</a>
+      <li>For release notes and the latest point releases, see <a href="https://github.com/LD4P/sinopia/wiki/Latest-Release,-What's-Next,-Release-Notes">Latest Release, What's Next, Release Notes</a> on the <a href="https://github.com/LD4P/sinopia/wiki/">Sinopia help site</a>.
       </li>
     </ul>
   </div>

--- a/src/components/NewsItem.jsx
+++ b/src/components/NewsItem.jsx
@@ -15,7 +15,7 @@ const NewsItem = () => (
         <li>Opening Resource Templates to see how they behave in cataloging.
         </li>
       </ul>
-      <li>For release notes and the latest point releases, see <a href="https://github.com/LD4P/sinopia/wiki/Latest-Release,-What's-Next,-Release-Notes">Latest Release, What's Next, Release Notes</a> on the <a href="https://github.com/LD4P/sinopia/wiki/">Sinopia help site</a>.
+      <li>For release notes and the latest point releases, see the <a href="https://github.com/LD4P/sinopia/wiki/">Sinopia help site</a>.
       </li>
     </ul>
   </div>

--- a/src/components/NewsPanel.jsx
+++ b/src/components/NewsPanel.jsx
@@ -14,7 +14,7 @@ class NewsPanel extends Component {
         <div className="panel panel-news">
           <div className="panel-body">
             <div className="row">
-              <div className="col-md-7">
+              <div className="col-md-17">
                 <NewsItem />
               </div>
             </div>


### PR DESCRIPTION
- revised text on homepage for release 0.3.0
- made the column for the news item wider so it didn't wrap weirdly (login fields used to be to the right of the news panel so we needed the narrower column previously)