### PR TITLE
Change propLabel to data-label

### DIFF
--- a/__tests__/integration/repeatableResources.test.js
+++ b/__tests__/integration/repeatableResources.test.js
@@ -13,7 +13,7 @@ describe('Adding new embedded Resource Templates', () => {
   describe('one level of nested resourceTemplate (Notes about the Instance)', () => {
     it('clicking AddButton adds second resource template', async () => {
       expect.assertions(5) // Includes 2 in beforeAll
-      const panelBodySel = 'div[propLabel="Notes about the Instance"] > div.panel-body'
+      const panelBodySel = 'div[data-label="Notes about the Instance"] > div.panel-body'
       let noteRtOutlines = await page.$$(`${panelBodySel} .rtOutline`)
 
       expect(noteRtOutlines.length).toEqual(1)
@@ -26,7 +26,7 @@ describe('Adding new embedded Resource Templates', () => {
   describe('two levels of nested resourceTemplates (Instance of -> Notes about the Work)', () => {
     it('clicking AddButton adds second resource template', async () => {
       expect.assertions(4)
-      const ptOutlineSel = 'div[propLabel="Instance of"] div.rtOutline[propLabel="Notes about the Work"]'
+      const ptOutlineSel = 'div[data-label="Instance of"] div.rtOutline[data-label="Notes about the Work"]'
 
       await pupExpect(page).toClick(`${ptOutlineSel} a[data-id='note']`)
       let noteRtOutlines = await page.$$(`${ptOutlineSel} .rtOutline`)
@@ -40,6 +40,6 @@ describe('Adding new embedded Resource Templates', () => {
 
   it('AddButton disabled for non-repeatable resourceTemplate (Item Information -> Barcode)', async () => {
     expect.assertions(1)
-    await pupExpect(page).toMatchElement('div[propLabel="Item Information"] > div.panel-body button', { disabled: true })
+    await pupExpect(page).toMatchElement('div[data-label="Item Information"] > div.panel-body button', { disabled: true })
   })
 })

--- a/src/components/editor/property/PropertyPanel.jsx
+++ b/src/components/editor/property/PropertyPanel.jsx
@@ -23,7 +23,7 @@ export default class PropertyPanel extends Component {
 
   render() {
     return (
-      <div className={this.getCssClasses()} propLabel={this.props.pt.propertyLabel}>
+      <div className={this.getCssClasses()} data-label={this.props.pt.propertyLabel}>
         <div className="panel-heading prop-heading">
           <PropertyLabel pt={this.props.pt} />
         </div>

--- a/src/components/editor/property/PropertyTemplateOutline.jsx
+++ b/src/components/editor/property/PropertyTemplateOutline.jsx
@@ -93,7 +93,7 @@ export class PropertyTemplateOutline extends Component {
 
   render() {
     return (
-      <div className="rtOutline" propLabel={this.props.propertyTemplate.propertyLabel}>
+      <div className="rtOutline" data-label={this.props.propertyTemplate.propertyLabel}>
         <OutlineHeader pt={this.props.propertyTemplate}
                        id={resourceToName(this.props.propertyTemplate.propertyURI)}
                        collapsed={this.state.collapsed}


### PR DESCRIPTION
propLabel was not recognized by react and raised a warning.  data-label can fulfill the same purpose and it doesn't raise a warning

Fixes #707