### PR TITLE
Updated version and regenerated lock file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sinopia_editor",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "editor",
     "rdf"
   ],
-  "version": "0.3.1",
+  "version": "0.3.2",
   "homepage": "http://github.com/LD4P/sinopia_editor/",
   "engines": {
     "node": "10.11.x"


### PR DESCRIPTION
Version bump; will create a tagged release `0.3.2` when merged.