### PR TITLE
Fix undefined label in the InputLookupQA component

### DIFF
--- a/__tests__/Utilities.test.js
+++ b/__tests__/Utilities.test.js
@@ -162,7 +162,7 @@ describe('Utilities', () => {
     })
 
     it('returns an array with an object otherwise', () => {
-      const propertyTemplate = {
+      const propertyTemplateWithDefaultsAndLabel = {
         valueConstraint: {
           defaults: [
             {
@@ -173,9 +173,27 @@ describe('Utilities', () => {
         },
       }
 
-      expect(defaultValuesFromPropertyTemplate(propertyTemplate)).toEqual([{
+      expect(defaultValuesFromPropertyTemplate(propertyTemplateWithDefaultsAndLabel)).toEqual([{
         id: 'http://id.loc.gov/vocabulary/mcolor/mul',
         label: 'color',
+        uri: 'http://id.loc.gov/vocabulary/mcolor/mul',
+      }])
+    })
+
+    it('returns the uri in place of the label if the label is undefined', () => {
+      const propertyTemplateWithDefaultsNoLabel = {
+        valueConstraint: {
+          defaults: [
+            {
+              defaultURI: 'http://id.loc.gov/vocabulary/mcolor/mul',
+            },
+          ],
+        },
+      }
+
+      expect(defaultValuesFromPropertyTemplate(propertyTemplateWithDefaultsNoLabel)).toEqual([{
+        id: 'http://id.loc.gov/vocabulary/mcolor/mul',
+        label: 'http://id.loc.gov/vocabulary/mcolor/mul',
         uri: 'http://id.loc.gov/vocabulary/mcolor/mul',
       }])
     })

--- a/__tests__/sinopiaServerSpoof.test.js
+++ b/__tests__/sinopiaServerSpoof.test.js
@@ -10,19 +10,19 @@ jest.spyOn(Config, 'spoofSinopiaServer', 'get').mockReturnValue(true)
 
 describe('sinopiaServerSpoof', () => {
   describe('resourceTemplateIds', () => {
-    it('array of length 19', () => {
-      expect(resourceTemplateIds).toHaveLength(19)
+    it('array of length 23', () => {
+      expect(resourceTemplateIds).toHaveLength(23)
     })
     it('resourceTemplateId is in expected format', () => {
       resourceTemplateIds.forEach((id) => {
-        expect(id).toMatch(/^resourceTemplate:((bf2)|(bflc)):.*/)
+        expect(id).toMatch(/^.*:.*:.*/)
       })
     })
   })
 
   describe('resourceTemplateId2Json', () => {
-    it('array of length 19', () => {
-      expect(resourceTemplateId2Json).toHaveLength(19)
+    it('array of length 23', () => {
+      expect(resourceTemplateId2Json).toHaveLength(23)
     })
     it('mapping has id', () => {
       expect(resourceTemplateId2Json[0].id).toBe('resourceTemplate:bf2:Monograph:Instance')
@@ -97,6 +97,10 @@ describe('sinopiaServerSpoof', () => {
               'http://spoof.trellis.io/ld4p/resourceTemplate:bf2:Item:ItemAcqSource',
               'http://spoof.trellis.io/ld4p/resourceTemplate:bf2:Item:Enumeration',
               'http://spoof.trellis.io/ld4p/resourceTemplate:bf2:Item:Chronology',
+              'http://spoof.trellis.io/ld4p/rt:bf2:AdminMetadata',
+              'http://spoof.trellis.io/ld4p/rt:bf2:AdminMetadata:Status',
+              'http://spoof.trellis.io/ld4p/rt:rda:item:monograph',
+              'http://spoof.trellis.io/ld4p/rt:rda:manifestation:monograph',
             ],
           },
         },

--- a/src/Utilities.js
+++ b/src/Utilities.js
@@ -16,11 +16,18 @@ export const defaultValuesFromPropertyTemplate = (propertyTemplate) => {
   // Use safe navigation to deal with differently shaped property templates
   const defaultValue = propertyTemplate?.valueConstraint?.defaults?.[0]
 
+  // Use the default URI for the literal value if the lliteral is undefined
+  const defaultLiteral = defaultValue?.defaultLiteral
+
+  const defaultURI = defaultValue?.defaultURI
+
+  const defaultLabel = defaultLiteral || defaultURI
+
   if (!defaultValue) return []
 
   return [{
     id: defaultValue.defaultURI,
-    label: defaultValue.defaultLiteral,
+    label: defaultLabel,
     uri: defaultValue.defaultURI,
   }]
 }

--- a/src/sinopiaServerSpoof.js
+++ b/src/sinopiaServerSpoof.js
@@ -19,6 +19,10 @@ const retentionRt = require('../static/spoofedFilesFromServer/fromSinopiaServer/
 const itemAcqSourceRt = require('../static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/ItemAcqSource.json')
 const enumerationRt = require('../static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/ItemEnumeration.json')
 const chronologyRt = require('../static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/ItemChronology.json')
+const adminMetaRt = require('../static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/adminMetadata.json')
+const adminMetaStatusRt = require('../static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/adminMetadataStatus.json')
+const rdaItemMonoRt = require('../static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/rdaItemMonograph.json')
+const rdaManifestMonoRt = require('../static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/RDAMainifestationMonograph.json')
 
 export const resourceTemplateId2Json = [
   { id: 'resourceTemplate:bf2:Monograph:Instance', json: monographInstanceRt },
@@ -40,6 +44,10 @@ export const resourceTemplateId2Json = [
   { id: 'resourceTemplate:bf2:Item:ItemAcqSource', json: itemAcqSourceRt },
   { id: 'resourceTemplate:bf2:Item:Enumeration', json: enumerationRt },
   { id: 'resourceTemplate:bf2:Item:Chronology', json: chronologyRt },
+  { id: 'rt:bf2:AdminMetadata', json: adminMetaRt },
+  { id: 'rt:bf2:AdminMetadata:Status', json: adminMetaStatusRt },
+  { id: 'rt:rda:item:monograph', json: rdaItemMonoRt },
+  { id: 'rt:rda:manifestation:monograph', json: rdaManifestMonoRt },
 ]
 
 const emptyTemplate = { propertyTemplates: [{}] }

--- a/static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/RDAMainifestationMonograph.json
+++ b/static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/RDAMainifestationMonograph.json
@@ -1,0 +1,937 @@
+{
+  "id": "rt:rda:manifestation:monograph",
+  "resourceURI": "http://rdaregistry.info/Elements/c/C10007",
+  "resourceLabel": "RT RDA Manifestation for monographs",
+  "author": "Crystal Clements (cec23@uw.edu)",
+  "date": "2019-05-01",
+  "schema": "https://ld4p.github.io/sinopia/schemas/0.0.9/resource-template.json",
+  "propertyTemplates": [
+    {
+      "propertyLabel": "Lookup",
+      "propertyURI": "http://rdaregistry.info/Elements/c/C10007",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "lookup",
+      "remark": "Lookup",
+      "valueConstraint": {
+        "useValuesFrom": [
+          "dummy"
+        ]
+      }
+    },
+    {
+      "propertyLabel": "Administrative Metadata for Manifestation",
+      "propertyURI": "http://id.loc.gov/ontologies/bibframe/adminMetadata",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "resource",
+      "remark": "",
+      "valueConstraint": {
+        "valueTemplateRefs": [
+          "rt:bf2:AdminMetadata"
+        ]
+      }
+    },
+    {
+      "propertyLabel": "has title proper (RDA 2.3.2)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30156",
+      "mandatory": "true",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/2.3.2.html"
+    },
+    {
+      "propertyLabel": "has parallel title proper (RDA 2.3.3)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30203",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/2.3.3.html"
+    },
+    {
+      "propertyLabel": "has other title information (RDA 2.3.4)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30142",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/2.3.4.html"
+    },
+    {
+      "propertyLabel": "has parallel other title information (RDA 2.3.5)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30151",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/2.3.5.html"
+    },
+    {
+      "propertyLabel": "has variant title of manifestation (RDA 2.3.6)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30128",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/2.3.6.html"
+    },
+    {
+      "propertyLabel": "has statement of responsibility relating to title proper (RDA 2.4.2)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30105",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/2.4.2.html"
+    },
+    {
+      "propertyLabel": "has parallel statement of responsibility relating to title proper (RDA 2.4.3)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30116",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/2.4.3.html"
+    },
+    {
+      "propertyLabel": "has designation of edition (RDA 2.5.2)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30133",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/2.5.2.html"
+    },
+    {
+      "propertyLabel": "has parallel designation of edition (RDA 2.5.3)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30013",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/2.5.3.html"
+    },
+    {
+      "propertyLabel": "has statement of responsibility relating to edition (RDA 2.5.4)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30121",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/2.5.4.html"
+    },
+    {
+      "propertyLabel": "has parallel statement of responsibility relating to edition (RDA 2.5.5)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30115",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/2.5.5.html"
+    },
+    {
+      "propertyLabel": "has designation of named revision of edition (RDA 2.5.6)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30132",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/2.5.6.html"
+    },
+    {
+      "propertyLabel": "has parallel designation of named revision of edition (RDA 2.5.7)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30012",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/2.5.7.html"
+    },
+    {
+      "propertyLabel": "has statement of responsibility relating to named revision of edition (RDA 2.5.8)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30118",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/2.5.8.html"
+    },
+    {
+      "propertyLabel": "has place of production (RDA 2.7.2)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30086",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/2.7.2.html"
+    },
+    {
+      "propertyLabel": "has parallel place of production (RDA 2.7.3)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30091",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/2.7.3.html"
+    },
+    {
+      "propertyLabel": "has name of producer (RDA 2.7.4)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30174",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/2.7.4.html"
+    },
+    {
+      "propertyLabel": "has parallel name of producer (RDA 2.7.5)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30094",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/2.7.5.html"
+    },
+    {
+      "propertyLabel": "has date of production (RDA 2.7.6)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30009",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/2.7.6.html"
+    },
+    {
+      "propertyLabel": "has place of publication (RDA 2.8.2)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30088",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/2.8.2.html"
+    },
+    {
+      "propertyLabel": "has parallel place of publication (RDA 2.8.3)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30092",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/2.8.3.html"
+    },
+    {
+      "propertyLabel": "has name of publisher (RDA 2.8.4)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30176",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/2.8.4.html"
+    },
+    {
+      "propertyLabel": "has parallel name of publisher (RDA 2.8.5)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30095",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/2.8.5.html"
+    },
+    {
+      "propertyLabel": "has date of publication (RDA 2.8.6)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30011",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/2.8.6.html"
+    },
+    {
+      "propertyLabel": "has place of distribution (RDA 2.9.2)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30085",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/2.9.2.html"
+    },
+    {
+      "propertyLabel": "has parallel place of distribution (RDA 2.9.3)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30089",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/2.9.3.html"
+    },
+    {
+      "propertyLabel": "has name of distributor (RDA 2.9.4)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30173",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/2.9.4.html"
+    },
+    {
+      "propertyLabel": "has date of distribution (RDA 2.9.6)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30008",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/2.9.6.html"
+    },
+    {
+      "propertyLabel": "has place of manufacture (RDA 2.10.2)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30087",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/2.10.2.html"
+    },
+    {
+      "propertyLabel": "has parallel place of manufacture (RDA 2.10.3)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30090",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/2.10.3.html"
+    },
+    {
+      "propertyLabel": "has name of manufacturer (RDA 2.10.4)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30175",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/2.10.4.html"
+    },
+    {
+      "propertyLabel": "has parallel name of manufacturer (RDA 2.10.5)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30049",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/2.10.5.html"
+    },
+    {
+      "propertyLabel": "has date of manufacture (RDA 2.10.6)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30010",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/2.10.6.html"
+    },
+    {
+      "propertyLabel": "has copyright date (RDA 2.11)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30007",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/2.11.html",
+      "valueConstraint": {
+        "defaults": [
+          {
+            "defaultLiteral": "©"
+          }
+        ]
+      }
+    },
+    {
+      "propertyLabel": "has title of series (RDA 2.12.2)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30157",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/2.12.2.html"
+    },
+    {
+      "propertyLabel": "has parallel title of series (RDA 2.12.3)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30204",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/2.12.3.html"
+    },
+    {
+      "propertyLabel": "has other title information of series (RDA 2.12.4)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30143",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/2.12.4.html"
+    },
+    {
+      "propertyLabel": "has parallel other title information of series (RDA 2.12.5)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30152",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/2.12.5.html"
+    },
+    {
+      "propertyLabel": "has statement of responsibility relating to series (RDA 2.12.6)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30119",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/2.12.6.html"
+    },
+    {
+      "propertyLabel": "has parallel statement of responsibility relating to series (RDA 2.12.7)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30113",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/2.12.7.html"
+    },
+    {
+      "propertyLabel": "has numbering within sequence (RDA 2.12.9)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30014",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/2.12.9.html"
+    },
+    {
+      "propertyLabel": "has mode of issuance (RDA 2.13)(Lookup)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30003",
+      "mandatory": "false",
+      "repeatable": "false",
+      "type": "lookup",
+      "remark": "http://access.rdatoolkit.org/2.13.html",
+      "valueConstraint": {
+        "useValuesFrom": [
+          "http://id.loc.gov/vocabulary/issuance",
+          "http://rdaregistry.info/termList/ModeIssue"
+        ],
+        "defaults": [
+          {
+            "defaultURI": "http://rdaregistry.info/termList/ModeIssue/1001",
+            "defaultLiteral": "single unit"
+          },
+          {
+            "defaultURI": "http://id.loc.gov/vocabulary/issuance/mono",
+            "defaultLiteral": "single unit"
+          }
+        ]
+      }
+    },
+    {
+      "propertyLabel": "has mode of issuance (RDA 2.13)(If lookup fails: record URI if available or authorized access point)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30003",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/2.13.html",
+      "valueConstraint": {
+        "defaults": [
+          {
+            "defaultURI": "http://rdaregistry.info/termList/ModeIssue/1001",
+            "defaultLiteral": "single unit"
+          },
+          {
+            "defaultURI": "http://id.loc.gov/vocabulary/issuance/mono",
+            "defaultLiteral": "single unit"
+          }
+        ]
+      }
+    },
+    {
+      "propertyLabel": "has note on manifestation (RDA 2.17)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30137",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/2.17.html"
+    },
+    {
+      "propertyLabel": "has note on title (RDA 2.17.2)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/datatype/P30063",
+      "mandatory": "false",
+      "repeatable": "false",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/2.17.2.html"
+    },
+    {
+      "propertyLabel": "has note on statement of responsibility (RDA 2.17.3)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/datatype/P30057",
+      "mandatory": "false",
+      "repeatable": "false",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/2.17.3.html"
+    },
+    {
+      "propertyLabel": "has note on edition statement (RDA 2.17.4)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/datatype/P30064",
+      "mandatory": "false",
+      "repeatable": "false",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/2.17.4.html"
+    },
+    {
+      "propertyLabel": "has note on numbering of sequence (RDA 2.17.5)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30062",
+      "mandatory": "false",
+      "repeatable": "false",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/2.17.5.html"
+    },
+    {
+      "propertyLabel": "has note on production statement (RDA 2.17.6)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30054",
+      "mandatory": "false",
+      "repeatable": "false",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/2.17.6.html"
+    },
+    {
+      "propertyLabel": "has note on publication statement (RDA 2.17.7)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30055",
+      "mandatory": "false",
+      "repeatable": "false",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/2.17.7.html"
+    },
+    {
+      "propertyLabel": "has note on distribution statement (RDA 2.17.8)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30052",
+      "mandatory": "false",
+      "repeatable": "false",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/2.17.8.html"
+    },
+    {
+      "propertyLabel": "has note on manufacture statement (RDA 2.17.9)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30053",
+      "mandatory": "false",
+      "repeatable": "false",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/2.17.9.html"
+    },
+    {
+      "propertyLabel": "has note on copyright date (RDA 2.17.10)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30059",
+      "mandatory": "false",
+      "repeatable": "false",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/2.17.10.html"
+    },
+    {
+      "propertyLabel": "has note on series statement (RDA 2.17.11)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30058",
+      "mandatory": "false",
+      "repeatable": "false",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/2.17.11.html"
+    },
+    {
+      "propertyLabel": "has note on issue, part, or iteration used as basis for identification of manifestation (RDA 2.17.13)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30050",
+      "mandatory": "false",
+      "repeatable": "false",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/2.17.13.html"
+    },
+    {
+      "propertyLabel": "has note on identifier for manifestation (RDA 2.17.14)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30260",
+      "mandatory": "false",
+      "repeatable": "false",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/2.17.14.html"
+    },
+    {
+      "propertyLabel": "has media type (RDA 3.2)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30002",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "lookup",
+      "remark": "http://access.rdatoolkit.org/3.2.html",
+      "valueConstraint": {
+        "useValuesFrom": [
+          "http://www.rdaregistry.info/termList/RDAMediaType/"
+        ]
+      }
+    },
+    {
+      "propertyLabel": "has media type (RDA 3.2)(If lookup fails: record URI if available or authorized access point)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30002",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/3.2.html"
+    },
+    {
+      "propertyLabel": "has carrier type (RDA 3.3)(Lookup)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30001",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "lookup",
+      "remark": "http://access.rdatoolkit.org/3.3.html",
+      "valueConstraint": {
+        "useValuesFrom": [
+          "http://www.rdaregistry.info/termList/RDACarrierType/"
+        ]
+      }
+    },
+    {
+      "propertyLabel": "has carrier type (RDA 3.3)(If lookup fails: record URI if available or authorized access point)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30001",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/3.3.html"
+    },
+    {
+      "propertyLabel": "has extent of manifestation (RDA 3.4)(lookup)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30182",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "lookup",
+      "remark": "http://access.rdatoolkit.org/3.4.html",
+      "valueConstraint": {
+        "useValuesFrom": [
+          "http://www.rdaregistry.info/termList/RDACarrierEU/"
+        ]
+      }
+    },
+    {
+      "propertyLabel": "has extent of manifestation (RDA 3.4)(If lookup fails: record URI if available or authorized access point)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30182",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/3.4.html"
+    },
+    {
+      "propertyLabel": "has dimensions (RDA 3.5)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30169",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/3.5.html"
+    },
+    {
+      "propertyLabel": "has base material (RDA 3.6)(Lookup)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30208",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "lookup",
+      "remark": "http://access.rdatoolkit.org/3.6.html",
+      "valueConstraint": {
+        "useValuesFrom": [
+          "http://www.rdaregistry.info/termList/RDAMaterial/"
+        ]
+      }
+    },
+    {
+      "propertyLabel": "has base material (RDA 3.6)(If lookup fails: record URI if available or authorized access point)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30208",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/3.6.html"
+    },
+    {
+      "propertyLabel": "has applied material (RDA 3.7)(Lookup)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30084",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "lookup",
+      "remark": "http://access.rdatoolkit.org/3.7.html",
+      "valueConstraint": {
+        "useValuesFrom": [
+          "http://www.rdaregistry.info/termList/RDAMaterial/"
+        ]
+      }
+    },
+    {
+      "propertyLabel": "has applied material (RDA 3.7)(If lookup fails: record URI if available or authorized access point)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30084",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/3.7.html"
+    },
+    {
+      "propertyLabel": "has mount (RDA 3.8)(Lookup)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30186",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "lookup",
+      "remark": "http://access.rdatoolkit.org/3.8.html",
+      "valueConstraint": {
+        "useValuesFrom": [
+          "http://www.rdaregistry.info/termList/RDAMaterial/"
+        ]
+      }
+    },
+    {
+      "propertyLabel": "has mount (RDA 3.8)(If lookup fails: record URI if available or authorized access point)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30186",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/3.8.html"
+    },
+    {
+      "propertyLabel": "has production method (RDA 3.9)(Lookup)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30187",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "lookup",
+      "remark": "http://access.rdatoolkit.org/3.9.html",
+      "valueConstraint": {
+        "useValuesFrom": [
+          "http://www.rdaregistry.info/termList/RDAproductionMethod/"
+        ]
+      }
+    },
+    {
+      "propertyLabel": "has production method (RDA 3.9)(If lookup fails: record URI if available or authorized access point)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30187",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/3.9.html"
+    },
+    {
+      "propertyLabel": "has generation (RDA 3.10)(Lookup)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30191",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "lookup",
+      "remark": "http://access.rdatoolkit.org/3.10.html",
+      "valueConstraint": {
+        "useValuesFrom": [
+          "http://www.rdaregistry.info/termList/RDAGeneration/"
+        ]
+      }
+    },
+    {
+      "propertyLabel": "has generation (RDA 3.10)(If lookup fails: record URI if available or authorized access point)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30191",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/3.10.html"
+    },
+    {
+      "propertyLabel": "has layout (RDA 3.11)(Lookup)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30155",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "lookup",
+      "remark": "http://access.rdatoolkit.org/3.11.html",
+      "valueConstraint": {
+        "useValuesFrom": [
+          "http://www.rdaregistry.info/termList/layout/"
+        ]
+      }
+    },
+    {
+      "propertyLabel": "has layout (RDA 3.11)(If lookup fails: record URI if available or authorized access point)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30155",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/3.11.html"
+    },
+    {
+      "propertyLabel": "has bibliographic format (RDA 3.12)(Lookup)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30197",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "lookup",
+      "remark": "http://access.rdatoolkit.org/3.12.html",
+      "valueConstraint": {
+        "useValuesFrom": [
+          "http://www.rdaregistry.info/termList/bookFormat/"
+        ]
+      }
+    },
+    {
+      "propertyLabel": "has bibliographic format (RDA 3.12)(If lookup fails: record URI if available or authorized access point)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30197",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/3.12.html"
+    },
+    {
+      "propertyLabel": "has font size (RDA 3.13)(Lookup)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30199",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "lookup",
+      "remark": "http://access.rdatoolkit.org/3.13.html",
+      "valueConstraint": {
+        "useValuesFrom": [
+          "http://www.rdaregistry.info/termList/fontSize/"
+        ]
+      }
+    },
+    {
+      "propertyLabel": "has font size (RDA 3.13)(If lookup fails: record URI if available or authorized access point)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30199",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/3.13.html"
+    },
+    {
+      "propertyLabel": "has equipment or system requirement (RDA 3.20)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30162",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/3.20.html"
+    },
+    {
+      "propertyLabel": "has note on extent of manifestation (RDA 3.21.2)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30061",
+      "mandatory": "false",
+      "repeatable": "false",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/3.21.2.html"
+    },
+    {
+      "propertyLabel": "has note on dimensions of manifestation (RDA 3.21.3)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30060",
+      "mandatory": "false",
+      "repeatable": "false",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/3.21.3.html"
+    },
+    {
+      "propertyLabel": "has note on changes in carrier characteristics (RDA 3.21.4)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30051",
+      "mandatory": "false",
+      "repeatable": "false",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/3.21.4.html"
+    },
+    {
+      "propertyLabel": "has type of binding",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30309",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": ""
+    },
+    {
+      "propertyLabel": "has term of availability (RDA 4.2)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30160",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/4.2.html"
+    },
+    {
+      "propertyLabel": "has uniform resource locator (RDA 4.6)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30154",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/4.6.html"
+    },
+    {
+      "propertyLabel": "has surveyor agent (RDA 18.5)(Lookup)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30312",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "lookup",
+      "remark": "http://access.rdatoolkit.org/18.5.html",
+      "valueConstraint": {
+        "useValuesFrom": [
+          "urn:ld4p:qa:dbpedia",
+          "urn:ld4p:qa:names"
+        ]
+      }
+    },
+    {
+      "propertyLabel": "has surveyor agent (RDA 18.5)(If lookup fails: record URI if available or authorized access point)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30312",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/18.5.html"
+    },
+    {
+      "propertyLabel": "has producer agent of unpublished manifestation (RDA 21.2)(Lookup)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30081",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "lookup",
+      "remark": "http://access.rdatoolkit.org/21.2.html",
+      "valueConstraint": {
+        "useValuesFrom": [
+          "urn:ld4p:qa:dbpedia",
+          "urn:ld4p:qa:names"
+        ]
+      }
+    },
+    {
+      "propertyLabel": "has producer agent of unpublished manifestation (RDA 21.2)(If lookup fails: record URI if available or authorized access point)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30081",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/21.2.html"
+    },
+    {
+      "propertyLabel": "has publisher agent (RDA 21.3)(Lookup)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30083",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "lookup",
+      "remark": "http://access.rdatoolkit.org/21.3.html",
+      "valueConstraint": {
+        "useValuesFrom": [
+          "urn:ld4p:qa:dbpedia",
+          "urn:ld4p:qa:names"
+        ]
+      }
+    },
+    {
+      "propertyLabel": "has publisher agent (RDA 21.3)(If lookup fails: record URI if available or authorized access point)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30083",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/21.3.html"
+    },
+    {
+      "propertyLabel": "has distributor agent (RDA 21.4)(Lookup)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30080",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "lookup",
+      "remark": "http://access.rdatoolkit.org/21.4.html",
+      "valueConstraint": {
+        "useValuesFrom": [
+          "urn:ld4p:qa:dbpedia",
+          "urn:ld4p:qa:names"
+        ]
+      }
+    },
+    {
+      "propertyLabel": "has distributor agent (RDA 21.4)(If lookup fails: record URI if available or authorized access point)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30080",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/21.4.html"
+    },
+    {
+      "propertyLabel": "has manufacturer agent (RDA 21.5)(Lookup)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30082",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "lookup",
+      "remark": "http://access.rdatoolkit.org/21.5.html",
+      "valueConstraint": {
+        "useValuesFrom": [
+          "urn:ld4p:qa:dbpedia",
+          "urn:ld4p:qa:names"
+        ]
+      }
+    },
+    {
+      "propertyLabel": "has manufacturer agent (RDA 21.5)(If lookup fails: record URI if available or authorized access point)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30082",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/21.5.html"
+    },
+    {
+      "propertyLabel": "has exemplar of manifestation (RDA 17.11)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30103",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "resource",
+      "valueConstraint": {
+        "valueTemplateRefs": [
+          "rt:rda:item:monograph"
+        ]
+      },
+      "remark": "http://access.rdatoolkit.org/17.11.html"
+    }
+  ]
+}

--- a/static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/adminMetadata.json
+++ b/static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/adminMetadata.json
@@ -1,0 +1,146 @@
+{
+  "resourceURI": "http://id.loc.gov/ontologies/bibframe/AdminMetadata",
+  "resourceLabel": "RT BF2 BFLC Admin Metadata",
+  "id": "rt:bf2:AdminMetadata",
+  "date": "2019-05-30",
+  "author": "Crystal Clements (cec23@uw.edu)",
+  "schema": "https://ld4p.github.io/sinopia/schemas/0.0.9/resource-template.json",
+  "propertyTemplates": [
+    {
+      "propertyLabel": "Your cataloger ID (UW netid)",
+      "propertyURI": "http://id.loc.gov/ontologies/bflc/catalogerID",
+      "mandatory": "true",
+      "repeatable": "true",
+      "type": "literal"
+    },
+    {
+      "propertyLabel": "Record status",
+      "propertyURI": "http://id.loc.gov/ontologies/bibframe/status",
+      "mandatory": "true",
+      "repeatable": "false",
+      "type": "resource",
+      "valueConstraint": {
+        "valueTemplateRefs": [
+          "rt:bf2:AdminMetadata:Status"
+        ]
+      }
+    },
+    {
+      "propertyLabel": "Encoding level",
+      "propertyURI": "http://id.loc.gov/ontologies/bflc/encodingLevel",
+      "mandatory": "true",
+      "repeatable": "false",
+      "type": "lookup",
+      "valueConstraint": {
+        "useValuesFrom": [
+          "https://id.loc.gov/vocabulary/menclvl"
+        ],
+        "valueDataType": {
+          "dataTypeURI": "http://id.loc.gov/ontologies/bflc/EncodingLevel"
+        },
+        "defaults": [
+          {
+            "defaultURI": "http://id.loc.gov/vocabulary/menclvl/f",
+            "defaultLiteral": "full"
+          }
+        ]
+      }
+    },
+    {
+      "propertyLabel": "Description conventions",
+      "propertyURI": "http://id.loc.gov/ontologies/bibframe/descriptionConventions",
+      "mandatory": "true",
+      "repeatable": "true",
+      "type": "lookup",
+      "valueConstraint": {
+        "useValuesFrom": [
+          "https://id.loc.gov/vocabulary/descriptionConventions"
+        ],
+        "valueDataType": {
+          "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/DescriptionConventions"
+        },
+        "defaults": [
+          {
+            "defaultURI": "http://id.loc.gov/vocabulary/descriptionConventions/rda",
+            "defaultLiteral": "Resource Description and Access"
+          },
+          {
+            "defaultURI": "http://id.loc.gov/vocabulary/descriptionConventions/isbd",
+            "defaultLiteral": "ISBD: International Standard Bibliographic Description"
+          }
+        ]
+      }
+    },
+    {
+      "propertyLabel": "Source of cataloging",
+      "propertyURI": "http://id.loc.gov/ontologies/bibframe/source",
+      "mandatory": "true",
+      "repeatable": "true",
+      "type": "lookup",
+      "valueConstraint": {
+        "useValuesFrom": [
+          "urn:ld4p:qa:names:organization",
+          "urn:ld4p:qa:subjects:organization"
+        ],
+        "valueDataType": {
+          "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Agent"
+        },
+        "defaults": [
+          {
+            "defaultURI": "http://id.loc.gov/vocabulary/organizations/wau"
+          }
+        ]
+      }
+    },
+    {
+      "propertyLabel": "Description language",
+      "propertyURI": "http://id.loc.gov/ontologies/bibframe/descriptionLanguage",
+      "mandatory": "true",
+      "repeatable": "false",
+      "type": "lookup",
+      "valueConstraint": {
+        "useValuesFrom": [
+          "http:s//id.loc.gov/vocabulary/languages"
+        ],
+        "valueDataType": {
+          "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Language"
+        },
+        "defaults": [
+          {
+            "defaultURI": "http://id.loc.gov/vocabulary/languages/eng",
+            "defaultLiteral": "English"
+          }
+        ]
+      }
+    },
+    {
+      "propertyLabel": "Data creation date",
+      "propertyURI": "http://id.loc.gov/ontologies/bibframe/creationDate",
+      "mandatory": "true",
+      "repeatable": "false",
+      "type": "literal"
+    },
+    {
+      "propertyLabel": "Data change date",
+      "propertyURI": "http://id.loc.gov/ontologies/bibframe/changeDate",
+      "mandatory": "false",
+      "repeatable": "false",
+      "type": "literal"
+    },
+    {
+      "propertyLabel": "Description authentication",
+      "propertyURI": "http://id.loc.gov/ontologies/bibframe/descriptionAuthentication",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "lookup",
+      "valueConstraint": {
+        "useValuesFrom": [
+          "https://id.loc.gov/vocabulary/marcauthen"
+        ],
+        "valueDataType": {
+          "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/DescriptionAuthentication"
+        }
+      }
+    }
+  ]
+}

--- a/static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/adminMetadataStatus.json
+++ b/static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/adminMetadataStatus.json
@@ -1,0 +1,67 @@
+{
+  "resourceURI": "http://id.loc.gov/ontologies/bibframe/Status",
+  "resourceLabel": "RT BF2 BFLC Admin Metadata Status",
+  "id": "rt:bf2:AdminMetadata:Status",
+  "date": "2019-05-30",
+  "author": "Crystal Clements (cec23@uw.edu)",
+  "schema": "https://ld4p.github.io/sinopia/schemas/0.0.9/resource-template.json",
+  "propertyTemplates": [
+    {
+      "propertyLabel": "Code",
+      "propertyURI": "http://id.loc.gov/ontologies/bibframe/code",
+      "mandatory": "true",
+      "repeatable": "true",
+      "type": "literal",
+      "valueConstraint": {
+        "defaults": [
+          {
+            "defaultLiteral": "n"
+          }
+        ]
+      }
+    },
+    {
+      "propertyLabel": "has mode of issuance (RDA 2.13)(Lookup)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30003",
+      "mandatory": "false",
+      "repeatable": "false",
+      "type": "lookup",
+      "remark": "http://access.rdatoolkit.org/2.13.html",
+      "valueConstraint": {
+        "useValuesFrom": [
+          "urn:ld4p:qa:names"
+        ],
+        "defaults": [
+          {
+            "defaultURI": "http://rdaregistry.info/termList/ModeIssue/1001",
+            "defaultLiteral": "single unit"
+          },
+          {
+            "defaultURI": "http://id.loc.gov/vocabulary/issuance/mono",
+            "defaultLiteral": "single unit"
+          }
+        ]
+      }
+    },
+    {
+      "propertyLabel": "has mode of issuance (RDA 2.13)(If lookup fails: record URI if available or authorized access point)",
+      "propertyURI": "http://rdaregistry.info/Elements/m/P30003",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/2.13.html",
+      "valueConstraint": {
+        "defaults": [
+          {
+            "defaultURI": "http://rdaregistry.info/termList/ModeIssue/1001",
+            "defaultLiteral": "single unit"
+          },
+          {
+            "defaultURI": "http://id.loc.gov/vocabulary/issuance/mono",
+            "defaultLiteral": "single unit"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/rdaItemMonograph.json
+++ b/static/spoofedFilesFromServer/fromSinopiaServer/resourceTemplates/rdaItemMonograph.json
@@ -1,0 +1,184 @@
+{
+  "id": "rt:rda:item:monograph",
+  "resourceURI": "http://rdaregistry.info/Elements/c/C10003",
+  "resourceLabel": "RT RDA Item for monographs",
+  "author": "Crystal Clements (cec23@uw.edu)",
+  "date": "2019-05-01",
+  "schema": "https://ld4p.github.io/sinopia/schemas/0.0.9/resource-template.json",
+  "propertyTemplates": [
+    {
+      "propertyLabel": "Lookup",
+      "propertyURI": "http://rdaregistry.info/Elements/c/C10003",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "lookup",
+      "remark": "Lookup",
+      "valueConstraint": {
+        "useValuesFrom": [
+          "dummy"
+        ]
+      }
+    },
+    {
+      "propertyLabel": "Administrative Metadata for Item",
+      "propertyURI": "http://id.loc.gov/ontologies/bibframe/adminMetadata",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "resource",
+      "remark": "",
+      "valueConstraint": {
+        "valueTemplateRefs": [
+          "rt:bf2:AdminMetadata"
+        ]
+      }
+    },
+    {
+      "propertyLabel": "has note on item (RDA 2.21)",
+      "propertyURI": "http://rdaregistry.info/Elements/i/P40028",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/2.21.html"
+    },
+    {
+      "propertyLabel": "has custodial history of item (RDA 2.18)",
+      "propertyURI": "http://rdaregistry.info/Elements/i/P40026",
+      "mandatory": "false",
+      "repeatable": "false",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/2.18.html"
+    },
+    {
+      "propertyLabel": "has immediate source of acquisition of item (RDA 2.19)",
+      "propertyURI": "http://rdaregistry.info/Elements/i/P40050",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/2.19.html"
+    },
+    {
+      "propertyLabel": "has note on extent of item (RDA 3.22.2)",
+      "propertyURI": "http://rdaregistry.info/Elements/i/P40011",
+      "mandatory": "false",
+      "repeatable": "false",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/3.22.2.html"
+    },
+    {
+      "propertyLabel": "has note on dimensions of item (RDA 3.22.3)",
+      "propertyURI": "http://rdaregistry.info/Elements/i/P40010",
+      "mandatory": "false",
+      "repeatable": "false",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/3.22.3.html"
+    },
+    {
+      "propertyLabel": "has restriction on access to item (RDA 4.4)",
+      "propertyURI": "http://rdaregistry.info/Elements/i/P40047",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/4.4.html"
+    },
+    {
+      "propertyLabel": "has related item of item",
+      "propertyURI": "http://rdaregistry.info/Elements/i/P40046",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "Do please note that there is no propertyURI"
+    },
+    {
+      "propertyLabel": "has owner agent (RDA 22.2)(Lookup)",
+      "propertyURI": "http://rdaregistry.info/Elements/i/P40021",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "lookup",
+      "remark": "http://access.rdatoolkit.org/22.2.html",
+      "valueConstraint": {
+        "useValuesFrom": [
+          "https://id.loc.gov/vocabulary/mcolor"
+        ],
+        "defaults": [
+          {
+            "defaultURI": "http://id.loc.gov/vocabulary/organizations/wauar ",
+            "defaultLiteral": "University of Washington Libraries, Manuscripts, Special Collections, University Archives"
+          }
+        ]
+      }
+    },
+    {
+      "propertyLabel": "has owner agent (RDA 22.2)(If lookup fails: record URI if available or authorized access point)",
+      "propertyURI": "http://rdaregistry.info/Elements/i/P40021",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/22.2.html",
+      "valueConstraint": {
+        "defaults": [
+          {
+            "defaultURI": "http://id.loc.gov/vocabulary/organizations/wauar ",
+            "defaultLiteral": "University of Washington Libraries, Manuscripts, Special Collections, University Archives"
+          }
+        ]
+      }
+    },
+    {
+      "propertyLabel": "has custodian agent (RDA 22.3)(Lookup)",
+      "propertyURI": "http://rdaregistry.info/Elements/i/P40020",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "lookup",
+      "remark": "http://access.rdatoolkit.org/22.3.html",
+      "valueConstraint": {
+        "useValuesFrom": [
+          "http://id.loc.gov/vocabulary/organizations"
+        ],
+        "defaults": [
+          {
+            "defaultURI": "http://id.loc.gov/vocabulary/organizations/wauar ",
+            "defaultLiteral": "University of Washington Libraries, Manuscripts, Special Collections, University Archives"
+          }
+        ]
+      }
+    },
+    {
+      "propertyLabel": "has custodian agent (RDA 22.3)(If lookup fails: record URI if available or authorized access point)",
+      "propertyURI": "http://rdaregistry.info/Elements/i/P40020",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": "http://access.rdatoolkit.org/22.3.html",
+      "valueConstraint": {
+        "defaults": [
+          {
+            "defaultURI": "http://id.loc.gov/vocabulary/organizations/wauar ",
+            "defaultLiteral": "University of Washington Libraries, Manuscripts, Special Collections, University Archives"
+          }
+        ]
+      }
+    },
+    {
+      "propertyLabel": "has related agent of item (RDA 22.4) (Lookup)",
+      "propertyURI": "http://rdaregistry.info/Elements/i/P40072",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "lookup",
+      "remark": "",
+      "valueConstraint": {
+        "useValuesFrom": [
+          "urn:ld4p:qa:dbpedia",
+          "urn:ld4p:qa:names"
+        ]
+      }
+    },
+    {
+      "propertyLabel": "has related agent of item (RDA 22.4)(If lookup fails: record URI if available or authorized access point)",
+      "propertyURI": "http://rdaregistry.info/Elements/i/P40072",
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "remark": ""
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #660 

Adds some new spoofed resource templates for testing this fix.

If the defaultLiteral value is undefined, use the defaultURI instead.

![Screen Shot 2019-06-11 at 11 44 46 AM](https://user-images.githubusercontent.com/3093850/59299837-821a4280-8c42-11e9-86ed-a36010c08c32.png)
![Screen Shot 2019-06-11 at 11 43 21 AM](https://user-images.githubusercontent.com/3093850/59299838-821a4280-8c42-11e9-8968-6fe3c7f9a13b.png)

