### PR TITLE
get the correct list of groups to display (and sort them in alphabetical order) when choosing where to save a resource

### DIFF
--- a/__tests__/components/editor/GroupChoiceModal.test.js
+++ b/__tests__/components/editor/GroupChoiceModal.test.js
@@ -51,23 +51,15 @@ describe('<GroupChoiceModal />', () => {
     })
 
     it('has the first select option as "Cornell University"', () => {
-      expect(wrapper.find(Modal.Body).find('form').find('select').find('option')
-        .first()
-        .childAt(0)
-        .text()).toEqual('Cornell University')
-      expect(wrapper.find(Modal.Body).find('form').find('select').find('option')
-        .first()
-        .prop('value')).toEqual('cornell')
+      const firstOpt = wrapper.find(Modal.Body).find('form select option').first()
+      expect(firstOpt.text()).toEqual('Cornell University')
+      expect(firstOpt.prop('value')).toEqual('cornell')
     })
 
     it('has the last select option as "Yale University"', () => {
-      expect(wrapper.find(Modal.Body).find('form').find('select').find('option')
-        .last()
-        .childAt(0)
-        .text()).toEqual('Yale University')
-      expect(wrapper.find(Modal.Body).find('form').find('select').find('option')
-        .last()
-        .prop('value')).toEqual('yale')
+      const lastOpt = wrapper.find(Modal.Body).find('form select option').last()
+      expect(lastOpt.text()).toEqual('Yale University')
+      expect(lastOpt.prop('value')).toEqual('yale')
     })
 
     it('displays the groups from the config in alphabetical order, with ld4p omitted', () => {

--- a/__tests__/components/editor/GroupChoiceModal.test.js
+++ b/__tests__/components/editor/GroupChoiceModal.test.js
@@ -4,6 +4,7 @@ import React from 'react'
 import Modal from 'react-bootstrap/lib/Modal'
 import Button from 'react-bootstrap/lib/Button'
 import { shallow } from 'enzyme'
+import Config from 'Config'
 import GroupChoiceModal from 'components/editor/GroupChoiceModal'
 /* eslint import/namespace: 'off' */
 import * as server from 'sinopiaServer'
@@ -19,13 +20,10 @@ describe('<GroupChoiceModal />', () => {
   const rdfFunc = jest.fn()
   const closeFunc = jest.fn()
   const closeRdfPreview = jest.fn()
-  const groups = [['pcc', 'PCC'],
-    ['wau', 'University of Washington']]
 
   const wrapper = shallow(<GroupChoiceModal.WrappedComponent show={true}
                                                              rdf={rdfFunc}
                                                              close={closeFunc}
-                                                             groups={groups}
                                                              closeRdfPreview={closeRdfPreview} />)
 
   it('renders the <GroupChoiceModal /> component as a Modal', () => {
@@ -52,24 +50,36 @@ describe('<GroupChoiceModal />', () => {
       expect(wrapper.find(Modal.Body).find('form').find('select').length).toEqual(1)
     })
 
-    it('has the first select option as "PCC"', () => {
+    it('has the first select option as "Cornell University"', () => {
       expect(wrapper.find(Modal.Body).find('form').find('select').find('option')
         .first()
         .childAt(0)
-        .text()).toEqual('PCC')
+        .text()).toEqual('Cornell University')
       expect(wrapper.find(Modal.Body).find('form').find('select').find('option')
         .first()
-        .prop('value')).toEqual('pcc')
+        .prop('value')).toEqual('cornell')
     })
 
-    it('has the last select option as "University of Washington"', () => {
+    it('has the last select option as "Yale University"', () => {
       expect(wrapper.find(Modal.Body).find('form').find('select').find('option')
         .last()
         .childAt(0)
-        .text()).toEqual('University of Washington')
+        .text()).toEqual('Yale University')
       expect(wrapper.find(Modal.Body).find('form').find('select').find('option')
         .last()
-        .prop('value')).toEqual('wau')
+        .prop('value')).toEqual('yale')
+    })
+
+    it('displays the groups from the config in alphabetical order, with ld4p omitted', () => {
+      const expectedGroups = Object.entries(Config.groupsInSinopia)
+        .filter(([groupSlug]) => groupSlug !== 'ld4p')
+        .sort(([, groupLabelA], [, groupLabelB]) => groupLabelA.localeCompare(groupLabelB))
+
+      const actualGroups = wrapper.find(Modal.Body)
+        .find('form.group-select-options select option')
+        .map(node => [node.prop('value'), node.text()])
+
+      expect(actualGroups).toEqual(expectedGroups)
     })
 
     it('has a Cancel link', () => {

--- a/src/Config.js
+++ b/src/Config.js
@@ -72,20 +72,33 @@ class Config {
     return process.env.MAX_RECORDS_FOR_QA_LOOKUPS || 8
   }
 
+  // WARNING: the groups section in config/default.js in the sinopia_acl codebase *must* be kept in sync with this section
   static get groupsInSinopia() {
-    return [
-      ['ld4p', 'LD4P'],
-      ['pcc', 'PCC'],
-      ['cub', 'University of Colorado Boulder'],
-      ['cornell', 'Cornell University'],
-      ['harvard', 'Harvard University'],
-      ['nlm', 'National Library of Medicine'],
-      ['stanford', 'Stanford University'],
-      ['ucsd', 'University of California, San Diego'],
-      ['penn', 'University of Pennsylvania'],
-      ['hrc', 'Harry Ransom Center, University of Texas at Austin'],
-      ['wau', 'University of Washington'],
-    ]
+    return {
+      alberta: 'University of Alberta',
+      boulder: 'University of Colorado, Boulder',
+      chicago: 'University of Chicago',
+      cornell: 'Cornell University',
+      dlc: 'Library of Congress',
+      duke: 'Duke University',
+      frick: 'Frick Art Reference Library',
+      harvard: 'Harvard University',
+      hrc: 'University of Texas, Austin, Harry Ransom Center',
+      ld4p: 'LD4P',
+      michigan: 'University of Michigan',
+      minnesota: 'University of Minnesota',
+      nlm: 'National Library of Medicine',
+      northwestern: 'Northwestern University',
+      pcc: 'PCC',
+      penn: 'University of Pennsylvania',
+      princeton: 'Princeton University',
+      stanford: 'Stanford University',
+      tamu: 'Texas A&M University',
+      ucdavis: 'University of California, Davis',
+      ucsd: 'University of California, San Diego',
+      washington: 'University of Washington',
+      yale: 'Yale University',
+    }
   }
 }
 

--- a/src/components/editor/GroupChoiceModal.jsx
+++ b/src/components/editor/GroupChoiceModal.jsx
@@ -15,7 +15,9 @@ const GroupChoiceModal = (props) => {
   const [selectedValue, setSelectedValue] = useState('ld4p')
 
   // The ld4p group is only for templates
-  const groups = Config.groupsInSinopia.filter(group => group[0] !== 'ld4p')
+  const groups = Object.entries(Config.groupsInSinopia)
+    .filter(([groupSlug]) => groupSlug !== 'ld4p')
+    .sort(([, groupLabelA], [, groupLabelB]) => groupLabelA.localeCompare(groupLabelB))
 
   const updateSelectedValue = (event) => {
     setSelectedValue(event.target.value)


### PR DESCRIPTION
a bit of light refactoring and tweaking to make it happen, plus a new integration test to make sure it worked.

the sort wasn't asked for, but it seemed easy enough to do, so i went ahead and did that.

if this gets merged as-is, we should also merge the comment in LD4P/sinopia_acl#75

closes #732