### PR TITLE
Expand nested resource test to verify content exists in preview RDF

### DIFF
--- a/__tests__/integration/nestedResources.test.js
+++ b/__tests__/integration/nestedResources.test.js
@@ -8,36 +8,64 @@ describe('Expanding a resource property in a property panel', () => {
     return await testUserLogin()
   })
 
-  it('loads up a resource template from the list of loaded templates', async () => {
+  it('loads up the BIBFRAME Instance resource template from the list of loaded templates', async () => {
     expect.assertions(2)
     await pupExpect(page).toClick('a', { text: 'BIBFRAME Instance' })
     await pupExpect(page).toMatch('BIBFRAME Instance')
   })
 
-  it('clicks on one of the property type rows to expand a nested resource', async () => {
+  it('clicks on the Has BIBFRAME Instance property type rows to expand the resource', async () => {
     expect.assertions(2)
     await pupExpect(page).toClick('a[data-id=\'hasInstance\']')
     await pupExpect(page).toMatchElement('h5', { text: 'BIBFRAME Instance' })
   })
 
-  it('clicks on a nested property to reveal an input component', async () => {
-    expect.assertions(2)
-    await pupExpect(page).toClick('a[data-id=\'heldBy\']')
-    await pupExpect(page).toMatchElement('input[placeholder=\'Holdings\']')
-  })
-
-  it('enters a value into a nested prooperty component', async () => {
+  it('clicks on the Title property to reveal the main title input component', async () => {
     expect.assertions(3)
-    await pupExpect(page).not.toMatchElement('div#userInput', { text: 'Some text' })
-    await expect(page).toFill('input[placeholder="Holdings"', 'Some text')
-    await page.keyboard.press('Enter')
-    await pupExpect(page).toMatchElement('div#userInput', { text: 'Some text' })
+    await pupExpect(page).toClick('a[data-id=\'title\']')
+    await pupExpect(page).toClick('a[data-id=\'mainTitle\']')
+    await pupExpect(page).toMatchElement('input[placeholder=\'Preferred Title for Work (RDA 6.2.2, RDA 6.14.2) (BIBFRAME: Main title)\']')
   })
 
-  it('enters a non-roman value into a nested property component', async () => {
-    expect.assertions(2)
-    await pupExpect(page).toFill('input[placeholder="Holdings"', '甲骨文')
+  it('enters a title into the BIBFRAME Instance Work Title component', async () => {
+    expect.assertions(3)
+    await pupExpect(page).not.toMatchElement('div#userInput', { text: 'An interesting title' })
+    await expect(page).toFill('input[placeholder="Preferred Title for Work (RDA 6.2.2, RDA 6.14.2) (BIBFRAME: Main title)"', 'An interesting title')
     await page.keyboard.press('Enter')
-    await pupExpect(page).toMatchElement('div#userInput', { text: '甲骨文' })
+    await pupExpect(page).toMatchElement('div#userInput', { text: 'An interesting title' })
+  })
+
+  it('clicks on the Responsibility Statement property to reveal the responsibility input component', async () => {
+    expect.assertions(2)
+    await pupExpect(page).toClick('a[data-id=\'responsibilityStatement\']')
+    await pupExpect(page).toMatchElement('input[placeholder=\'Statement of Responsibility Relating to Title Proper (RDA 2.4.2)\']')
+  })
+
+  it('enters text into the BIBFRAME Instance Statement of Responsibility component', async () => {
+    expect.assertions(3)
+    await pupExpect(page).not.toMatchElement('div#userInput', { text: 'A statement of responsibility' })
+    await expect(page).toFill('input[placeholder="Statement of Responsibility Relating to Title Proper (RDA 2.4.2)"', 'A statement of responsibility')
+    await page.keyboard.press('Enter')
+    await pupExpect(page).toMatchElement('div#userInput', { text: 'A statement of responsibility' })
+  })
+
+  it('clicks on Contribution property to reveal the input component', async () => {
+    expect.assertions(6)
+    await pupExpect(page).toClick('a[data-id=\'contribution\']')
+    await pupExpect(page).toMatchElement('input[placeholder=\'Agent Contribution\']')
+    await expect(page).toFill('input[placeholder=\'Agent Contribution\']', 'Stanford family')
+    await pupExpect(page).toMatchElement('ul#lookupComponent')
+    await page.waitForSelector('li#rbt-menu-item-0')
+    await pupExpect(page).toMatchElement('li#rbt-menu-item-0')
+    await pupExpect(page).toClick('li#rbt-menu-item-0')
+  })
+
+  it('it clicks on Preview RDF and verifies the text', async () => {
+    expect.assertions(4)
+    await pupExpect(page).toClick('button', { text: 'Preview RDF' })
+    const rdfOut = await page.$eval('pre', e => e.textContent) // Copy the text from the modal into a variable
+    await expect(rdfOut).toMatch('An interesting title')
+    await expect(rdfOut).toMatch('A statement of responsibility')
+    await expect(rdfOut).toMatch('http://id.loc.gov/authorities/subjects/sh85127327') // this is the Stanford family URI
   })
 })

--- a/__tests__/integration/previewSaveRDF.test.js
+++ b/__tests__/integration/previewSaveRDF.test.js
@@ -8,25 +8,29 @@ describe('Previewing the RDF', () => {
     return await testUserLogin()
   })
 
-  beforeEach(async () => {
+  it('builds the rdf and has dialog for saving', async () => {
+    expect.assertions(18)
     await pupExpect(page).toClick('a', { text: 'BIBFRAME Instance' })
-    // await pupExpect(page).toMatch('BIBFRAME Instance')
-    await page.waitForSelector('a[data-id=\'title\'')
-    await page.click('a[data-id=\'title\']')
-    await page.waitForSelector('a[data-id=\'mainTitle\']')
-    await page.click('a[data-id=\'mainTitle\']')
+    await pupExpect(page).toMatch('BIBFRAME Instance')
+
+    // Click on one of the property type rows to expand a nested resource
+    await pupExpect(page).toClick('a[data-id=\'title\']')
+    await pupExpect(page).toMatchElement('h5', { text: 'Work Title' })
+
+    // Fill in required element
+    await pupExpect(page).toClick('a[data-id=\'mainTitle\']')
     await page.type('[placeholder=\'Preferred Title for Work (RDA 6.2.2, RDA 6.14.2) (BIBFRAME: Main title)\']', 'Hello')
     await page.keyboard.press('Enter')
-    await page.type('[placeholder=\'Statement of Responsibility Relating to Title Proper (RDA 2.4.2)\'', 'World')
-    await page.keyboard.press('Enter')
-    await page.type('[placeholder=\'Agent Contribution\']', 'Stanford family')
+
+    // Fill in required element
+    await page.type('[placeholder=\'Agent Contribution\']', 'Typing')
     // wait until autosuggest has returned something to click on
     await page.waitForSelector('#rbt-menu-item-0')
-    await page.click('#rbt-menu-item-0')
-  })
+    await pupExpect(page).toClick('#rbt-menu-item-0')
 
-  it('builds the rdf and has dialog for saving', async () => {
-    expect.assertions(13) // Includes one assertion from setup
+    // Fill in required element
+    await page.type('[placeholder=\'Statement of Responsibility Relating to Title Proper (RDA 2.4.2)\'', 'World')
+    await page.keyboard.press('Enter')
 
     // Click on the PreviewRDF button and a modal appears
     await pupExpect(page).toClick('button', { text: 'Preview RDF' })
@@ -34,11 +38,9 @@ describe('Previewing the RDF', () => {
     await pupExpect(page).toMatch('If this looks good, then click Save and Publish')
 
     // Present a choice of group to save to from the RDFModal
-    await page.waitForSelector('#modal-save')
     await pupExpect(page).toClick('#modal-save', { text: 'Save & Publish' })
-    await page.waitForSelector('.modal-title')
-    await page.screenshot({ path: '1.png', fullPage: true })
-    await pupExpect(page).toMatch('Which group do you want to save to?') // Add class modal-title
+
+    await pupExpect(page).toMatch('Which group do you want to save to?')
     await pupExpect(page).toMatch('Which group do you want to associate this record to?')
 
     // Click on the select menu to choose a group
@@ -52,58 +54,6 @@ describe('Previewing the RDF', () => {
 
     // Subsequent updates don't pop up the group modal
     await pupExpect(page).toClick('button', { text: 'Save & Publish' })
-    await pupExpect(page).not.toMatch('Which group do you want to save to?')  
+    await pupExpect(page).not.toMatch('Which group do you want to save to?')
   })
-
-//   describe('Hold this test', () => {
-//   // it('clicks on the Has BIBFRAME Instance property type rows to expand the resource', async () => {
-//   //   expect.assertions(2)
-//   //   await pupExpect(page).toClick('a[data-id=\'hasInstance\']')
-//   //   await pupExpect(page).toMatchElement('h5', { text: 'BIBFRAME Instance' })
-//   // })
-
-//   // it('clicks on the Title property to reveal the main title input component', async () => {
-//   //   expect.assertions(3)
-//   //   await pupExpect(page).toClick('a[data-id=\'title\']')
-//   //   await pupExpect(page).toClick('a[data-id=\'mainTitle\']')
-//   //   await pupExpect(page).toMatchElement('input[placeholder=\'Preferred Title for Work (RDA 6.2.2, RDA 6.14.2) (BIBFRAME: Main title)\']')
-//   // })
-
-//   // Asserting that the value entered above is now visible
-//   it('enters a title into the BIBFRAME Instance Work Title component', async () => {
-//     expect.assertions(2) // Includes an assertion from beforeEach
-//     await pupExpect(page).toMatchElement('div#userInput', { text: 'Hello' })
-//   })
-
-//   // it('clicks on the Responsibility Statement property to reveal the responsibility input component', async () => {
-//   //   expect.assertions(2)
-//   //   await pupExpect(page).toClick('a[data-id=\'responsibilityStatement\']')
-//   //   await pupExpect(page).toMatchElement('input[placeholder=\'Statement of Responsibility Relating to Title Proper (RDA 2.4.2)\']')
-//   // })
-
-//   it('enters text into the BIBFRAME Instance Statement of Responsibility component', async () => {
-//     expect.assertions(2) // Includes an assertion from beforeEach
-//     await pupExpect(page).toMatchElement('div#userInput', { text: 'World' })
-//   })
-
-//   it('clicks on Contribution property to reveal the input component', async () => {
-//     expect.assertions(6)
-//     await pupExpect(page).toClick('a[data-id=\'contribution\']')
-//     await pupExpect(page).toMatchElement('input[placeholder=\'Agent Contribution\']')
-//     await expect(page).toFill('input[placeholder=\'Agent Contribution\']', 'Stanford family')
-//     await pupExpect(page).toMatchElement('ul#lookupComponent')
-//     await page.waitForSelector('li#rbt-menu-item-0')
-//     await pupExpect(page).toMatchElement('li#rbt-menu-item-0')
-//     await pupExpect(page).toClick('li#rbt-menu-item-0')
-//   })
-
-//   it('it clicks on Preview RDF and verifies the text', async () => {
-//     expect.assertions(3)
-//     await pupExpect(page).toClick('button', { text: 'Preview RDF' })
-//     const rdfOut = await page.$eval('pre', e => e.textContent) // Copy the text from the modal into a variable
-//     await expect(rdfOut).toMatch(/Hello/)
-//     await expect(rdfOut).toMatch(/World/)
-//     await expect(rdfOut).toMatch(/http:\/\/id.loc.gov\/authorities\/subjects\/sh85127327/) // this is the Stanford family URI
-//   })
-// })
 })

--- a/__tests__/integration/previewSaveRDF.test.js
+++ b/__tests__/integration/previewSaveRDF.test.js
@@ -8,29 +8,25 @@ describe('Previewing the RDF', () => {
     return await testUserLogin()
   })
 
-  it('builds the rdf and has dialog for saving', async () => {
-    expect.assertions(16)
+  beforeEach(async () => {
     await pupExpect(page).toClick('a', { text: 'BIBFRAME Instance' })
-    await pupExpect(page).toMatch('BIBFRAME Instance')
-
-    // Click on one of the property type rows to expand a nested resource
-    await pupExpect(page).toClick('a[data-id=\'title\']')
-    await pupExpect(page).toMatchElement('h5', { text: 'Work Title' })
-
-    // Fill in required element
-    await pupExpect(page).toClick('a[data-id=\'mainTitle\']')
+    // await pupExpect(page).toMatch('BIBFRAME Instance')
+    await page.waitForSelector('a[data-id=\'title\'')
+    await page.click('a[data-id=\'title\']')
+    await page.waitForSelector('a[data-id=\'mainTitle\']')
+    await page.click('a[data-id=\'mainTitle\']')
     await page.type('[placeholder=\'Preferred Title for Work (RDA 6.2.2, RDA 6.14.2) (BIBFRAME: Main title)\']', 'Hello')
     await page.keyboard.press('Enter')
-
-    // Fill in required element
-    await page.type('[placeholder=\'Agent Contribution\']', 'Typing')
-    // wait until autosuggest has returned something to click on
-    await page.waitForSelector('#rbt-menu-item-0')
-    await pupExpect(page).toClick('#rbt-menu-item-0')
-
-    // Fill in required element
     await page.type('[placeholder=\'Statement of Responsibility Relating to Title Proper (RDA 2.4.2)\'', 'World')
     await page.keyboard.press('Enter')
+    await page.type('[placeholder=\'Agent Contribution\']', 'Stanford family')
+    // wait until autosuggest has returned something to click on
+    await page.waitForSelector('#rbt-menu-item-0')
+    await page.click('#rbt-menu-item-0')
+  })
+
+  it('builds the rdf and has dialog for saving', async () => {
+    expect.assertions(13) // Includes one assertion from setup
 
     // Click on the PreviewRDF button and a modal appears
     await pupExpect(page).toClick('button', { text: 'Preview RDF' })
@@ -38,9 +34,11 @@ describe('Previewing the RDF', () => {
     await pupExpect(page).toMatch('If this looks good, then click Save and Publish')
 
     // Present a choice of group to save to from the RDFModal
+    await page.waitForSelector('#modal-save')
     await pupExpect(page).toClick('#modal-save', { text: 'Save & Publish' })
-
-    await pupExpect(page).toMatch('Which group do you want to save to?')
+    await page.waitForSelector('.modal-title')
+    await page.screenshot({ path: '1.png', fullPage: true })
+    await pupExpect(page).toMatch('Which group do you want to save to?') // Add class modal-title
     await pupExpect(page).toMatch('Which group do you want to associate this record to?')
 
     // Click on the select menu to choose a group
@@ -51,5 +49,61 @@ describe('Previewing the RDF', () => {
     await pupExpect(page).toClick('button', { text: 'Save & Publish' })
     await pupExpect(page).toMatch('Which group do you want to save to?')
     await pupExpect(page).toMatch('Which group do you want to associate this record to?')
+
+    // Subsequent updates don't pop up the group modal
+    await pupExpect(page).toClick('button', { text: 'Save & Publish' })
+    await pupExpect(page).not.toMatch('Which group do you want to save to?')  
   })
+
+//   describe('Hold this test', () => {
+//   // it('clicks on the Has BIBFRAME Instance property type rows to expand the resource', async () => {
+//   //   expect.assertions(2)
+//   //   await pupExpect(page).toClick('a[data-id=\'hasInstance\']')
+//   //   await pupExpect(page).toMatchElement('h5', { text: 'BIBFRAME Instance' })
+//   // })
+
+//   // it('clicks on the Title property to reveal the main title input component', async () => {
+//   //   expect.assertions(3)
+//   //   await pupExpect(page).toClick('a[data-id=\'title\']')
+//   //   await pupExpect(page).toClick('a[data-id=\'mainTitle\']')
+//   //   await pupExpect(page).toMatchElement('input[placeholder=\'Preferred Title for Work (RDA 6.2.2, RDA 6.14.2) (BIBFRAME: Main title)\']')
+//   // })
+
+//   // Asserting that the value entered above is now visible
+//   it('enters a title into the BIBFRAME Instance Work Title component', async () => {
+//     expect.assertions(2) // Includes an assertion from beforeEach
+//     await pupExpect(page).toMatchElement('div#userInput', { text: 'Hello' })
+//   })
+
+//   // it('clicks on the Responsibility Statement property to reveal the responsibility input component', async () => {
+//   //   expect.assertions(2)
+//   //   await pupExpect(page).toClick('a[data-id=\'responsibilityStatement\']')
+//   //   await pupExpect(page).toMatchElement('input[placeholder=\'Statement of Responsibility Relating to Title Proper (RDA 2.4.2)\']')
+//   // })
+
+//   it('enters text into the BIBFRAME Instance Statement of Responsibility component', async () => {
+//     expect.assertions(2) // Includes an assertion from beforeEach
+//     await pupExpect(page).toMatchElement('div#userInput', { text: 'World' })
+//   })
+
+//   it('clicks on Contribution property to reveal the input component', async () => {
+//     expect.assertions(6)
+//     await pupExpect(page).toClick('a[data-id=\'contribution\']')
+//     await pupExpect(page).toMatchElement('input[placeholder=\'Agent Contribution\']')
+//     await expect(page).toFill('input[placeholder=\'Agent Contribution\']', 'Stanford family')
+//     await pupExpect(page).toMatchElement('ul#lookupComponent')
+//     await page.waitForSelector('li#rbt-menu-item-0')
+//     await pupExpect(page).toMatchElement('li#rbt-menu-item-0')
+//     await pupExpect(page).toClick('li#rbt-menu-item-0')
+//   })
+
+//   it('it clicks on Preview RDF and verifies the text', async () => {
+//     expect.assertions(3)
+//     await pupExpect(page).toClick('button', { text: 'Preview RDF' })
+//     const rdfOut = await page.$eval('pre', e => e.textContent) // Copy the text from the modal into a variable
+//     await expect(rdfOut).toMatch(/Hello/)
+//     await expect(rdfOut).toMatch(/World/)
+//     await expect(rdfOut).toMatch(/http:\/\/id.loc.gov\/authorities\/subjects\/sh85127327/) // this is the Stanford family URI
+//   })
+// })
 })


### PR DESCRIPTION
This is an expansion of the existing nested resource template to interact with the Preview RDF and verify that the entered text is present.

Opening this for review of direction / input.