### PR TITLE
Display a message if a property component is misconfigured as a resource

### DIFF
--- a/__tests__/components/editor/property/PropertyComponent.test.js
+++ b/__tests__/components/editor/property/PropertyComponent.test.js
@@ -100,6 +100,22 @@ describe('<PropertyComponent />', () => {
       expect(wrapper.find('Connect(InputLookupQA)').length).toEqual(0)
       expect(wrapper.find('Connect(InputLiteral)').length).toEqual(0)
     })
+
+    it('returns a warning message if the property type is not literal (i.e. resource)', () => {
+      const template = {
+        propertyURI: 'http://id.loc.gov/ontologies/bibframe/note',
+        type: 'resource',
+        valueConstraint: {
+          valueTemplateRefs: [],
+          useValuesFrom: [],
+        },
+      }
+
+      const wrapper = shallow(<PropertyComponent propertyTemplate={template}
+                                                 reduxPath={['http://id.loc.gov/ontologies/bibframe/note']}/>)
+
+      expect(wrapper.find('div.alert-warning').text()).toEqual('This property is defined as a resource in the template but does not have references to other resources.')
+    })
   })
 
   it('logs an error if <PropertyComponent /> is missing reduxPath props', () => {

--- a/__tests__/components/editor/property/PropertyComponent.test.js
+++ b/__tests__/components/editor/property/PropertyComponent.test.js
@@ -114,7 +114,7 @@ describe('<PropertyComponent />', () => {
       const wrapper = shallow(<PropertyComponent propertyTemplate={template}
                                                  reduxPath={['http://id.loc.gov/ontologies/bibframe/note']}/>)
 
-      expect(wrapper.find('div.alert-warning').text()).toEqual('This property is defined as a resource in the template but does not have references to other resources.')
+      expect(wrapper.find('div.alert-warning').text()).toEqual('<FontAwesomeIcon />This property is defined as a resource in the template but does not have references to other resources.')
     })
   })
 

--- a/src/components/editor/property/PropertyComponent.jsx
+++ b/src/components/editor/property/PropertyComponent.jsx
@@ -31,6 +31,7 @@ export class PropertyComponent extends Component {
     reduxPath.push(property.propertyURI)
     const keyId = shortid.generate()
 
+    let defaultInput
     switch (config) {
       case 'lookup':
         return (<InputLookupQA key = {this.props.index}
@@ -42,12 +43,15 @@ export class PropertyComponent extends Component {
                               lookupConfig = {this.state.configuration[0]} />)
       default:
         if (property.type === 'literal') {
-          return (<InputLiteral key={keyId} id={keyId}
-                                reduxPath={reduxPath} />)
+          defaultInput = <InputLiteral key={keyId} id={keyId} reduxPath={reduxPath} />
+        } else if (property.type === 'resource') {
+          defaultInput = <div className="alert alert-warning">
+            This property is defined as a resource in the template but does not have references to other resources.
+          </div>
         }
     }
 
-    return false
+    return defaultInput
   }
 
   render() {

--- a/src/components/editor/property/PropertyComponent.jsx
+++ b/src/components/editor/property/PropertyComponent.jsx
@@ -3,6 +3,8 @@
 import React, { Component } from 'react'
 import shortid from 'shortid'
 import PropTypes from 'prop-types'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons'
 import InputLiteral from './InputLiteral'
 import InputListLOC from './InputListLOC'
 import InputLookupQA from './InputLookupQA'
@@ -46,7 +48,8 @@ export class PropertyComponent extends Component {
           defaultInput = <InputLiteral key={keyId} id={keyId} reduxPath={reduxPath} />
         } else if (property.type === 'resource') {
           defaultInput = <div className="alert alert-warning">
-            This property is defined as a resource in the template but does not have references to other resources.
+            <FontAwesomeIcon className="fa fa-exclamation-triangle" icon={faExclamationTriangle} />
+              This property is defined as a resource in the template but does not have references to other resources.
           </div>
         }
     }


### PR DESCRIPTION
I came across this while testing various sever templates for the demo:

When `type: 'resource'` without `valueTemplateRefs`

Before:
![Screen Shot 2019-06-19 at 3 59 19 PM](https://user-images.githubusercontent.com/3093850/59808816-afa26400-92b2-11e9-8580-5055d55c3864.png)

After:
![Screen Shot 2019-06-19 at 3 59 26 PM](https://user-images.githubusercontent.com/3093850/59808817-b0d39100-92b2-11e9-898d-de56dd82bfd0.png)