### PR TITLE
Close the previewRDF modal if validations fail

### DIFF
--- a/__tests__/reducers/inputs.test.js
+++ b/__tests__/reducers/inputs.test.js
@@ -61,6 +61,7 @@ describe('showGroupChooser()', () => {
 
       expect(result.editor.displayValidations).toBe(true)
       expect(result.editor.groupChoice.show).toBe(false)
+      expect(result.editor.rdfPreview.show).toBe(false)
     })
   })
 })

--- a/src/reducers/inputs.js
+++ b/src/reducers/inputs.js
@@ -18,6 +18,7 @@ export const showGroupChooser = (state) => {
   } else {
     // Show errors that prevent save
     newState.editor.displayValidations = true
+    newState.editor.rdfPreview.show = false
   }
 
   return newState


### PR DESCRIPTION
Sets the state for the rdfPreview.show modal to false and tests that the condition is set for invalid RDF.

Fixes #781 