### PR TITLE
Simple integration test for unauthenticated users

### DIFF
--- a/__tests__/integration/unauthenticatedNavigation.test.js
+++ b/__tests__/integration/unauthenticatedNavigation.test.js
@@ -7,8 +7,10 @@ describe('When an unauthenticated user tries to access resource templates', () =
     jest.setTimeout(60000) // this seems to take around 10s in practice, but be generous, just in case
     await page.goto('http://127.0.0.1:8888/templates')
 
-    // Attempt to logout
-    // This try block is necessary to avoid failing after logout
+    /*
+     * Attempt to logout
+     * This try block is necessary to avoid failing after logout
+     */
     try {
       await page.waitForSelector('button.signout-btn')
       await page.click('button.signout-btn')

--- a/__tests__/integration/unauthenticatedNavigation.test.js
+++ b/__tests__/integration/unauthenticatedNavigation.test.js
@@ -19,6 +19,10 @@ describe('When an unauthenticated user tries to access resource templates', () =
     }
   })
 
+  it('displays the login form', async () => {
+    await page.waitForSelector('form.login-form')
+  })
+
   it('does not display "Available Resource Templates in Sinopia"', async () => {
     await expect(page).not.toMatch('Available Resource Templates in Sinopia')
   })

--- a/__tests__/integration/unauthenticatedNavigation.test.js
+++ b/__tests__/integration/unauthenticatedNavigation.test.js
@@ -1,0 +1,23 @@
+// Copyright 2019 Stanford University see LICENSE for license
+import expect from 'expect-puppeteer'
+import 'isomorphic-fetch'
+
+describe('When an unauthenticated user tries to access resource templates', () => {
+  beforeAll(async () => {
+    jest.setTimeout(60000) // this seems to take around 10s in practice, but be generous, just in case
+    await page.goto('http://127.0.0.1:8888/templates')
+
+    // Attempt to logout
+    // This try block is necessary to avoid failing after logout
+    try {
+      await page.waitForSelector('button.signout-btn')
+      await page.click('button.signout-btn')
+      } catch (error) {
+      console.info(error)
+    }
+  })
+
+  it('does not display "Available Resource Templates in Sinopia"', async () => {
+    await expect(page).not.toMatch('Available Resource Templates in Sinopia')
+  })
+})

--- a/__tests__/integration/unauthenticatedNavigation.test.js
+++ b/__tests__/integration/unauthenticatedNavigation.test.js
@@ -12,7 +12,7 @@ describe('When an unauthenticated user tries to access resource templates', () =
     try {
       await page.waitForSelector('button.signout-btn')
       await page.click('button.signout-btn')
-      } catch (error) {
+    } catch (error) {
       console.info(error)
     }
   })


### PR DESCRIPTION
This is just a simple (and possibly not useful) pass at an integration test to verify that a logged out user cannot access the resource templates that require authentication. This is part of #421 which is has some testing already complete in other PRs.