### PR TITLE
Restore the ability for defaults to be used in a lookup

### DIFF
--- a/__tests__/components/editor/property/InputLookupQA.test.js
+++ b/__tests__/components/editor/property/InputLookupQA.test.js
@@ -1,4 +1,4 @@
-// Copyright 2018 Stanford University see LICENSE for license
+// Copyright 2019 Stanford University see LICENSE for license
 
 import 'jsdom-global/register'
 import React from 'react'
@@ -125,16 +125,6 @@ describe('<InputLookupQA />', () => {
       jest.restoreAllMocks()
     })
 
-    it('sets the default values according to the property template if they exist', () => {
-      const defaults = [{
-        id: 'http://id.loc.gov/vocabulary/carriers/nc',
-        uri: 'http://id.loc.gov/vocabulary/carriers/nc',
-        label: 'volume',
-      }]
-
-      expect(wrapper.state('defaults')).toEqual(defaults)
-    })
-
     it('logs an error when no defaults are set', () => {
       const plProps = {
         id: 'lookupComponent',
@@ -169,9 +159,8 @@ describe('<InputLookupQA />', () => {
       }
 
       const infoSpy = jest.spyOn(console, 'info').mockReturnValue(null)
-      const wrapper2 = shallow(<InputLookupQA.WrappedComponent {...plProps} handleSelectedChange={mockFormDataFn} />)
+      shallow(<InputLookupQA.WrappedComponent {...plProps} handleSelectedChange={mockFormDataFn} />)
 
-      expect(wrapper2.state('defaults')).toEqual([])
       expect(infoSpy).toBeCalledWith(`no defaults defined in property template: ${JSON.stringify(plProps.propertyTemplate)}`)
     })
 

--- a/src/components/editor/property/InputLookupQA.jsx
+++ b/src/components/editor/property/InputLookupQA.jsx
@@ -18,16 +18,8 @@ class InputLookupQA extends Component {
   constructor(props) {
     super(props)
 
-    const defaults = defaultValuesFromPropertyTemplate(this.props.propertyTemplate)
-
-    if (defaults.length === 0) {
-      // Property templates do not require defaults but we like to know when this happens
-      console.info(`no defaults defined in property template: ${JSON.stringify(this.props.propertyTemplate)}`)
-    }
-
     this.state = {
       isLoading: false,
-      defaults,
     }
   }
 
@@ -178,6 +170,13 @@ class InputLookupQA extends Component {
       return null
     }
 
+    const defaults = defaultValuesFromPropertyTemplate(this.props.propertyTemplate)
+
+    if (defaults.length === 0) {
+      // Property templates do not require defaults but we like to know when this happens
+      console.info(`no defaults defined in property template: ${JSON.stringify(this.props.propertyTemplate)}`)
+    }
+
     const typeaheadProps = {
       id: 'lookupComponent',
       required: this.isMandatory,
@@ -188,7 +187,7 @@ class InputLookupQA extends Component {
       isLoading: this.state.isLoading,
       onSearch: this.search(),
       options: this.state.options,
-      defaultSelected: this.state.defaults,
+      defaultSelected: defaults,
       delay: 300,
     }
 


### PR DESCRIPTION
This was causing problems because it was expecting props to be set in the constructor rather than the render function

Fixes #755 