### PR TITLE
PropertyTemplateOutline does not need initNewResourceTemplate

### DIFF
--- a/src/components/editor/property/PropertyTemplateOutline.jsx
+++ b/src/components/editor/property/PropertyTemplateOutline.jsx
@@ -140,7 +140,6 @@ PropertyTemplateOutline.propTypes = {
   addButtonDisabled: PropTypes.bool,
   handleAddClick: PropTypes.func,
   handleCollapsed: PropTypes.func,
-  initNewResourceTemplate: PropTypes.func,
   isRequired: PropTypes.func,
   propertyTemplate: PropTypes.object,
   reduxPath: PropTypes.array,

--- a/src/components/editor/property/ResourceProperty.jsx
+++ b/src/components/editor/property/ResourceProperty.jsx
@@ -60,7 +60,6 @@ export class ResourceProperty extends Component {
                                    propertyTemplate={rtProperty}
                                    reduxPath={newReduxPath}
                                    addButtonDisabled={isAddDisabled}
-                                   initNewResourceTemplate={this.props.initNewResourceTemplate}
                                    resourceTemplate={resourceTemplate} />,
         )
       })


### PR DESCRIPTION
This is just cleanup.