### PR TITLE
improve css selectors in tests; ensure no false positives for async tests

### DIFF
--- a/__tests__/components/editor/ImportFileZone.test.js
+++ b/__tests__/components/editor/ImportFileZone.test.js
@@ -29,6 +29,7 @@ describe('<ImportFileZone />', () => {
       })
 
       it('resolves the passing RT validation, returning undefined', async () => {
+        expect.assertions(1)
         template = require('../../__fixtures__/lcc_v0.2.0.json')
         schemaUrl = wrapper.instance().schemaUrl(template)
         const resolution = await wrapper.instance().promiseTemplateValidated(template, schemaUrl)
@@ -43,6 +44,7 @@ describe('<ImportFileZone />', () => {
       })
 
       it('resolves the passing profile validation, returning undefined', async () => {
+        expect.assertions(1)
         template = require('../../__fixtures__/place_profile_v0.2.0.json')
         schemaUrl = wrapper.instance().schemaUrl(template)
         const resolution = await wrapper.instance().promiseTemplateValidated(template, schemaUrl)
@@ -63,6 +65,7 @@ describe('<ImportFileZone />', () => {
       })
 
       it('resolves the passing RT validation, returning undefined', async () => {
+        expect.assertions(1)
         template = require('../../__fixtures__/lcc_no_schema_specified.json')
         schemaUrl = wrapper.instance().schemaUrl(template)
         const resolution = await wrapper.instance().promiseTemplateValidated(template, schemaUrl)
@@ -77,6 +80,7 @@ describe('<ImportFileZone />', () => {
       })
 
       it('resolves the passing profile validation, returning undefined', async () => {
+        expect.assertions(1)
         template = require('../../__fixtures__/place_profile_no_schema_specified.json')
         schemaUrl = wrapper.instance().schemaUrl(template)
         const resolution = await wrapper.instance().promiseTemplateValidated(template, schemaUrl)

--- a/__tests__/components/editor/ImportResourceTemplate.test.js
+++ b/__tests__/components/editor/ImportResourceTemplate.test.js
@@ -52,6 +52,7 @@ describe('<ImportResourceTemplate />', () => {
     }
 
     it('resets messages, creates one resource per template, and then updates state', async () => {
+      expect.assertions(3)
       const createResourceSpy = jest.spyOn(wrapper.instance(), 'createResource').mockImplementation(async () => {})
       const updateStateSpy = jest.spyOn(wrapper.instance(), 'updateStateFromServerResponses').mockReturnValue(null)
       const resetMessagesSpy = jest.spyOn(wrapper.instance(), 'resetMessages').mockReturnValue(null)
@@ -66,6 +67,7 @@ describe('<ImportResourceTemplate />', () => {
 
   describe('createResource()', () => {
     it('returns response from sinopia client call when successful', async () => {
+      expect.assertions(1)
       createResourceTemplate.mockImplementation(async () => ({
         response: 'i am a response for a created object',
       }))
@@ -76,6 +78,7 @@ describe('<ImportResourceTemplate />', () => {
     })
 
     it('returns error response and adds to state when client call fails', async () => {
+      expect.assertions(2)
       createResourceTemplate.mockImplementation(async () => {
         throw {
           response: 'i am an error for a created object',
@@ -96,6 +99,7 @@ describe('<ImportResourceTemplate />', () => {
 
   describe('updateResource()', () => {
     it('returns response from sinopia client call when successful', async () => {
+      expect.assertions(1)
       updateResourceTemplate.mockImplementation(async () => ({
         response: 'i am a response for an updated object',
       }))
@@ -106,6 +110,7 @@ describe('<ImportResourceTemplate />', () => {
     })
 
     it('returns error response when client call fails', async () => {
+      expect.assertions(1)
       updateResourceTemplate.mockImplementation(async () => {
         throw {
           response: 'i am an error for an updated object',
@@ -300,6 +305,7 @@ describe('<ImportResourceTemplate />', () => {
     ]
 
     it('updates every template, updates state, closes the modal and reloads', async () => {
+      expect.assertions(3)
       const updateResourceSpy = jest.spyOn(wrapper.instance(), 'updateResource').mockImplementation(async () => {})
       const updateStateSpy = jest.spyOn(wrapper.instance(), 'updateStateFromServerResponses').mockReturnValue(null)
       const modalCloseSpy = jest.spyOn(wrapper.instance(), 'modalClose').mockReturnValue(null)

--- a/__tests__/components/editor/SinopiaResourceTemplates.test.js
+++ b/__tests__/components/editor/SinopiaResourceTemplates.test.js
@@ -42,6 +42,7 @@ describe('<SinopiaResourceTemplates />', () => {
     const initialUpdateKey = 1
 
     it('calls fetchResourceTemplatesFromGroups() and resets errors if updateKey has been incremented', async () => {
+      expect.assertions(2)
       const wrapper2 = shallow(<SinopiaResourceTemplates messages={messages} updateKey={initialUpdateKey} />)
       const fetchSpy = jest.spyOn(wrapper2.instance(), 'fetchResourceTemplatesFromGroups').mockReturnValue(null)
       const setStateSpy = jest.spyOn(wrapper2.instance(), 'setState').mockReturnValue(null)
@@ -53,6 +54,7 @@ describe('<SinopiaResourceTemplates />', () => {
     })
 
     it('calls fetchResourceTemplatesFromGroups() and resets errors if server has new templates', async () => {
+      expect.assertions(3)
       const wrapper2 = shallow(<SinopiaResourceTemplates messages={messages} updateKey={initialUpdateKey} />)
       const fetchSpy = jest.spyOn(wrapper2.instance(), 'fetchResourceTemplatesFromGroups').mockReturnValue(null)
       const serverCheckSpy = jest.spyOn(wrapper2.instance(), 'serverHasNewTemplates').mockReturnValue(true)
@@ -66,6 +68,7 @@ describe('<SinopiaResourceTemplates />', () => {
     })
 
     it('returns early if updateKey has not changed and no new templates on server', async () => {
+      expect.assertions(3)
       const wrapper2 = shallow(<SinopiaResourceTemplates messages={messages} updateKey={initialUpdateKey} />)
       const fetchSpy = jest.spyOn(wrapper2.instance(), 'fetchResourceTemplatesFromGroups').mockReturnValue(null)
       const serverCheckSpy = jest.spyOn(wrapper2.instance(), 'serverHasNewTemplates').mockReturnValue(false)
@@ -81,6 +84,7 @@ describe('<SinopiaResourceTemplates />', () => {
 
   describe('serverHasNewTemplates()', () => {
     it('returns false when etag has not changed', async () => {
+      expect.assertions(1)
       getEntityTagFromGroupContainer.mockImplementation(async () => 'foobar')
       const wrapper2 = shallow(<SinopiaResourceTemplates messages={messages} updateKey={1} />)
 
@@ -90,6 +94,7 @@ describe('<SinopiaResourceTemplates />', () => {
     })
 
     it('returns true and resets etag value when etag changes', async () => {
+      expect.assertions(2)
       getEntityTagFromGroupContainer.mockImplementation(async () => 'bazquux')
       const wrapper2 = shallow(<SinopiaResourceTemplates messages={messages} updateKey={1} />)
 
@@ -98,6 +103,7 @@ describe('<SinopiaResourceTemplates />', () => {
     })
 
     it('returns false and logs a messages when there are errors', async () => {
+      expect.assertions(2)
       getEntityTagFromGroupContainer.mockImplementation(async () => {
         throw 'ack!'
       })
@@ -125,6 +131,7 @@ describe('<SinopiaResourceTemplates />', () => {
     }
 
     it('does not set state if groups have no resource templates', async () => {
+      expect.assertions(1)
       listResourcesInGroupContainer.mockReturnValue(new Promise((resolve) => {
         resolve(containsNothing)
       }))
@@ -138,6 +145,7 @@ describe('<SinopiaResourceTemplates />', () => {
     })
 
     it('sets state when there is a non-zero number of templates', async () => {
+      expect.assertions(1)
       listResourcesInGroupContainer.mockReturnValue(new Promise((resolve) => {
         resolve(containsTemplate)
       }))
@@ -151,6 +159,7 @@ describe('<SinopiaResourceTemplates />', () => {
     })
 
     it('adds errors to state if anything throws', async () => {
+      expect.assertions(2)
       listResourcesInGroupContainer.mockImplementation(async () => {
         throw 'uh oh!'
       })
@@ -178,6 +187,7 @@ describe('<SinopiaResourceTemplates />', () => {
 
   describe('setStateFromServerResponse()', () => {
     it('calls getResourceTemplate() once when passed a string', async () => {
+      expect.assertions(2)
       const getResourceTemplateSpy = jest.fn().mockReturnValue({
         response: {
           body: {
@@ -199,6 +209,7 @@ describe('<SinopiaResourceTemplates />', () => {
     })
 
     it('calls getResourceTemplate n times where n is the length of the array passed in', async () => {
+      expect.assertions(2)
       const getResourceTemplateSpy = jest.fn().mockReturnValue({
         response: {
           body: {
@@ -220,6 +231,7 @@ describe('<SinopiaResourceTemplates />', () => {
     })
 
     it('does not add templates to state if they already exist', async () => {
+      expect.assertions(2)
       const getResourceTemplateSpy = jest.fn().mockReturnValue({
         response: {
           body: {
@@ -268,6 +280,7 @@ describe('<SinopiaResourceTemplates />', () => {
     const wrapper4 = shallow(<SinopiaResourceTemplates messages={messages}/>)
 
     it('renders a link to the Editor with the id of the resource template to fetch', async () => {
+      expect.assertions(2)
       const link = await wrapper4.instance().linkFormatter(cell, row)
 
       await expect(link.props.to.pathname).toEqual('/editor')

--- a/__tests__/components/editor/property/InputLang.test.js
+++ b/__tests__/components/editor/property/InputLang.test.js
@@ -41,6 +41,7 @@ describe('<InputLang />', () => {
   })
 
   it('should call the onFocus event and set the selected option', () => {
+    expect.assertions(4)
     const opts = { id: 'URI', label: 'LABEL', uri: 'URI' }
 
     wrapper.instance().opts = opts

--- a/__tests__/components/editor/property/InputListLOC.test.js
+++ b/__tests__/components/editor/property/InputListLOC.test.js
@@ -157,6 +157,7 @@ describe('<Typeahead /> component', () => {
   })
 
   it('should call the onFocus event and set the selected option', () => {
+    expect.assertions(2)
     const opts = { id: 'URI', label: 'LABEL', uri: 'URI' }
 
     wrapper.instance().opts = opts

--- a/__tests__/integration/landingPage.test.js
+++ b/__tests__/integration/landingPage.test.js
@@ -1,14 +1,15 @@
 // Copyright 2018 Stanford University see LICENSE for license
-import expect from 'expect-puppeteer'
+import pupExpect from 'expect-puppeteer'
 import 'isomorphic-fetch'
 
 describe('Basic end to end Sinopia Linked Data Editor', () => {
   beforeAll(async () => {
-    await page.goto('http://127.0.0.1:8888/')
+    return await page.goto('http://127.0.0.1:8888/')
   })
 
   it('displays "Linked Data Editor" and "Profile Editor" in menu', async () => {
-    await expect(page).toMatch('Linked Data Editor')
-    await expect(page).toMatch('Profile Editor')
+    expect.assertions(2)
+    await pupExpect(page).toMatch('Linked Data Editor')
+    await pupExpect(page).toMatch('Profile Editor')
   })
 })

--- a/__tests__/integration/nestedResources.test.js
+++ b/__tests__/integration/nestedResources.test.js
@@ -5,20 +5,23 @@ import { testUserLogin } from './loginHelper'
 
 describe('Expanding a resource property in a property panel', () => {
   beforeAll(async () => {
-    await testUserLogin()
+    return await testUserLogin()
   })
 
   it('loads up a resource template from the list of loaded templates', async () => {
+    expect.assertions(2)
     await pupExpect(page).toClick('a', { text: 'BIBFRAME Instance' })
     await pupExpect(page).toMatch('BIBFRAME Instance')
   })
 
   it('clicks on one of the property type rows to expand a nested resource', async () => {
+    expect.assertions(2)
     await pupExpect(page).toClick('a[data-id=\'hasInstance\']')
     await pupExpect(page).toMatchElement('h5', { text: 'BIBFRAME Instance' })
   })
 
   it('clicks on a nested prooperty to reveal an input component', async () => {
+    expect.assertions(2)
     await pupExpect(page).toClick('a[data-id=\'heldBy\']')
     await pupExpect(page).toMatchElement('input[placeholder=\'Holdings\']')
   })

--- a/__tests__/integration/previewSaveRDF.test.js
+++ b/__tests__/integration/previewSaveRDF.test.js
@@ -5,37 +5,43 @@ import { testUserLogin } from './loginHelper'
 
 describe('Expanding a resource property in a property panel', () => {
   beforeAll(async () => {
-    await testUserLogin()
+    return await testUserLogin()
   })
 
   it('loads up a resource template from the list of loaded templates', async () => {
+    expect.assertions(2)
     await pupExpect(page).toClick('a', { text: 'BIBFRAME Instance' })
     await pupExpect(page).toMatch('BIBFRAME Instance')
   })
 
   it('clicks on one of the property type rows to expand a nested resource', async () => {
+    expect.assertions(2)
     await pupExpect(page).toClick('a[data-id=\'hasInstance\']')
     await pupExpect(page).toMatchElement('h5', { text: 'BIBFRAME Instance' })
   })
 
   it('clicks on the PreviewRDF button and a modal appears', async () => {
+    expect.assertions(3)
     await pupExpect(page).toClick('button', { text: 'Preview RDF' })
     await pupExpect(page).toMatch('RDF Preview')
     await pupExpect(page).toMatch('If this looks good, then click Save and Publish')
   })
 
   it('presents a choice of group to save to', async () => {
+    expect.assertions(3)
     await pupExpect(page).toClick('button', { text: 'Save & Publish' })
     await pupExpect(page).toMatch('Which group do you want to save to?')
     await pupExpect(page).toMatch('Which group do you want to associate this record to?')
   })
 
   it('can click on the select menu to choose a group', async () => {
+    expect.assertions(1)
     await page.select('.group-select-options select', 'stanford')
     await pupExpect(page).toClick('button', { text: 'Save' })
   })
 
-  it('for now has a dialog confirming the save function that can be dismissed', async () => {
+  it.skip('for now has a dialog confirming the save function that can be dismissed', async () => {
+    // FIXME:  does not seem to test anything;  adding expect.assertions(1) causes it to fail
     await pupExpect(page.on('dialog', (dialog) => {
       dialog.dismiss()
     }))

--- a/__tests__/integration/repeatableResources.test.js
+++ b/__tests__/integration/repeatableResources.test.js
@@ -6,28 +6,37 @@ import { testUserLogin } from './loginHelper'
 describe('Adding new embedded Resource Templates', () => {
   beforeAll(async () => {
     await testUserLogin()
-  })
-
-  it('loads up a resource template from the list of loaded templates', async () => {
     await pupExpect(page).toClick('a', { text: 'BIBFRAME Instance' })
-    await pupExpect(page).toMatch('BIBFRAME Instance')
+    return await pupExpect(page).toMatch('BIBFRAME Instance')
   })
 
-  // TODO: Simplify CSS selectors in the tests below, see ticket #573
-  it('clicks on an AddButton in Notes about the Instance and looks for a second resource template', async () => {
-    await pupExpect(page).toClick('div.panel:nth-child(5) > div:nth-child(2) > div:nth-child(1) > div:nth-child(1) > section:nth-child(2) > div:nth-child(1) > button:nth-child(1)')
-    await pupExpect(page).toMatchElement('div.panel:nth-child(5) > div:nth-child(2) > div:nth-child(1) > div:nth-child(2) > h4:nth-child(2)', { text: 'Note' })
+  describe('one level of nested resourceTemplate (Notes about the Instance)', () => {
+    it('clicking AddButton adds second resource template', async () => {
+      const panelBodySel = 'div[propLabel="Notes about the Instance"] > div.panel-body'
+      let noteRtOutlines = await page.$$(`${panelBodySel} .rtOutline`)
+
+      expect(noteRtOutlines.length).toEqual(1)
+      await pupExpect(page).toClick(`${panelBodySel} button`) // Add button
+      noteRtOutlines = await page.$$(`${panelBodySel} .rtOutline`)
+      expect(noteRtOutlines.length).toEqual(2)
+    })
   })
 
-  it('clicks on a nested property with an embedded Note resource template and then clicks on the AddButton for a second resource template', async () => {
-    await pupExpect(page).toClick('a[data-id=\'note\']')
-    await pupExpect(page).toClick('.col-sm-4 > div:nth-child(1) > button:nth-child(1)')
-    await pupExpect(page).toMatchElement('div.panel-body > div > div:nth-child(2) > div:nth-child(3) > div.rOutline-property > div:nth-child(2) > div.row > section.col-sm-8> h5',
-      { text: 'Note' })
+  describe('two levels of nested resourceTemplates (Instance of -> Notes about the Work)', () => {
+    it('clicking AddButton adds second resource template', async () => {
+      const ptOutlineSel = 'div[propLabel="Instance of"] div.rtOutline[propLabel="Notes about the Work"]'
+
+      await pupExpect(page).toClick(`${ptOutlineSel} a[data-id='note']`)
+      let noteRtOutlines = await page.$$(`${ptOutlineSel} .rtOutline`)
+
+      expect(noteRtOutlines.length).toEqual(1)
+      await pupExpect(page).toClick(`${ptOutlineSel} button`) // Add button
+      noteRtOutlines = await page.$$(`${ptOutlineSel} .rtOutline`)
+      expect(noteRtOutlines.length).toEqual(2)
+    })
   })
 
-  it('checks that a non-repeatable resource template\'s AddButton is disabled', async () => {
-    await pupExpect(page).toMatchElement('div.panel:nth-child(7) > div:nth-child(2) > div:nth-child(1) > div:nth-child(1) > section:nth-child(2) > div:nth-child(1) > button:nth-child(1)',
-      { disabled: true })
+  it('AddButton disabled for non-repeatable resourceTemplate (Item Information -> Barcode)', async () => {
+    await pupExpect(page).toMatchElement('div[propLabel="Item Information"] > div.panel-body button', { disabled: true })
   })
 })

--- a/__tests__/integration/repeatableResources.test.js
+++ b/__tests__/integration/repeatableResources.test.js
@@ -12,6 +12,7 @@ describe('Adding new embedded Resource Templates', () => {
 
   describe('one level of nested resourceTemplate (Notes about the Instance)', () => {
     it('clicking AddButton adds second resource template', async () => {
+      expect.assertions(5) // Includes 2 in beforeAll
       const panelBodySel = 'div[propLabel="Notes about the Instance"] > div.panel-body'
       let noteRtOutlines = await page.$$(`${panelBodySel} .rtOutline`)
 
@@ -24,6 +25,7 @@ describe('Adding new embedded Resource Templates', () => {
 
   describe('two levels of nested resourceTemplates (Instance of -> Notes about the Work)', () => {
     it('clicking AddButton adds second resource template', async () => {
+      expect.assertions(4)
       const ptOutlineSel = 'div[propLabel="Instance of"] div.rtOutline[propLabel="Notes about the Work"]'
 
       await pupExpect(page).toClick(`${ptOutlineSel} a[data-id='note']`)
@@ -37,6 +39,7 @@ describe('Adding new embedded Resource Templates', () => {
   })
 
   it('AddButton disabled for non-repeatable resourceTemplate (Item Information -> Barcode)', async () => {
+    expect.assertions(1)
     await pupExpect(page).toMatchElement('div[propLabel="Item Information"] > div.panel-body button', { disabled: true })
   })
 })

--- a/__tests__/integration/schemaValidation.test.js
+++ b/__tests__/integration/schemaValidation.test.js
@@ -5,10 +5,11 @@ import { testUserLogin } from './loginHelper'
 
 describe('Importing a profile/template with bad JSON', () => {
   beforeAll(async () => {
-    await testUserLogin()
+    return await testUserLogin()
   })
 
   it('Displays an error message', async () => {
+    expect.assertions(2)
     await page.goto('http://127.0.0.1:8888/templates')
 
     await page.waitForSelector('button#ImportProfile')

--- a/__tests__/integration/unauthenticatedNavigation.test.js
+++ b/__tests__/integration/unauthenticatedNavigation.test.js
@@ -1,5 +1,5 @@
 // Copyright 2019 Stanford University see LICENSE for license
-import expect from 'expect-puppeteer'
+import pupExpect from 'expect-puppeteer'
 import 'isomorphic-fetch'
 import { testUserLogout } from './loginHelper'
 
@@ -13,13 +13,11 @@ describe('When an unauthenticated user tries to access resource templates', () =
     } catch (error) {
       // Avoid failing after logout
     }
-  })
-
-  it('displays the login form', async () => {
-    await page.waitForSelector('form.login-form')
+    return await page.waitForSelector('form.login-form') // Waiting for login form
   })
 
   it('does not display "Available Resource Templates in Sinopia"', async () => {
-    await expect(page).not.toMatch('Available Resource Templates in Sinopia')
+    expect.assertions(1)
+    await pupExpect(page).not.toMatch('Available Resource Templates in Sinopia')
   })
 })

--- a/__tests__/sinopiaServer.test.js
+++ b/__tests__/sinopiaServer.test.js
@@ -9,6 +9,7 @@ jest.spyOn(Config, 'spoofSinopiaServer', 'get').mockReturnValue(true)
 describe('sinopiaServer', () => {
   describe('getResourceTemplate', () => {
     it('known id: returns JSON for resource template', async () => {
+      expect.assertions(2)
       const template = await sinopiaServer.getResourceTemplate('resourceTemplate:bf2:Title')
 
       expect(template.response.body.id).toEqual('resourceTemplate:bf2:Title')

--- a/__tests__/sinopiaServerSpoof.test.js
+++ b/__tests__/sinopiaServerSpoof.test.js
@@ -36,6 +36,7 @@ describe('sinopiaServerSpoof', () => {
 
   describe('spoofedGetResourceTemplate', () => {
     it('known id: returns JSON for resource template', async () => {
+      expect.assertions(2)
       const template = await spoofedGetResourceTemplate('resourceTemplate:bf2:Title')
 
       expect(template.response.body.id).toEqual('resourceTemplate:bf2:Title')

--- a/src/components/editor/property/PropertyPanel.jsx
+++ b/src/components/editor/property/PropertyPanel.jsx
@@ -23,7 +23,7 @@ export default class PropertyPanel extends Component {
 
   render() {
     return (
-      <div className={this.getCssClasses()}>
+      <div className={this.getCssClasses()} propLabel={this.props.pt.propertyLabel}>
         <div className="panel-heading prop-heading">
           <PropertyLabel pt={this.props.pt} />
         </div>

--- a/src/components/editor/property/PropertyTemplateOutline.jsx
+++ b/src/components/editor/property/PropertyTemplateOutline.jsx
@@ -88,7 +88,7 @@ export class PropertyTemplateOutline extends Component {
 
   render() {
     return (
-      <div className="rtOutline">
+      <div className="rtOutline" propLabel={this.props.propertyTemplate.propertyLabel}>
         <OutlineHeader pt={this.props.propertyTemplate}
                        id={resourceToName(this.props.propertyTemplate.propertyURI)}
                        collapsed={this.state.collapsed}


### PR DESCRIPTION
This makes the css selectors a lot more readable for integration tests.

Since those were async tests and I realized they needed a little bit of love to avoid false positives, I just did a search on `async` in all the tests and applied the same love everywhere.
- be sure to "return" on async beforeXXX blocks  (https://jestjs.io/docs/en/setup-teardown) 
- indicate the number of assertions expected in a test (https://jestjs.io/docs/en/asynchronous)


Only one test showed up as being a no-op, which I marked "skip".

closes #573