### PR TITLE
ResourceProperty: separate state changes from rendering

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -134,7 +134,8 @@ module.exports = {
     "import/no-namespace": "off",
     "no-nested-ternary": "off",
     'lines-around-comment': ['error', { 'allowBlockStart': true }],
-    'capitalized-comments': "off"
+    'capitalized-comments': "off",
+    'multiline-comment-style': "off"
   },
   overrides: [
     {

--- a/src/components/editor/property/ResourceProperty.jsx
+++ b/src/components/editor/property/ResourceProperty.jsx
@@ -12,8 +12,17 @@ import { booleanPropertyFromTemplate } from 'Utilities'
 const _ = require('lodash')
 
 export class ResourceProperty extends Component {
+  dispatchPayloads = [] // to separate needed state changes from rendering
+
   constructor(props) {
     super(props)
+    this.dispatchPayloads = []
+  }
+
+  // NOTE:  if this component is ever re-rendered, we will need to ensure we get *changed* payloads to redux
+  //   as of 2019-06-18, the code base never re-renders this component, AFAICT.  We load the resource template up once.
+  componentDidMount() {
+    this.dispatchPayloads.forEach((payload) => { this.props.initNewResourceTemplate(payload) })
   }
 
   renderResourcePropertyJsx = () => {
@@ -56,8 +65,8 @@ export class ResourceProperty extends Component {
 
         propertyReduxPath.push(rtProperty.propertyURI)
         const payload = { reduxPath: propertyReduxPath, property: rtProperty }
+        this.dispatchPayloads.push(payload)
 
-        this.props.initNewResourceTemplate(payload)
         const isAddDisabled = !booleanPropertyFromTemplate(rtProperty, 'repeatable', false)
 
         jsx.push(


### PR DESCRIPTION
Fixes #649 - warning about state changes during rendering of `ResourceProperty` component.

Assumptions / Questions:
- [ ] It appears that we do not need to concern ourselves with `componentDidUpdate()` state changes, as this component is seemingly never updated after the first render (?)  -- all the pertinent state information is passed to child components (or they read it from redux)
- [ ] I believe that the same error from #649 would surface if I used component specific state (rather than redux) and updated component state during rendering -- hence a "class variable" approach.
- [ ] I'm unclear on the best way to have a "class variable" so that the `renderResourcePropertyJsx()` method can write to it, and it will never have cruft.
- [ ] I set the class variable to empty array in the constructor "just in case" - not sure it's needed.
- [ ] Because this is about a console warning that only appears when running in React development mode, (https://developmentarc.gitbooks.io/react-indepth/content/life_cycle/birth/component_render.html), I assumed allowing the existing tests to pass would be sufficient testing (aside from what I did manually).
