### PR TITLE
Fixes bug where subsequently selected resource templates are appended to selectorReducer.resource

### DIFF
--- a/__tests__/reducers/index.test.js
+++ b/__tests__/reducers/index.test.js
@@ -332,14 +332,14 @@ describe('refreshResourceTemplate', () => {
       },
     })
 
-    const overwiteStateResult = refreshResourceTemplate(initialState.selectorReducer, {
+    const overwriteStateResult = refreshResourceTemplate(initialState.selectorReducer, {
       type: 'REFRESH_RESOURCE_TEMPLATE',
       payload: {
         reduxPath: ['resource', 'resourceTemplate:bf2:Monograph:Work', 'http://sinopia.io/next_example'],
       },
     })
 
-    expect(overwiteStateResult).toEqual({
+    expect(overwriteStateResult).toEqual({
       entities: {
         resourceTemplates: {
           'resourceTemplate:bf2:Note': {

--- a/src/components/editor/property/ResourceProperty.jsx
+++ b/src/components/editor/property/ResourceProperty.jsx
@@ -74,7 +74,6 @@ export class ResourceProperty extends Component {
                                    propertyTemplate={rtProperty}
                                    reduxPath={propertyReduxPath}
                                    addButtonDisabled={isAddDisabled}
-                                   initNewResourceTemplate={this.props.initNewResourceTemplate}
                                    resourceTemplate={resourceTemplate} />,
         )
       })

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -67,6 +67,18 @@ export const populatePropertyDefaults = (propertyTemplate) => {
   }))
 }
 
+/**
+ * The purpose of this function is to fill out the resource state tree with initial and additional properties,
+ * also calling the function to fill in the default values for those properties. This is called when a new top-level
+ * resource template is initialized and also when a property template with a nested resource is initialized
+ * (by expanding the property in a panel).
+ *
+ * Whenever a new resource template is initialized, the reduce method (bound to the lastObject variable) will by default
+ * append it to the `newState` accumulator, so before everything we must pop out the latest resource id and set that
+ * as the only resource in the state tree.
+ *
+ * @returns {{}} the new state of the redux store.
+ */
 export const refreshResourceTemplate = (state, action) => {
   const resourceTemplateId = Object.keys(state.resource).pop()
   const newResource = { resource: { [resourceTemplateId]: state.resource[resourceTemplateId] } }

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -68,8 +68,8 @@ export const populatePropertyDefaults = (propertyTemplate) => {
 }
 
 export const refreshResourceTemplate = (state, action) => {
-  const rtId = Object.keys(state.resource).pop()
-  const newResource = { resource: { [rtId]: state.resource[rtId] } }
+  const resourceTemplateId = Object.keys(state.resource).pop()
+  const newResource = { resource: { [resourceTemplateId]: state.resource[resourceTemplateId] } }
 
   const newState = { ...state, ...newResource }
 

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -10,6 +10,7 @@ import {
 } from './inputs'
 import { defaultLangTemplate } from 'Utilities'
 
+
 export const findNode = (selectorReducer, reduxPath) => {
   const items = reduxPath.reduce((obj, key) => (obj && obj[key] !== 'undefined' ? obj[key] : undefined), selectorReducer)
 
@@ -67,7 +68,11 @@ export const populatePropertyDefaults = (propertyTemplate) => {
 }
 
 export const refreshResourceTemplate = (state, action) => {
-  const newState = { ...state }
+  const rtId = Object.keys(state.resource).pop()
+  const newResource = { resource: { [rtId]: state.resource[rtId] } }
+
+  const newState = { ...state, ...newResource }
+
   const reduxPath = action.payload.reduxPath
   const propertyTemplate = action.payload.property
 
@@ -75,9 +80,7 @@ export const refreshResourceTemplate = (state, action) => {
     return newState
   }
   const defaults = populatePropertyDefaults(propertyTemplate)
-
   const items = defaults.length > 0 ? { items: defaults } : {}
-
   const lastKey = reduxPath.pop()
   const lastObject = reduxPath.reduce((newState, key) => newState[key] = newState[key] || {}, newState)
 
@@ -96,6 +99,7 @@ export const refreshResourceTemplate = (state, action) => {
  */
 export const setResourceTemplate = (state, action) => {
   let newState = resourceTemplateLoaded(state, action)
+
   const resourceTemplateId = action.payload.id
 
   action.payload.propertyTemplates.forEach((property) => {
@@ -105,7 +109,6 @@ export const setResourceTemplate = (state, action) => {
         property,
       },
     }
-
     newState = refreshResourceTemplate(newState, propertyAction)
   })
 


### PR DESCRIPTION
Selections of new resource templates from list should replace the state of `selectorReducer.resource`

