### PR TITLE
add loginHelper for integration tests

### DIFF
--- a/__tests__/integration/loginHelper.js
+++ b/__tests__/integration/loginHelper.js
@@ -1,0 +1,30 @@
+// Copyright 2019 Stanford University see LICENSE for license
+
+import Config from '../../src/Config'
+
+export async function testUserLogin() {
+  jest.setTimeout(60000) // Takes around 10s in practice, but be generous, just in case
+  await page.goto('http://127.0.0.1:8888/templates')
+
+  try {
+    await page.waitForSelector('form.login-form')
+    await page.type('form.login-form input[name=username]', Config.cognitoTestUserName)
+    await page.type('form.login-form input[name=password]', Config.cognitoTestUserPass)
+    await page.click('form.login-form button[type=submit]')
+  } catch (error) {
+    console.info(error)
+  }
+
+  // Sign out button should only show up after successful login
+  await page.waitForSelector('button.signout-btn')
+  jest.setTimeout(5000) // Reset timeout to default
+}
+
+export async function testUserLogout() {
+  jest.setTimeout(60000) // Takes around 10s in practice, but be generous, just in case
+  await page.goto('http://127.0.0.1:8888/templates')
+
+  await page.waitForSelector('button.signout-btn')
+  await page.click('button.signout-btn')
+  jest.setTimeout(5000) // Reset timeout to default
+}

--- a/__tests__/integration/nestedResources.test.js
+++ b/__tests__/integration/nestedResources.test.js
@@ -1,25 +1,11 @@
 // Copyright 2019 Stanford University see LICENSE for license
 
 import pupExpect from 'expect-puppeteer'
-import Config from '../../src/Config'
+import { testUserLogin } from './loginHelper'
 
 describe('Expanding a resource property in a property panel', () => {
   beforeAll(async () => {
-    jest.setTimeout(60000) // This seems to take around 10s in practice, but be generous, just in case
-    await page.goto('http://127.0.0.1:8888/templates')
-
-    // Attempt to enter and submit login info
-    try {
-      await page.waitForSelector('form.login-form')
-      await page.type('form.login-form input[name=username]', Config.cognitoTestUserName)
-      await page.type('form.login-form input[name=password]', Config.cognitoTestUserPass)
-      await page.click('form.login-form button[type=submit]')
-    } catch (error) {
-      console.info(error)
-    }
-
-    // Sign out button should only show up after successful login
-    await page.waitForSelector('button.signout-btn')
+    await testUserLogin()
   })
 
   it('loads up a resource template from the list of loaded templates', async () => {

--- a/__tests__/integration/previewSaveRDF.test.js
+++ b/__tests__/integration/previewSaveRDF.test.js
@@ -1,25 +1,11 @@
 // Copyright 2019 Stanford University see LICENSE for license
 
 import pupExpect from 'expect-puppeteer'
-import Config from '../../src/Config'
+import { testUserLogin } from './loginHelper'
 
 describe('Expanding a resource property in a property panel', () => {
   beforeAll(async () => {
-    jest.setTimeout(60000) // This seems to take around 10s in practice, but be generous, just in case
-    await page.goto('http://127.0.0.1:8888/templates')
-
-    // Attempt to enter and submit login info
-    try {
-      await page.waitForSelector('form.login-form')
-      await page.type('form.login-form input[name=username]', Config.cognitoTestUserName)
-      await page.type('form.login-form input[name=password]', Config.cognitoTestUserPass)
-      await page.click('form.login-form button[type=submit]')
-    } catch (error) {
-      console.info(error)
-    }
-
-    // Sign out button should only show up after successful login
-    await page.waitForSelector('button.signout-btn')
+    await testUserLogin()
   })
 
   it('loads up a resource template from the list of loaded templates', async () => {

--- a/__tests__/integration/repeatableResources.test.js
+++ b/__tests__/integration/repeatableResources.test.js
@@ -1,25 +1,11 @@
 // Copyright 2019 Stanford University see LICENSE for license
 
 import pupExpect from 'expect-puppeteer'
-import Config from '../../src/Config'
+import { testUserLogin } from './loginHelper'
 
 describe('Adding new embedded Resource Templates', () => {
   beforeAll(async () => {
-    jest.setTimeout(60000) // This seems to take around 10s in practice, but be generous, just in case
-    await page.goto('http://127.0.0.1:8888/templates')
-
-    // Attempt to enter and submit login info
-    try {
-      await page.waitForSelector('form.login-form')
-      await page.type('form.login-form input[name=username]', Config.cognitoTestUserName)
-      await page.type('form.login-form input[name=password]', Config.cognitoTestUserPass)
-      await page.click('form.login-form button[type=submit]')
-    } catch (error) {
-      console.info(error)
-    }
-
-    // Sign out button should only show up after successful login
-    await page.waitForSelector('button.signout-btn')
+    await testUserLogin()
   })
 
   it('loads up a resource template from the list of loaded templates', async () => {

--- a/__tests__/integration/schemaValidation.test.js
+++ b/__tests__/integration/schemaValidation.test.js
@@ -1,25 +1,11 @@
-// Copyright 2018 Stanford University see LICENSE for license
+// Copyright 2018, 2019 Stanford University see LICENSE for license
 
 import pupExpect from 'expect-puppeteer'
-import Config from '../../src/Config'
+import { testUserLogin } from './loginHelper'
 
 describe('Importing a profile/template with bad JSON', () => {
   beforeAll(async () => {
-    jest.setTimeout(60000) // This seems to take around 10s in practice, but be generous, just in case
-    await page.goto('http://127.0.0.1:8888/')
-
-    // Attempt to enter and submit login info
-    try {
-      await page.waitForSelector('form.login-form')
-      await page.type('form.login-form input[name=username]', Config.cognitoTestUserName)
-      await page.type('form.login-form input[name=password]', Config.cognitoTestUserPass)
-      await page.click('form.login-form button[type=submit]')
-    } catch (error) {
-      console.info(error)
-    }
-
-    // Sign out button should only show up after successful login
-    await page.waitForSelector('button.signout-btn')
+    await testUserLogin()
   })
 
   it('Displays an error message', async () => {

--- a/__tests__/integration/unauthenticatedNavigation.test.js
+++ b/__tests__/integration/unauthenticatedNavigation.test.js
@@ -1,21 +1,17 @@
 // Copyright 2019 Stanford University see LICENSE for license
 import expect from 'expect-puppeteer'
 import 'isomorphic-fetch'
+import { testUserLogout } from './loginHelper'
 
 describe('When an unauthenticated user tries to access resource templates', () => {
   beforeAll(async () => {
     jest.setTimeout(60000) // This seems to take around 10s in practice, but be generous, just in case
     await page.goto('http://127.0.0.1:8888/templates')
 
-    /*
-     * Attempt to logout
-     * This try block is necessary to avoid failing after logout
-     */
     try {
-      await page.waitForSelector('button.signout-btn')
-      await page.click('button.signout-btn')
+      await testUserLogout()
     } catch (error) {
-      console.info(error)
+      // Avoid failing after logout
     }
   })
 

--- a/package.json
+++ b/package.json
@@ -141,7 +141,8 @@
       "jest-junit"
     ],
     "testPathIgnorePatterns": [
-      "/node_modules/"
+      "/node_modules/",
+      "__tests__/integration/loginHelper"
     ],
     "setupFiles": [
       "jest-localstorage-mock",


### PR DESCRIPTION
Given the same code was copied into 5 different tests, it seemed worthwhile to make helper functions for it.  I suspect we'll be adding more integration tests requiring login in the future, too.

Fixes #547