### PR TITLE
Add test to verify content exists in preview RDF

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -153,6 +153,13 @@ module.exports = {
       }
     },
     {
+      // There is a known issue with exporting async default functions
+      "files": ["__tests__/integration/previewRDFHelper.js"],
+      "rules": {
+        "import/prefer-default-export": "off"
+      }
+    },
+    {
       // Allow ImportFileZone test to require `isomorphic-fetch`
       "files": ["__tests__/components/editor/ImportFileZone.test.js"],
       "rules": {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -154,6 +154,7 @@ module.exports = {
     },
     {
       // There is a known issue with exporting async default functions
+      // Link: https://github.com/babel/babel/issues/6262
       "files": ["__tests__/integration/previewRDFHelper.js"],
       "rules": {
         "import/prefer-default-export": "off"

--- a/__tests__/integration/previewRDFHelper.js
+++ b/__tests__/integration/previewRDFHelper.js
@@ -2,7 +2,7 @@
 
 import pupExpect from 'expect-puppeteer'
 
-export async function previewRDFSetup() {
+export async function fillInRequredFieldsForBibframeInstance() {
   // This assertion adds 1 to each it blocks assertion count
   await pupExpect(page).toClick('a', { text: 'BIBFRAME Instance' })
 

--- a/__tests__/integration/previewRDFHelper.js
+++ b/__tests__/integration/previewRDFHelper.js
@@ -1,0 +1,28 @@
+// Copyright 2019 Stanford University see LICENSE for license
+
+import pupExpect from 'expect-puppeteer'
+
+export async function previewRDFSetup() {
+    // This assertion adds 1 to each it blocks assertion count
+    await pupExpect(page).toClick('a', { text: 'BIBFRAME Instance' })
+
+    // Click on one of the property type rows to expand a nested resource
+    await page.waitForSelector('a[data-id=\'title\']')
+    await page.click('a[data-id=\'title\']')
+    await page.waitForSelector('a[data-id=\'mainTitle\']')
+
+    // Fill in required element
+    await page.click('a[data-id=\'mainTitle\']')
+    await page.type('[placeholder=\'Preferred Title for Work (RDA 6.2.2, RDA 6.14.2) (BIBFRAME: Main title)\']', 'Hello')
+    await page.keyboard.press('Enter')
+
+    // Fill in required element
+    await page.type('[placeholder=\'Statement of Responsibility Relating to Title Proper (RDA 2.4.2)\'', 'World')
+    await page.keyboard.press('Enter')
+
+    // Fill in required element
+    await page.type('[placeholder=\'Agent Contribution\']', 'Typing')
+    // wait until autosuggest has returned something to click on
+    await page.waitForSelector('#rbt-menu-item-0')
+    await page.click('#rbt-menu-item-0')
+}

--- a/__tests__/integration/previewRDFHelper.js
+++ b/__tests__/integration/previewRDFHelper.js
@@ -3,26 +3,27 @@
 import pupExpect from 'expect-puppeteer'
 
 export async function previewRDFSetup() {
-    // This assertion adds 1 to each it blocks assertion count
-    await pupExpect(page).toClick('a', { text: 'BIBFRAME Instance' })
+  // This assertion adds 1 to each it blocks assertion count
+  await pupExpect(page).toClick('a', { text: 'BIBFRAME Instance' })
 
-    // Click on one of the property type rows to expand a nested resource
-    await page.waitForSelector('a[data-id=\'title\']')
-    await page.click('a[data-id=\'title\']')
-    await page.waitForSelector('a[data-id=\'mainTitle\']')
+  // Click on one of the property type rows to expand a nested resource
+  await page.waitForSelector('a[data-id=\'title\']')
+  await page.click('a[data-id=\'title\']')
+  await page.waitForSelector('a[data-id=\'mainTitle\']')
 
-    // Fill in required element
-    await page.click('a[data-id=\'mainTitle\']')
-    await page.type('[placeholder=\'Preferred Title for Work (RDA 6.2.2, RDA 6.14.2) (BIBFRAME: Main title)\']', 'Hello')
-    await page.keyboard.press('Enter')
+  // Fill in required element
+  await page.click('a[data-id=\'mainTitle\']')
+  await page.type('[placeholder=\'Preferred Title for Work (RDA 6.2.2, RDA 6.14.2) (BIBFRAME: Main title)\']', 'Hello')
+  await page.keyboard.press('Enter')
 
-    // Fill in required element
-    await page.type('[placeholder=\'Statement of Responsibility Relating to Title Proper (RDA 2.4.2)\'', 'World')
-    await page.keyboard.press('Enter')
+  // Fill in required element
+  await page.type('[placeholder=\'Statement of Responsibility Relating to Title Proper (RDA 2.4.2)\'', 'World')
+  await page.keyboard.press('Enter')
 
-    // Fill in required element
-    await page.type('[placeholder=\'Agent Contribution\']', 'Typing')
-    // wait until autosuggest has returned something to click on
-    await page.waitForSelector('#rbt-menu-item-0')
-    await page.click('#rbt-menu-item-0')
+  // Fill in required element
+  await page.type('[placeholder=\'Agent Contribution\']', 'Stanford family')
+
+  // Wait until autosuggest has returned something to click on
+  await page.waitForSelector('#rbt-menu-item-0')
+  await page.click('#rbt-menu-item-0')
 }

--- a/__tests__/integration/previewSaveRDF.test.js
+++ b/__tests__/integration/previewSaveRDF.test.js
@@ -2,35 +2,19 @@
 
 import pupExpect from 'expect-puppeteer'
 import { testUserLogin } from './loginHelper'
+import { previewRDFSetup } from './previewRDFHelper'
 
 describe('Previewing the RDF', () => {
   beforeAll(async () => {
     return await testUserLogin()
   })
 
+  beforeEach(async () => {
+    return await previewRDFSetup()
+  })
+
   it('builds the rdf and has dialog for saving', async () => {
-    expect.assertions(18)
-    await pupExpect(page).toClick('a', { text: 'BIBFRAME Instance' })
-    await pupExpect(page).toMatch('BIBFRAME Instance')
-
-    // Click on one of the property type rows to expand a nested resource
-    await pupExpect(page).toClick('a[data-id=\'title\']')
-    await pupExpect(page).toMatchElement('h5', { text: 'Work Title' })
-
-    // Fill in required element
-    await pupExpect(page).toClick('a[data-id=\'mainTitle\']')
-    await page.type('[placeholder=\'Preferred Title for Work (RDA 6.2.2, RDA 6.14.2) (BIBFRAME: Main title)\']', 'Hello')
-    await page.keyboard.press('Enter')
-
-    // Fill in required element
-    await page.type('[placeholder=\'Agent Contribution\']', 'Typing')
-    // wait until autosuggest has returned something to click on
-    await page.waitForSelector('#rbt-menu-item-0')
-    await pupExpect(page).toClick('#rbt-menu-item-0')
-
-    // Fill in required element
-    await page.type('[placeholder=\'Statement of Responsibility Relating to Title Proper (RDA 2.4.2)\'', 'World')
-    await page.keyboard.press('Enter')
+    expect.assertions(13)
 
     // Click on the PreviewRDF button and a modal appears
     await pupExpect(page).toClick('button', { text: 'Preview RDF' })

--- a/__tests__/integration/previewSaveRDF.test.js
+++ b/__tests__/integration/previewSaveRDF.test.js
@@ -2,7 +2,7 @@
 
 import pupExpect from 'expect-puppeteer'
 import { testUserLogin } from './loginHelper'
-import { previewRDFSetup } from './previewRDFHelper'
+import { fillInRequredFieldsForBibframeInstance } from './previewRDFHelper'
 
 describe('Previewing the RDF', () => {
   beforeAll(async () => {

--- a/__tests__/integration/previewSaveRDF.test.js
+++ b/__tests__/integration/previewSaveRDF.test.js
@@ -10,7 +10,7 @@ describe('Previewing the RDF', () => {
   })
 
   beforeEach(async () => {
-    return await previewRDFSetup()
+    return await fillInRequredFieldsForBibframeInstance()
   })
 
   it('builds the rdf and has dialog for saving', async () => {

--- a/__tests__/integration/previewSaveRDF.test.js
+++ b/__tests__/integration/previewSaveRDF.test.js
@@ -14,7 +14,7 @@ describe('Previewing the RDF', () => {
   })
 
   it('builds the rdf and has dialog for saving', async () => {
-    expect.assertions(13)
+    expect.assertions(13) // An additional assertion is done in previewRDFSetup
 
     // Click on the PreviewRDF button and a modal appears
     await pupExpect(page).toClick('button', { text: 'Preview RDF' })

--- a/__tests__/integration/previewSaveRDF.test.js
+++ b/__tests__/integration/previewSaveRDF.test.js
@@ -14,7 +14,7 @@ describe('Previewing the RDF', () => {
   })
 
   it('builds the rdf and has dialog for saving', async () => {
-    expect.assertions(13) // An additional assertion is done in previewRDFSetup
+    expect.assertions(13) // An additional assertion is done in fillInRequredFieldsForBibframeInstance
 
     // Click on the PreviewRDF button and a modal appears
     await pupExpect(page).toClick('button', { text: 'Preview RDF' })

--- a/__tests__/integration/verifyPreviewRDF.test.js
+++ b/__tests__/integration/verifyPreviewRDF.test.js
@@ -2,7 +2,7 @@
 
 import pupExpect from 'expect-puppeteer'
 import { testUserLogin } from './loginHelper'
-import { previewRDFSetup } from './previewRDFHelper'
+import { fillInRequredFieldsForBibframeInstance } from './previewRDFHelper'
 
 describe('Previewing the RDF', () => {
   beforeAll(async () => {

--- a/__tests__/integration/verifyPreviewRDF.test.js
+++ b/__tests__/integration/verifyPreviewRDF.test.js
@@ -14,7 +14,7 @@ describe('Previewing the RDF', () => {
   })
 
   it('builds the rdf and verifies the expected content', async () => {
-    expect.assertions(6) // An additional assertion is done in previewRDFSetup
+    expect.assertions(6) // An additional assertion is done in fillInRequredFieldsForBibframeInstance
 
     // Click on the PreviewRDF button and a modal appears
     await pupExpect(page).toClick('button', { text: 'Preview RDF' })

--- a/__tests__/integration/verifyPreviewRDF.test.js
+++ b/__tests__/integration/verifyPreviewRDF.test.js
@@ -1,0 +1,29 @@
+// Copyright 2019 Stanford University see LICENSE for license
+
+import pupExpect from 'expect-puppeteer'
+import { testUserLogin } from './loginHelper'
+import { previewRDFSetup } from './previewRDFHelper'
+
+describe('Previewing the RDF', () => {
+  beforeAll(async () => {
+    return await testUserLogin()
+  })
+
+  beforeEach(async () => {
+    return await previewRDFSetup()
+  })
+
+  it('builds the rdf and verifies the expected content', async () => {
+    expect.assertions(6) // An additional assertion is done in previewRDFSetup
+
+    // Click on the PreviewRDF button and a modal appears
+    await pupExpect(page).toClick('button', { text: 'Preview RDF' })
+    await pupExpect(page).toMatch('RDF Preview')
+    const rdfOut = await page.$eval('pre', e => e.textContent) // Copy the text from the modal into a variable
+
+    // Verify that the values entered in previewRDFSetup show up in the generated graph
+    await expect(rdfOut).toMatch('Hello')
+    await expect(rdfOut).toMatch('World')
+    await expect(rdfOut).toMatch('http://id.loc.gov/authorities/subjects/sh85127327') // This is the Stanford family URI
+  })
+})

--- a/__tests__/integration/verifyPreviewRDF.test.js
+++ b/__tests__/integration/verifyPreviewRDF.test.js
@@ -10,7 +10,7 @@ describe('Previewing the RDF', () => {
   })
 
   beforeEach(async () => {
-    return await previewRDFSetup()
+    return await fillInRequredFieldsForBibframeInstance()
   })
 
   it('builds the rdf and verifies the expected content', async () => {

--- a/package.json
+++ b/package.json
@@ -145,7 +145,8 @@
     ],
     "testPathIgnorePatterns": [
       "/node_modules/",
-      "__tests__/integration/loginHelper"
+      "__tests__/integration/loginHelper",
+      "__tests__/integration/previewRDFHelper"
     ],
     "setupFiles": [
       "jest-localstorage-mock",


### PR DESCRIPTION
Replacement PR for #758, this moves the reusable setup steps from `previewSaveRDF` into a helper method. This is reused in a new test `verifyPreviewRDF` which doesn't rely on the "Save & Publish" clicks but checks the content of the modal.

This also avoids changing the intent of the nestedResource test.