### PR TITLE
Demonstrate a lightweight pattern for cross-environment routes

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Stanford University see LICENSE for license
+ * Copyright 2018, 2019 Stanford University see LICENSE for license
  * Minimal BIBFRAME Editor Node.js server. To run from the command-line:
  *  npm start  or node server.js
  */
@@ -13,6 +13,10 @@ app.use(express.static(`${__dirname}/`))
 app.listen(port)
 
 const versoSpoof = require('./src/versoSpoof.js')
+
+app.get('/api/search', (req, res) => {
+  res.json({ foo: 'bar' })
+})
 
 
 app.all('/verso/api/configs', (req, res, next) => {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -31,8 +31,8 @@ module.exports = {
     ]
   },
   node: {
-   fs: "empty"
- },
+    fs: "empty"
+  },
   resolve: {
     extensions: ['*', '.js', '.jsx']
   },
@@ -64,6 +64,9 @@ module.exports = {
   devServer: {
     historyApiFallback: true,
     hot: true,
-    port: 8888
+    port: 8888,
+    proxy: {
+      '/api/search': 'http://localhost:8000'
+    }
   }
 }


### PR DESCRIPTION
Refs #630

The now-reverted #793 PR—which replaced `webpack-dev-server` (used as the web server in dev and test environments) with `webpack-dev-middleware` sitting in front of an environment-specific express server—showed a thorough mechanism to use the same server infrastructure across dev, test, and prod environments. It also fundamentally broke the build and introduced way more code than was necessary for the task.

After thrashing in the deep-end briefly, wrapping my head around what it means to bring our dev/test and prod servers more into alignment—such that both `npm start` and `npm run dev-start` both spin up servers with the same routes, to support the ElasticSearch proxy (#630)—I reckoned that a much simpler approach (outlined by @jermnelson in a Slack thread the other day) is probably a better choice for now: continue to declare routes in `server.js`, which is only used in prod-like environments, and proxy routes needed in dev/test environments in `webpack.config.js`.

The cost of this approach is it will require that developers have both `npm start` *and* `npm run dev-start` spinning simultaneously, which, if this PR/approach is acceptable, I plan to cover in a README change as part of the work on #630, once it is unblocked.