### PR TITLE
Change default display label for Typeahead component

### DIFF
--- a/__tests__/components/editor/property/InputLang.test.js
+++ b/__tests__/components/editor/property/InputLang.test.js
@@ -52,6 +52,7 @@ describe('<InputLang />', () => {
 
     wrapper.find('#langComponent').simulate('focus', event(wrapper))
     expect(wrapper.state().options[0]).toEqual(opts)
+    expect(wrapper.find('TypeaheadContainer(WrappedTypeahead)').props().emptyLabel).toEqual('retrieving list of languages...')
 
     wrapper.find('#langComponent').simulate('change', event(wrapper))
     expect(wrapper.state().selected[0]).toEqual(opts)

--- a/src/components/editor/property/InputLang.jsx
+++ b/src/components/editor/property/InputLang.jsx
@@ -29,13 +29,13 @@ class InputLang extends Component {
     const uri = Object.getOwnPropertyDescriptor(item, '@id').value
     const labelArrayDescr = Object.getOwnPropertyDescriptor(item, 'http://www.loc.gov/mads/rdf/v1#authoritativeLabel')
 
-    // There are some odd entries, so ignoring if don't have labels.
+    // Some of the LOC items do not have labels so ignore them.
     if (!labelArrayDescr) return result
     const labelArray = labelArrayDescr.value
 
-    // Looking for English label
     let label = null
 
+    // Looking for English label
     labelArray.forEach((langItem) => {
       if (langItem['@language'] === 'en') {
         label = langItem['@value']
@@ -57,6 +57,7 @@ class InputLang extends Component {
       options: this.state.options,
       selected: this.state.selected,
       emptyLabel: 'retrieving list of languages...',
+      autoFocus: true,
     }
 
     return (
@@ -64,7 +65,6 @@ class InputLang extends Component {
         <label htmlFor="langComponent">Select language for {this.props.textValue}
           <Typeahead
             onFocus={() => {
-              // onFocus seems to get called multiple times.
               if (this.state.isLoading) {
                 return
               }

--- a/src/components/editor/property/InputLang.jsx
+++ b/src/components/editor/property/InputLang.jsx
@@ -56,6 +56,7 @@ class InputLang extends Component {
       isLoading: this.state.isLoading,
       options: this.state.options,
       selected: this.state.selected,
+      emptyLabel: 'retrieving list of languages...',
     }
 
     return (


### PR DESCRIPTION
The default Typeahead component `emptyLabel` is "no matches found." Sometimes the list lookup to LOC takes a couple of seconds, so changing the label to something more user friendly might help avoid confusion.