### PR TITLE
setResourceTemplate should clear the editor state

### DIFF
--- a/__tests__/reducers/index.test.js
+++ b/__tests__/reducers/index.test.js
@@ -5,6 +5,7 @@ import selectorReducer, {
   populatePropertyDefaults,
   refreshResourceTemplate,
   resourceTemplateLoaded,
+  setResourceTemplate,
 } from 'reducers/index'
 /* eslint import/namespace: 'off' */
 import * as inputs from 'reducers/inputs'
@@ -415,6 +416,7 @@ describe('resourceTemplateLoaded()', () => {
     })
 
     expect(newState).toStrictEqual({
+      editor: {},
       entities: {
         resourceTemplates: {
           'resourceTemplate:bf2:Monograph:Work': {
@@ -424,9 +426,37 @@ describe('resourceTemplateLoaded()', () => {
         },
       },
       resource: {},
+    })
+  })
+})
+
+describe('setResourceTemplate()', () => {
+  it('adds resource to the resourceTemplates entities state', () => {
+    const template = {
+      id: 'resourceTemplate:bf2:Monograph:Work',
+      propertyTemplates: [
+        { propertyURI: 'http://id.loc.gov/ontologies/bibframe/title' },
+      ],
+    }
+    const newState = setResourceTemplate(initialState.selectorReducer, {
+      type: 'SET_RESOURCE_TEMPLATE',
+      payload: template,
+    })
+
+    expect(newState).toStrictEqual({
       editor: {
         errors: [],
         displayValidations: false,
+      },
+      entities: {
+        resourceTemplates: {
+          'resourceTemplate:bf2:Monograph:Work': template,
+        },
+      },
+      resource: {
+        'resourceTemplate:bf2:Monograph:Work': {
+          'http://id.loc.gov/ontologies/bibframe/title': {},
+        },
       },
     })
   })

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -79,6 +79,10 @@ export const setResourceTemplate = (state, action) => {
     newState = refreshResourceTemplate(newState, propertyAction)
   })
 
+  // Clear any existing validation errors when we load a resource template
+  newState.editor.errors = []
+  newState.editor.displayValidations = false
+
   return newState
 }
 
@@ -87,10 +91,6 @@ export const resourceTemplateLoaded = (state, action) => {
   const newState = { ...state }
 
   newState.entities.resourceTemplates[resourceTemplateId] = action.payload
-
-  // Clear any existing validation errors when we load a resource template
-  newState.editor.errors = []
-  newState.editor.displayValidations = false
 
   return newState
 }


### PR DESCRIPTION
Rather than resourceTemplateLoaded.  resourceTemplateLoaded occurs for each new template that is added so we don't want to clear the editor state when a new template is added, only when the root template is added.