### PR TITLE
Clear validation errors when a resource template is loaded

### DIFF
--- a/__tests__/integration/previewRDFHelper.js
+++ b/__tests__/integration/previewRDFHelper.js
@@ -31,14 +31,4 @@ export async function fillInRequredFieldsForBibframeInstance() {
 export async function incompleteFieldsForBibframeInstance() {
   // This assertion adds 1 to each it blocks assertion count
   await pupExpect(page).toClick('a', { text: 'BIBFRAME Instance' })
-
-  // Click on one of the property type rows to expand a nested resource
-  await page.waitForSelector('a[data-id=\'title\']')
-  await page.click('a[data-id=\'title\']')
-  await page.waitForSelector('a[data-id=\'mainTitle\']')
-
-  // Fill in required element
-  await page.click('a[data-id=\'mainTitle\']')
-  await page.type('[placeholder=\'Preferred Title for Work (RDA 6.2.2, RDA 6.14.2) (BIBFRAME: Main title)\']', 'Hello')
-  await page.keyboard.press('Enter')
 }

--- a/__tests__/integration/previewRDFHelper.js
+++ b/__tests__/integration/previewRDFHelper.js
@@ -27,3 +27,18 @@ export async function fillInRequredFieldsForBibframeInstance() {
   await page.waitForSelector('#rbt-menu-item-0')
   await page.click('#rbt-menu-item-0')
 }
+
+export async function incompleteFieldsForBibframeInstance() {
+  // This assertion adds 1 to each it blocks assertion count
+  await pupExpect(page).toClick('a', { text: 'BIBFRAME Instance' })
+
+  // Click on one of the property type rows to expand a nested resource
+  await page.waitForSelector('a[data-id=\'title\']')
+  await page.click('a[data-id=\'title\']')
+  await page.waitForSelector('a[data-id=\'mainTitle\']')
+
+  // Fill in required element
+  await page.click('a[data-id=\'mainTitle\']')
+  await page.type('[placeholder=\'Preferred Title for Work (RDA 6.2.2, RDA 6.14.2) (BIBFRAME: Main title)\']', 'Hello')
+  await page.keyboard.press('Enter')
+}

--- a/__tests__/integration/saveIncompleteRDF.test.js
+++ b/__tests__/integration/saveIncompleteRDF.test.js
@@ -1,0 +1,28 @@
+// Copyright 2019 Stanford University see LICENSE for license
+
+import pupExpect from 'expect-puppeteer'
+import { testUserLogin } from './loginHelper'
+import { incompleteFieldsForBibframeInstance } from './previewRDFHelper'
+
+describe('Previewing the RDF', () => {
+  beforeAll(async () => {
+    return await testUserLogin()
+  })
+
+  beforeEach(async () => {
+    return await incompleteFieldsForBibframeInstance()
+  })
+
+  it('builds the rdf and has dialog for saving', async () => {
+    expect.assertions(6) // An additional assertion is done in incompleteFieldsForBibframeInstance
+
+    // Click on the PreviewRDF button and a modal appears
+    await pupExpect(page).toClick('button', { text: 'Preview RDF' })
+    await pupExpect(page).toMatch('RDF Preview')
+    await pupExpect(page).toMatch('If this looks good, then click Save and Publish')
+
+    // Present a choice of group to save to from the RDFModal
+    await pupExpect(page).toClick('#modal-save', { text: 'Save & Publish' })
+    await pupExpect(page).toMatchElement('div.alert')
+  })
+})

--- a/__tests__/integration/saveIncompleteRDF.test.js
+++ b/__tests__/integration/saveIncompleteRDF.test.js
@@ -10,10 +10,11 @@ describe('Previewing the RDF', () => {
   })
 
   beforeEach(async () => {
+    await page.goto('http://127.0.0.1:8888/templates')
     return await incompleteFieldsForBibframeInstance()
   })
 
-  it('builds the rdf and has dialog for saving', async () => {
+  it('builds the rdf and displays validation errors after attempting to save', async () => {
     expect.assertions(6) // An additional assertion is done in incompleteFieldsForBibframeInstance
 
     // Click on the PreviewRDF button and a modal appears
@@ -24,5 +25,10 @@ describe('Previewing the RDF', () => {
     // Present a choice of group to save to from the RDFModal
     await pupExpect(page).toClick('#modal-save', { text: 'Save & Publish' })
     await pupExpect(page).toMatchElement('div.alert')
+  })
+
+  it('does not display the alert for a reloaded template', async () => {
+    expect.assertions(2) // An additional assertion is done in incompleteFieldsForBibframeInstance
+    await pupExpect(page).not.toMatchElement('div.alert')
   })
 })

--- a/__tests__/reducers/index.test.js
+++ b/__tests__/reducers/index.test.js
@@ -20,6 +20,8 @@ beforeEach(() => {
       },
       resource: { // The state we're displaying in the editor
       },
+      editor: {
+      },
     },
   }
 })
@@ -190,6 +192,10 @@ describe('selectorReducer', () => {
           },
         },
       },
+      editor: {
+        errors: [],
+        displayValidations: false,
+      },
     })
   })
 
@@ -238,6 +244,7 @@ describe('refreshResourceTemplate', () => {
           'http://sinopia.io/example': {},
         },
       },
+      editor: {},
     })
   })
 
@@ -282,6 +289,10 @@ describe('refreshResourceTemplate', () => {
         'resourceTemplate:bf2:Monograph:Work': {
           'http://sinopia.io/next_example': {},
         },
+      },
+      editor: {
+        errors: [],
+        displayValidations: false,
       },
     })
   })
@@ -413,6 +424,10 @@ describe('resourceTemplateLoaded()', () => {
         },
       },
       resource: {},
+      editor: {
+        errors: [],
+        displayValidations: false,
+      },
     })
   })
 })

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -79,7 +79,6 @@ export const setResourceTemplate = (state, action) => {
     newState = refreshResourceTemplate(newState, propertyAction)
   })
 
-  newState.errors = []
   return newState
 }
 

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -79,6 +79,7 @@ export const setResourceTemplate = (state, action) => {
     newState = refreshResourceTemplate(newState, propertyAction)
   })
 
+  newState.errors = []
   return newState
 }
 
@@ -87,6 +88,11 @@ export const resourceTemplateLoaded = (state, action) => {
   const newState = { ...state }
 
   newState.entities.resourceTemplates[resourceTemplateId] = action.payload
+
+  // Clear any existing validation errors when we load a resource template
+  newState.editor.errors = []
+  newState.editor.displayValidations = false
+
   return newState
 }
 


### PR DESCRIPTION
Fixes #745 

Clears the errors and sets displayValidations to false when a resource template is loaded. Adds unit testing for the values and an integration test for displaying and clearing the validation errors on the page.

Before: After validation errors and clicking on a new template - Validation errors are still displayed. 

![Screen Shot 2019-06-20 at 11 14 57 AM](https://user-images.githubusercontent.com/2294288/59871595-cc8b7580-934c-11e9-9403-0b520f53b53d.png)

After:  After validation errors and clicking on a new template - Validation errors are cleared.

![Screen Shot 2019-06-20 at 11 15 28 AM](https://user-images.githubusercontent.com/2294288/59871634-e462f980-934c-11e9-9949-882272376029.png)
