### PR TITLE
Do not add extra property rows when clicking the plus/add button.

### DIFF
--- a/__tests__/components/editor/property/PropertyTemplateOutline.test.js
+++ b/__tests__/components/editor/property/PropertyTemplateOutline.test.js
@@ -126,6 +126,13 @@ describe('<PropertyTemplateOutline />', () => {
       wrapper.instance().addPropertyTypeRows(propertyRtPropsLiteral.propertyTemplate)
       expect(wrapper.find('div PropertyTypeRow').length).toEqual(1)
       expect(wrapper.find('div PropertyComponent').length).toEqual(1)
+
+      // This tests to ensure that we are not adding an addition property row when we click to collapse the row
+      wrapper.setState({ collapsed: true })
+      wrapper.instance().outlineRowClass()
+      wrapper.instance().addPropertyTypeRows(propertyRtPropsLiteral.propertyTemplate)
+      expect(wrapper.find('div PropertyTypeRow').length).toEqual(1)
+      expect(wrapper.find('div PropertyComponent').length).toEqual(1)
     })
   })
 })

--- a/src/components/editor/property/PropertyTemplateOutline.jsx
+++ b/src/components/editor/property/PropertyTemplateOutline.jsx
@@ -51,13 +51,17 @@ export class PropertyTemplateOutline extends Component {
   // When the plus button is clicked, load reference templates (property.valueConstraint.valueTemplateRefs)
   handleClick = property => (event) => {
     event.preventDefault()
+
+    if (this.state.collapsed && !this.state.added) {
+      const templateRefList = isResourceWithValueTemplateRef(property) ? property.valueConstraint.valueTemplateRefs : []
+
+      this.fulfillRTPromises(this.resourceTemplatePromises(templateRefList)).then(() => {
+        this.addPropertyTypeRows(this.props.propertyTemplate)
+      })
+      this.setState({ added: true })
+    }
+
     this.setState({ collapsed: !this.state.collapsed })
-
-    const templateRefList = isResourceWithValueTemplateRef(property) ? property.valueConstraint.valueTemplateRefs : []
-
-    this.fulfillRTPromises(this.resourceTemplatePromises(templateRefList)).then(() => {
-      this.addPropertyTypeRows(this.props.propertyTemplate)
-    })
   }
 
   addPropertyTypeRows = (property) => {

--- a/src/components/editor/property/PropertyTemplateOutline.jsx
+++ b/src/components/editor/property/PropertyTemplateOutline.jsx
@@ -52,13 +52,12 @@ export class PropertyTemplateOutline extends Component {
   handleClick = property => (event) => {
     event.preventDefault()
 
-    if (this.state.collapsed && !this.state.added) {
+    if (this.state.collapsed && !this.state.rowAdded) {
       const templateRefList = isResourceWithValueTemplateRef(property) ? property.valueConstraint.valueTemplateRefs : []
 
       this.fulfillRTPromises(this.resourceTemplatePromises(templateRefList)).then(() => {
         this.addPropertyTypeRows(this.props.propertyTemplate)
       })
-      this.setState({ added: true })
     }
 
     this.setState({ collapsed: !this.state.collapsed })

--- a/src/components/editor/property/PropertyTemplateOutline.jsx
+++ b/src/components/editor/property/PropertyTemplateOutline.jsx
@@ -70,7 +70,7 @@ export class PropertyTemplateOutline extends Component {
     if (this.state.collapsed) {
       return
     }
-  
+
     if (isResourceWithValueTemplateRef(property)) {
       const isAddDisabled = !templateBoolean(property.repeatable) || newOutput.length > 0
 

--- a/src/components/editor/property/PropertyTemplateOutline.jsx
+++ b/src/components/editor/property/PropertyTemplateOutline.jsx
@@ -67,6 +67,10 @@ export class PropertyTemplateOutline extends Component {
     const newOutput = [...this.state.propertyTypeRow]
     let propertyJsx
 
+    if (this.state.collapsed) {
+      return
+    }
+  
     if (isResourceWithValueTemplateRef(property)) {
       const isAddDisabled = !templateBoolean(property.repeatable) || newOutput.length > 0
 


### PR DESCRIPTION
Fixes #697 

I am working on a more complete test for this. I'm happy to continue that test here or in a follow up PR if this fix needs to get in ASAP.