### PR TITLE
Don't allow constructors to change state

### DIFF
--- a/src/components/editor/property/InputListLOC.jsx
+++ b/src/components/editor/property/InputListLOC.jsx
@@ -16,13 +16,20 @@ class InputListLOC extends Component {
       options: [],
       defaults: defaultValuesFromPropertyTemplate(this.props.propertyTemplate),
     }
+  }
 
+  componentDidMount() {
+    this._isMounted = true
     if (this.state.defaults.length > 0) {
       this.setPayLoad(this.state.defaults)
     } else {
       // Property templates do not require defaults but we like to know when this happens
       console.info(`no defaults defined in property template: ${JSON.stringify(this.props.propertyTemplate)}`)
     }
+  }
+
+  componentWillUnmount() {
+    this._isMounted = false
   }
 
   setPayLoad(items) {
@@ -110,7 +117,9 @@ const mapStateToProps = state => ({ ...state })
 
 const mapDispatchToProps = dispatch => ({
   handleSelectedChange(selected) {
-    dispatch(changeSelections(selected))
+    if (this._isMounted) {
+      dispatch(changeSelections(selected))
+    }
   },
 })
 


### PR DESCRIPTION
State change can happen once it's mounted via componentDidMount()

Fixes this error:

<img width="1568" alt="Screen Shot 2019-06-05 at 8 57 57 PM" src="https://user-images.githubusercontent.com/92044/59001569-a99d8500-87d4-11e9-8986-8a2fb4efee08.png">
