### PR TITLE
[Refactor] Rename setResourceTemplate to rootResourceTemplateLoaded

### DIFF
--- a/__tests__/actions/index.test.js
+++ b/__tests__/actions/index.test.js
@@ -66,9 +66,9 @@ describe('authentication actions', () => {
 })
 
 describe('initializes the Redux State', () => {
-  it('should return Redux state based on SET_RESOURCE_TEMPLATE action', () => {
-    expect(actions.setResourceTemplate({}, { reduxPath: ['http://sinopia.io/example'] })).toEqual({
-      type: 'SET_RESOURCE_TEMPLATE',
+  it('should return Redux state based on ROOT_RESOURCE_TEMPLATE_LOADED action', () => {
+    expect(actions.rootResourceTemplateLoaded({}, { reduxPath: ['http://sinopia.io/example'] })).toEqual({
+      type: 'ROOT_RESOURCE_TEMPLATE_LOADED',
       payload: {},
     })
   })

--- a/__tests__/reducers/index.test.js
+++ b/__tests__/reducers/index.test.js
@@ -5,7 +5,7 @@ import selectorReducer, {
   populatePropertyDefaults,
   refreshResourceTemplate,
   resourceTemplateLoaded,
-  setResourceTemplate,
+  rootResourceTemplateLoaded,
 } from 'reducers/index'
 /* eslint import/namespace: 'off' */
 import * as inputs from 'reducers/inputs'
@@ -151,11 +151,11 @@ describe('selectorReducer', () => {
     expect(inputs.setBaseURL).toBeCalledWith(oldState, action)
   })
 
-  it('handles SET_RESOURCE_TEMPLATE', () => {
+  it('handles ROOT_RESOURCE_TEMPLATE_LOADED', () => {
     shortid.generate = jest.fn().mockReturnValue(0)
     const result = selectorReducer(initialState,
       {
-        type: 'SET_RESOURCE_TEMPLATE',
+        type: 'ROOT_RESOURCE_TEMPLATE_LOADED',
         payload: {
           id: 'resourceTemplate:bf2:Monograph:Instance',
           resourceURI: 'http://id.loc.gov/ontologies/bibframe/Instance',
@@ -200,11 +200,11 @@ describe('selectorReducer', () => {
     })
   })
 
-  it('allows SET_RESOURCE_TEMPLATE on templates without valueConstraint', () => {
+  it('allows ROOT_RESOURCE_TEMPLATE_LOADED on templates without valueConstraint', () => {
     shortid.generate = jest.fn().mockReturnValue(0)
     const result = selectorReducer(initialState,
       {
-        type: 'SET_RESOURCE_TEMPLATE',
+        type: 'ROOT_RESOURCE_TEMPLATE_LOADED',
         payload: {
           id: 'resourceTemplate:bf2:Monograph:Instance',
           propertyTemplates: propertyTemplateWithoutConstraint,
@@ -258,7 +258,7 @@ describe('refreshResourceTemplate', () => {
     ]
 
     selectorReducer(initialState, {
-      type: 'SET_RESOURCE_TEMPLATE',
+      type: 'ROOT_RESOURCE_TEMPLATE_LOADED',
       payload: {
         id: 'resourceTemplate:bf2:Note',
         resourceURI: 'http://id.loc.gov/ontologies/bibframe/Note',
@@ -430,7 +430,7 @@ describe('resourceTemplateLoaded()', () => {
   })
 })
 
-describe('setResourceTemplate()', () => {
+describe('rootResourceTemplateLoaded()', () => {
   it('adds resource to the resourceTemplates entities state', () => {
     const template = {
       id: 'resourceTemplate:bf2:Monograph:Work',
@@ -438,8 +438,8 @@ describe('setResourceTemplate()', () => {
         { propertyURI: 'http://id.loc.gov/ontologies/bibframe/title' },
       ],
     }
-    const newState = setResourceTemplate(initialState.selectorReducer, {
-      type: 'SET_RESOURCE_TEMPLATE',
+    const newState = rootResourceTemplateLoaded(initialState.selectorReducer, {
+      type: 'ROOT_RESOURCE_TEMPLATE_LOADED',
       payload: template,
     })
 

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -19,8 +19,8 @@ export const refreshResourceTemplate = update => ({
   payload: update,
 })
 
-export const setResourceTemplate = resourceTemplate => ({
-  type: 'SET_RESOURCE_TEMPLATE',
+export const rootResourceTemplateLoaded = resourceTemplate => ({
+  type: 'ROOT_RESOURCE_TEMPLATE_LOADED',
   payload: resourceTemplate,
 })
 

--- a/src/components/editor/ResourceTemplate.jsx
+++ b/src/components/editor/ResourceTemplate.jsx
@@ -4,7 +4,7 @@ import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
 import ResourceTemplateForm from './ResourceTemplateForm'
-import { setResourceTemplate } from 'actions/index'
+import { rootResourceTemplateLoaded } from 'actions/index'
 import { getResourceTemplate } from 'sinopiaServer'
 
 const _ = require('lodash')
@@ -73,7 +73,7 @@ ResourceTemplate.propTypes = {
 
 const mapDispatchToProps = dispatch => ({
   handleResourceTemplate(resourceTemplate) {
-    dispatch(setResourceTemplate(resourceTemplate))
+    dispatch(rootResourceTemplateLoaded(resourceTemplate))
   },
 })
 

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -64,7 +64,7 @@ export const refreshResourceTemplate = (state, action) => {
  * Called when a top level resource template is loaded
  * the body of the resource template is in `action.payload'
  */
-export const setResourceTemplate = (state, action) => {
+export const rootResourceTemplateLoaded = (state, action) => {
   let newState = resourceTemplateLoaded(state, action)
 
   const resourceTemplateId = action.payload.id
@@ -99,8 +99,8 @@ export const makeShortID = () => shortid.generate()
 
 const selectorReducer = (state = {}, action) => {
   switch (action.type) {
-    case 'SET_RESOURCE_TEMPLATE':
-      return setResourceTemplate(state, action)
+    case 'ROOT_RESOURCE_TEMPLATE_LOADED':
+      return rootResourceTemplateLoaded(state, action)
     case 'SET_ITEMS':
     case 'CHANGE_SELECTIONS':
       return setItemsOrSelections(state, action)


### PR DESCRIPTION
This makes it clearer this is only for the root template.  It also is more consistent with other actions that use "loaded" as a suffix