### PR TITLE
Export language tags to RDF

### DIFF
--- a/__tests__/GraphBuilder.test.js
+++ b/__tests__/GraphBuilder.test.js
@@ -48,6 +48,12 @@ describe('GraphBuilder', () => {
                     {
                       content: 'Very colorful',
                       id: '3TzRpgv65',
+                      lang: {
+                        items: [{
+                          id: 'en',
+                          label: 'English',
+                        }],
+                      },
                     },
                     {
                       content: 'Sparkly',
@@ -94,21 +100,20 @@ describe('GraphBuilder', () => {
 
       expect(graph.has(propertyTriple)).toBeTruthy()
 
-      // Multiple items
-      const result1 = graph.filter(quad => quad.object.equals(rdf.literal('Very colorful'))).toArray()
-
-      expect(result1.length).toEqual(1)
-
+      // An triple with a lang tag
+      const result1 = graph.filter(quad => quad.object.equals(rdf.literal('Very colorful', 'en'))).toArray()
+      // An triple without a lang tag
       const result2 = graph.filter(quad => quad.object.equals(rdf.literal('Sparkly'))).toArray()
-
-      expect(result2.length).toEqual(1)
-
-      // Multiple resources (notes)
+      // A triple on a separate resource (bf:Note)
       const result3 = graph.filter(quad => quad.object.equals(rdf.literal('Shiney'))).toArray()
 
+      expect(result1.length).toEqual(1)
+      expect(result2.length).toEqual(1)
       expect(result3.length).toEqual(1)
+
       // Literals from the same note share blank node.
       expect(result1[0].subject).toEqual(result2[0].subject)
+
       // Literals from different notes have different blank node.
       expect(result1[0].subject).not.toEqual(result3[0].subject)
     })

--- a/__tests__/components/editor/property/InputLang.test.js
+++ b/__tests__/components/editor/property/InputLang.test.js
@@ -1,4 +1,5 @@
-// Copyright 2018 Stanford University see LICENSE for license
+// Copyright 2019 Stanford University see LICENSE for license
+
 import React from 'react'
 import { shallow } from 'enzyme'
 import InputLang from 'components/editor/property/InputLang'
@@ -65,7 +66,7 @@ describe('<InputLang />', () => {
   it('creates a hash of options that it renders in the form field', () => {
     const lcLanguage = [
       {
-        '@id': 'http://id.loc.gov/vocabulary/languages/sna',
+        '@id': 'http://id.loc.gov/vocabulary/iso639-1/sn',
         'http://www.loc.gov/mads/rdf/v1#authoritativeLabel': [
           {
             '@language': 'en',
@@ -80,6 +81,6 @@ describe('<InputLang />', () => {
     const options = wrapper.instance().createOptions(lcLanguage)
 
     // Ignoring odd entries that don't have label
-    expect(options).toEqual([{ id: 'http://id.loc.gov/vocabulary/languages/sna', uri: 'http://id.loc.gov/vocabulary/languages/sna', label: 'Shona' }])
+    expect(options).toEqual([{ id: 'sn', label: 'Shona' }])
   })
 })

--- a/__tests__/reducers/index.test.js
+++ b/__tests__/reducers/index.test.js
@@ -342,9 +342,8 @@ describe('refreshResourceTemplate', () => {
               id: 0,
               lang: {
                 items: [{
-                  id: 'http://id.loc.gov/vocabulary/languages/eng',
+                  id: 'en',
                   label: 'English',
-                  uri: 'http://id.loc.gov/vocabulary/languages/eng',
                 }],
               },
               uri: undefined,
@@ -422,9 +421,8 @@ describe('populatePropertyDefaults()', () => {
       id: 0,
       lang: {
         items: [{
-          id: 'http://id.loc.gov/vocabulary/languages/eng',
+          id: 'en',
           label: 'English',
-          uri: 'http://id.loc.gov/vocabulary/languages/eng',
         }],
       },
       uri: 'http://id.loc.gov/vocabulary/organizations/dlc',

--- a/src/GraphBuilder.js
+++ b/src/GraphBuilder.js
@@ -89,11 +89,8 @@ export default class GraphBuilder {
 
       if (value.items) {
         for (const item of value.items) {
-          if (item.uri) {
-            this.dataset.add(rdf.quad(baseURI, rdf.namedNode(predicate), rdf.namedNode(item.uri)))
-          } else {
-            this.dataset.add(rdf.quad(baseURI, rdf.namedNode(predicate), rdf.literal(item.content)))
-          }
+          const object = item.uri ? rdf.namedNode(item.uri) : this.createLiteral(item)
+          this.dataset.add(rdf.quad(baseURI, rdf.namedNode(predicate), object))
         }
       } else { // It's a deeply nested object
         Object.keys(value).filter(elem => elem !== 'errors').forEach((key) => {
@@ -105,6 +102,15 @@ export default class GraphBuilder {
         })
       }
     }
+  }
+
+  /**
+   * Returns a literal with an optional language tag
+   * @param {Object} item from the redux store
+   * @return {rdf.LiteralExt} the literal with a language value
+   */
+  createLiteral(item) {
+    return rdf.literal(item.content, item.lang?.items[0].id)
   }
 
 

--- a/src/Utilities.js
+++ b/src/Utilities.js
@@ -49,9 +49,8 @@ export const booleanPropertyFromTemplate = (template, key, defaultValue) => {
 export const defaultLangTemplate = () => ({
   items: [
     {
-      id: 'http://id.loc.gov/vocabulary/languages/eng',
+      id: 'en',
       label: 'English',
-      uri: 'http://id.loc.gov/vocabulary/languages/eng',
     },
   ],
 })

--- a/src/components/editor/property/InputLang.jsx
+++ b/src/components/editor/property/InputLang.jsx
@@ -1,10 +1,15 @@
-// Copyright 2018 Stanford University see LICENSE for license
+// Copyright 2019 Stanford University see LICENSE for license
 
 import React, { Component } from 'react'
 import { Typeahead } from 'react-bootstrap-typeahead'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 
+/**
+ * Provides the RFC 5646 language tag for a literal element.
+ * See https://tools.ietf.org/html/rfc5646
+ * See ISO 639 for the list of registered language codes
+ */
 class InputLang extends Component {
   constructor(props) {
     super(props)
@@ -26,7 +31,7 @@ class InputLang extends Component {
 
   createOptions = json => json.reduce((result, item) => {
     // Object.getOwnPropertyDescriptor is necessary to handle the @
-    const uri = Object.getOwnPropertyDescriptor(item, '@id').value
+    const id = Object.getOwnPropertyDescriptor(item, '@id').value.replace('http://id.loc.gov/vocabulary/iso639-1/', '')
     const labelArrayDescr = Object.getOwnPropertyDescriptor(item, 'http://www.loc.gov/mads/rdf/v1#authoritativeLabel')
 
     // Some of the LOC items do not have labels so ignore them.
@@ -44,7 +49,7 @@ class InputLang extends Component {
     // But not every language has an English label.
     if (!label) return result
 
-    result.push({ id: uri, uri, label })
+    result.push({ id, label })
     return result
   }, [])
 
@@ -69,7 +74,7 @@ class InputLang extends Component {
                 return
               }
               this.setState({ isLoading: true })
-              fetch('https://id.loc.gov/vocabulary/languages.json')
+              fetch('https://id.loc.gov/vocabulary/iso639-1.json')
                 .then(resp => resp.json())
                 .then((json) => {
                   this.setState({


### PR DESCRIPTION
This involved switching to using iso639-1 language codes because these are required for language tags per RFC 5646.

Fixes #666