### PR TITLE
Raise alert when the signout fails

### DIFF
--- a/__tests__/components/LoginPanel.test.js
+++ b/__tests__/components/LoginPanel.test.js
@@ -9,6 +9,7 @@ import LoginPanel from '../../src/components/LoginPanel'
 import Config from '../../src/Config'
 import CognitoUtils from '../../src/CognitoUtils'
 
+global.alert = jest.fn().mockImplementationOnce(() => {});
 
 describe('<LoginPanel /> when the user is not authenticated', () => {
   const wrapper = shallow(<LoginPanel.WrappedComponent />)
@@ -100,6 +101,7 @@ describe('<LoginPanel /> when the user is authenticated', () => {
       wrapper.find('button.signout-btn').simulate('click')
       expect(signout).not.toHaveBeenCalled()
       expect(signoutSpy).toHaveBeenCalled()
+      expect(global.alert).toHaveBeenCalled()
     })
   })
 })

--- a/__tests__/components/LoginPanel.test.js
+++ b/__tests__/components/LoginPanel.test.js
@@ -9,7 +9,7 @@ import LoginPanel from '../../src/components/LoginPanel'
 import Config from '../../src/Config'
 import CognitoUtils from '../../src/CognitoUtils'
 
-global.alert = jest.fn().mockImplementationOnce(() => {});
+global.alert = jest.fn().mockImplementationOnce(() => {})
 
 describe('<LoginPanel /> when the user is not authenticated', () => {
   const wrapper = shallow(<LoginPanel.WrappedComponent />)

--- a/src/components/LoginPanel.jsx
+++ b/src/components/LoginPanel.jsx
@@ -67,7 +67,7 @@ class LoginPanel extends Component {
     const currentUser = this.props.currentUser
     const currentSession = this.props.currentSession
     const authenticationError = this.props.authenticationError
-  
+
     const currentUserInfoPanel = (
       <div className="row logged-in-user-info">
         <div>current cognito user: { currentUser ? currentUser.username : null }</div>

--- a/src/components/LoginPanel.jsx
+++ b/src/components/LoginPanel.jsx
@@ -57,6 +57,7 @@ class LoginPanel extends Component {
       },
       onFailure: (err) => {
         // TODO: capture error in state so you can display an error somewhere in the UI
+        alert(err.message)
         console.error(err)
       },
     })
@@ -66,7 +67,7 @@ class LoginPanel extends Component {
     const currentUser = this.props.currentUser
     const currentSession = this.props.currentSession
     const authenticationError = this.props.authenticationError
-
+  
     const currentUserInfoPanel = (
       <div className="row logged-in-user-info">
         <div>current cognito user: { currentUser ? currentUser.username : null }</div>


### PR DESCRIPTION
Fixes #594 

This raises an alert so the user is aware that the signout failed. Since jest does not implement the window.alert method specifically, a `global.alert` declaration is required to avoid a `window.alert is not implemented` error message.