### PR TITLE
Fix Blank Screen when performing a Lookup

### DIFF
--- a/__tests__/Utilities.test.js
+++ b/__tests__/Utilities.test.js
@@ -137,6 +137,19 @@ describe('Utilities', () => {
       expect(defaultValuesFromPropertyTemplate(propertyTemplate)).toEqual([])
     })
 
+    it('returns an empty array if the defaults are blank', () => {
+      const propertyTemplate = {
+        valueConstraint: {
+          defaults: [{
+            defaultLiteral: '',
+            defaultURI: '',
+          }],
+        },
+      }
+
+      expect(defaultValuesFromPropertyTemplate(propertyTemplate)).toEqual([])
+    })
+
     it('returns an array with an object otherwise', () => {
       const propertyTemplateWithDefaultsAndLabel = {
         valueConstraint: {

--- a/__tests__/reducers/inputs.test.js
+++ b/__tests__/reducers/inputs.test.js
@@ -293,13 +293,33 @@ describe('setMySelections', () => {
       type: 'CHANGE_SELECTIONS',
       payload: {
         id: 'nomatter',
-        uri: 'http://not/importanr',
+        uri: 'http://not.important',
         reduxPath,
         items: [],
       },
     })
 
     expect(findNode(result, reduxPath)).toEqual({ items: [] })
+  })
+
+  it('adds an empty object for a key if the key does not contain an object by default', () => {
+    initialState.resource = {
+      'resourceTemplate:Monograph:Instance': {
+        'http://schema.org/name': {},
+      },
+    }
+
+    const reduxPath = ['resource', 'resourceTemplate:Monograph:Instance', 'http://schema.org/name', 'QBzX5hqphW', 'test:RT:SomethingElse', 'http://not.important']
+    const result = setMySelections(initialState, {
+      type: 'CHANGE_SELECTIONS',
+      payload: {
+        uri: 'http://not.important/now',
+        items: [{ id: 'http://lookup.source/1', label: 'Something looked up', uri: 'http://lookup.source/1' }],
+        reduxPath,
+      },
+    })
+
+    expect(findNode(result, reduxPath)).toEqual({ items: [{ id: 'http://lookup.source/1', label: 'Something looked up', uri: 'http://lookup.source/1' }] })
   })
 })
 

--- a/__tests__/reducers/inputs.test.js
+++ b/__tests__/reducers/inputs.test.js
@@ -1,7 +1,7 @@
 // Copyright 2019 Stanford University see LICENSE for license
 
 import {
-  removeAllContent, removeMyItem, setMyItems, setMySelections, setBaseURL,
+  removeAllContent, removeMyItem, setItemsOrSelections, setBaseURL,
   validate, showGroupChooser, closeGroupChooser, showRdfPreview,
 } from 'reducers/inputs'
 
@@ -89,7 +89,7 @@ describe('showRdfPreview()', () => {
   })
 })
 
-describe('setMyItems', () => {
+describe('setItemsOrSelections with action type: SET_ITEMS', () => {
   it('adds item to state', () => {
     initialState.resource = {
       'resourceTemplate:Monograph:Instance': {
@@ -98,7 +98,7 @@ describe('setMyItems', () => {
     }
 
     const reduxPath = ['resource', 'resourceTemplate:Monograph:Instance', 'http://schema.org/name']
-    const result = setMyItems(initialState, {
+    const result = setItemsOrSelections(initialState, {
       type: 'SET_ITEMS',
       payload: {
         rtId: 'resourceTemplate:Monograph:Instance',
@@ -115,7 +115,7 @@ describe('setMyItems', () => {
 
   it('adds item to an empty state', () => {
     const reduxPath = ['resource', 'resourceTemplate:Monograph:Instance', 'http://schema.org/name']
-    const result = setMyItems(initialState,
+    const result = setItemsOrSelections(initialState,
       {
         type: 'SET_ITEMS',
         payload: {
@@ -137,7 +137,7 @@ describe('setMyItems', () => {
     }
 
     const reduxPath = ['resource', 'resourceTemplate:Monograph:Instance', 'http://schema.org/description']
-    const result = setMyItems(initialState,
+    const result = setItemsOrSelections(initialState,
       {
         type: 'SET_ITEMS',
         payload: {
@@ -169,7 +169,7 @@ describe('setMyItems', () => {
       'resourceTemplate:bf2:Title',
       'http://id.loc.gov/ontologies/bibframe/mainTitle',
     ]
-    const result = setMyItems(initialState,
+    const result = setItemsOrSelections(initialState,
       {
         type: 'SET_ITEMS',
         payload: {
@@ -200,7 +200,7 @@ describe('setMyItems', () => {
     }
 
     const reduxPath = ['resource', 'resourceTemplate:Monograph:Instance', 'http://schema.org/description']
-    const result = setMyItems(initialState,
+    const result = setItemsOrSelections(initialState,
       {
         type: 'SET_ITEMS',
         payload: {
@@ -223,7 +223,7 @@ describe('setMyItems', () => {
   })
 })
 
-describe('setMySelections', () => {
+describe('setItemsOrSelections with action type: CHANGE_SELECTIONS', () => {
   it('adds items to state', () => {
     initialState.resource = {
       'resourceTemplate:Monograph:Instance': {
@@ -232,7 +232,7 @@ describe('setMySelections', () => {
     }
 
     const reduxPath = ['resource', 'resourceTemplate:Monograph:Instance', 'http://schema.org/name']
-    const result = setMySelections(initialState, {
+    const result = setItemsOrSelections(initialState, {
       type: 'CHANGE_SELECTIONS',
       payload: {
         id: 'abc123',
@@ -255,7 +255,7 @@ describe('setMySelections', () => {
     }
 
     const reduxPath = ['resource', 'resourceTemplate:Monograph:Instance', 'http://schema.org/name']
-    const result = setMySelections(initialState, {
+    const result = setItemsOrSelections(initialState, {
       type: 'CHANGE_SELECTIONS',
       payload: {
         id: 'def456',
@@ -289,7 +289,7 @@ describe('setMySelections', () => {
     }
 
     const reduxPath = ['resource', 'resourceTemplate:Monograph:Instance', 'http://schema.org/name']
-    const result = setMySelections(initialState, {
+    const result = setItemsOrSelections(initialState, {
       type: 'CHANGE_SELECTIONS',
       payload: {
         id: 'nomatter',
@@ -310,7 +310,7 @@ describe('setMySelections', () => {
     }
 
     const reduxPath = ['resource', 'resourceTemplate:Monograph:Instance', 'http://schema.org/name', 'QBzX5hqphW', 'test:RT:SomethingElse', 'http://not.important']
-    const result = setMySelections(initialState, {
+    const result = setItemsOrSelections(initialState, {
       type: 'CHANGE_SELECTIONS',
       payload: {
         uri: 'http://not.important/now',

--- a/src/Utilities.js
+++ b/src/Utilities.js
@@ -24,7 +24,7 @@ export const defaultValuesFromPropertyTemplate = (propertyTemplate) => {
 
   const defaultLabel = defaultLiteral || defaultURI
 
-  if (!defaultValue) return []
+  if (!defaultValue || !defaultLabel) return []
 
   return [{
     id: defaultValue.defaultURI,

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -5,7 +5,7 @@ import { combineReducers } from 'redux'
 import shortid from 'shortid'
 import authenticate from './authenticate'
 import {
-  removeAllContent, removeMyItem, setMyItems, setMySelections, setBaseURL, setMyItemsLang,
+  removeAllContent, removeMyItem, setItemsOrSelections, setBaseURL, setMyItemsLang,
   showGroupChooser, closeGroupChooser, showRdfPreview,
 } from './inputs'
 import GraphBuilder from '../GraphBuilder'
@@ -143,7 +143,8 @@ const selectorReducer = (state = {}, action) => {
     case 'SET_RESOURCE_TEMPLATE':
       return setResourceTemplate(state, action)
     case 'SET_ITEMS':
-      return setMyItems(state, action)
+    case 'CHANGE_SELECTIONS':
+      return setItemsOrSelections(state, action)
     case 'SET_BASE_URL':
       return setBaseURL(state, action)
     case 'SHOW_GROUP_CHOOSER':
@@ -156,8 +157,6 @@ const selectorReducer = (state = {}, action) => {
       return showRdfPreview(state, action)
     case 'RESOURCE_TEMPLATE_LOADED':
       return resourceTemplateLoaded(state, action)
-    case 'CHANGE_SELECTIONS':
-      return setMySelections(state, action)
     case 'REFRESH_RESOURCE_TEMPLATE':
       return refreshResourceTemplate(state, action)
     case 'REMOVE_ITEM':

--- a/src/reducers/inputs.js
+++ b/src/reducers/inputs.js
@@ -129,6 +129,10 @@ export const setMySelections = (state, action) => {
       obj[key].items = action.payload.items
     }
 
+    if (!Object.keys(obj).includes(key)) {
+      obj[key] = {}
+    }
+
     return obj[key]
   }, newState)
 

--- a/src/reducers/inputs.js
+++ b/src/reducers/inputs.js
@@ -65,7 +65,7 @@ export const removeAllContent = (state, action) => {
   return validate(newState)
 }
 
-export const setMyItems = (state, action) => {
+export const setItemsOrSelections = (state, action) => {
   const newState = { ...state }
   const reduxPath = action.payload.reduxPath
   let level = 0
@@ -76,9 +76,14 @@ export const setMyItems = (state, action) => {
       if ((key in obj) !== true || !Object.keys(obj[key]).includes('items')) {
         obj[key] = { items: [] }
       }
-      action.payload.items.map((row) => {
-        obj[key].items.push(row)
-      })
+      if (action.type === 'SET_ITEMS') {
+        action.payload.items.map((row) => {
+          obj[key].items.push(row)
+        })
+      }
+      else if (action.type === 'CHANGE_SELECTIONS') {
+        obj[key].items = action.payload.items
+      }
     }
     if (!Object.keys(obj).includes(key)) {
       obj[key] = {}
@@ -113,30 +118,6 @@ export const setMyItemsLang = (state, action) => {
   }, newState)
 
   return newState
-}
-
-export const setMySelections = (state, action) => {
-  const newState = { ...state }
-  const reduxPath = action.payload.reduxPath
-  let level = 0
-
-  reduxPath.reduce((obj, key) => {
-    level++
-    if (level === reduxPath.length) {
-      if ((key in obj) !== true) {
-        obj[key] = { items: [] }
-      }
-      obj[key].items = action.payload.items
-    }
-
-    if (!Object.keys(obj).includes(key)) {
-      obj[key] = {}
-    }
-
-    return obj[key]
-  }, newState)
-
-  return validate(newState)
 }
 
 export const setBaseURL = (state, action) => {


### PR DESCRIPTION
Fixes #712:
Similar to https://github.com/LD4P/sinopia_editor/pull/684, if the lookup component has a `defaultURI` defined as an empty string, the `TypeaheadComponent` will expect a label to go along with that default and without one will crash. This PR redefines when the defaults should return an empty array to that component.

Fixes #718:
If the initial state of a redux resource object is undefined, and the defined property component assigns a `shortid` in the redux path, the component crashes when trying to filter on an undefined object in that path, so check for that in the reducer when reassigning state.

I ran across the bug surfaced in #718 while testing #712, so that's why this PR fixes both issues. I can split the PRs up if desired, but the changes here are not extensive.