### PR TITLE
when there are no defaults defined for a property template, log a debug level message to console

### DIFF
--- a/__tests__/components/editor/property/InputLookupQA.test.js
+++ b/__tests__/components/editor/property/InputLookupQA.test.js
@@ -158,10 +158,10 @@ describe('<InputLookupQA />', () => {
         ],
       }
 
-      const infoSpy = jest.spyOn(console, 'info').mockReturnValue(null)
+      const loggingSpy = jest.spyOn(console, 'debug').mockReturnValue(null)
       shallow(<InputLookupQA.WrappedComponent {...plProps} handleSelectedChange={mockFormDataFn} />)
 
-      expect(infoSpy).toBeCalledWith(`no defaults defined in property template: ${JSON.stringify(plProps.propertyTemplate)}`)
+      expect(loggingSpy).toBeCalledWith(`no defaults defined in property template: ${JSON.stringify(plProps.propertyTemplate)}`)
     })
 
     it('sets the async typeahead component defaultSelected attribute', () => {

--- a/src/components/editor/property/InputLookupQA.jsx
+++ b/src/components/editor/property/InputLookupQA.jsx
@@ -174,7 +174,7 @@ class InputLookupQA extends Component {
 
     if (defaults.length === 0) {
       // Property templates do not require defaults but we like to know when this happens
-      console.info(`no defaults defined in property template: ${JSON.stringify(this.props.propertyTemplate)}`)
+      console.debug(`no defaults defined in property template: ${JSON.stringify(this.props.propertyTemplate)}`)
     }
 
     const typeaheadProps = {


### PR DESCRIPTION
 instead of an info level message