### PR TITLE
Salvage useful bits of #793

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -6,4 +6,3 @@ static/*
 static-analysis/*
 dist/*
 node_modules/*
-webpack.config.js

--- a/README.md
+++ b/README.md
@@ -136,11 +136,16 @@ in the foreground, `docker run -p 8000:8000 --rm --name=sinopia_editor ld4p/sino
 
 ### Docker-Compose
 
-A docker-compose configuration is also provided to allow integration of the editor with Sinopia's platform components, including Trellis, ElasticSearch, ActiveMQ, Postgres, and the Sinopia indexing pipeline. You can spin up these components, with Trellis listening on http://localhost:8080/, via:
+A docker-compose configuration is also provided to allow integration of the editor with Sinopia's platform components, including Trellis, ElasticSearch, ActiveMQ, Postgres, and the Sinopia indexing pipeline. You can spin up these components via:
 
 ```sh
-$ docker-compose up pipeline # add the '-d' flag to daemonize and run in background
+$ docker-compose up editor # add the '-d' flag to daemonize and run in background
 ```
+
+Of particular interest:
+
+* The editor is at http://localhost:8000/
+* Trellis is at http://localhost:8080/
 
 Note that this will provide you with "out-of-the-box" Trellis, with no data in it. To spin up Trellis and its dependencies with the Sinopia container structure (root, repository, and group containers) and ACLs (declared on root container) pre-created, you can do using the `platformdata` docker-compose service:
 
@@ -149,6 +154,8 @@ $ docker-compose run platformdata
 ```
 
 **NOTE**: In order for the above to work, you will need to set `COGNITO_ADMIN_PASSWORD`, `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY` in a file named `.env` in the sinopia_editor root.
+
+At this point, you will likely want to begin importing resource templates into the editor, after which you can begin creating linked data resources. To import a small set of interesting resource templates, consult the [instructions in this README](https://github.com/LD4P/sinopia_sample_profiles/blob/master/configuration_demo/readme.md).
 
 If you'd like to see how the indexing pipeline is indexing Trellis data into ElasticSearch, you can spy on the ElasticSearch indexes using the DejaVu app included in the `docker-compose` configuration:
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Specify the environment variable `USE_FIXTURES=true` when building the applicati
 
 `npm run dev-start`
 
-Runs the webpack-dev-server, allowing immediate loading of live code changes without having to restart the server. The webpack-dev-server is available on at [http://localhost:8888](http://localhost:8888).
+Runs the webpack-dev-server, allowing immediate loading of live code changes without having to restart the server. The webpack-dev-server is available at [http://localhost:8888](http://localhost:8888).
 Note that running the webpack server does NOT call server.js
 
 ### Building with webpack
@@ -61,10 +61,9 @@ Note that running the webpack server does NOT call server.js
 
 We are using webpack as a build tool.  See `webpack.config.js` for build dependencies and configuration.
 
-##### Running the server with express directory
+### Running the production server
 
-`npm start` will spin up express directly.
-The express server is available on at [http://localhost:8000](http://localhost:8000).
+`npm start` will spin up the production server (this depends on `npm run build` already having been run). The web server is available at [http://localhost:8000](http://localhost:8000).
 
 ### Linter for JavaScript
 
@@ -94,7 +93,7 @@ You can also run the tests together with the linter all in one, similar to what 
 
 ```sh
 npm run ci
-````
+```
 
 Note that if you have an instance of the dev server already running in a separate terminal, you may need to stop the server or you may get a port conflict
 when running the integration tests.
@@ -129,6 +128,7 @@ with images hosted on [Dockerhub](https://hub.docker.com/r/ld4p/sinopia_editor/)
 and with an available Dockerfile to build locally.
 
 ### Running latest Dockerhub Image
+
 To run the Docker image, first download the latest image by
 `docker pull ld4p/sinopia_editor:latest` and then to run the editor locally
 in the foreground, `docker run -p 8000:8000 --rm --name=sinopia_editor ld4p/sinopia_editor`. The running Sinopia Editor should now be available locally at
@@ -139,16 +139,24 @@ in the foreground, `docker run -p 8000:8000 --rm --name=sinopia_editor ld4p/sino
 A docker-compose configuration is also provided to allow integration of the editor with Sinopia's platform components, including Trellis, ElasticSearch, ActiveMQ, Postgres, and the Sinopia indexing pipeline. You can spin up these components, with Trellis listening on http://localhost:8080/, via:
 
 ```sh
-$ docker-compose up # add the '-d' flag to daemonize and run in background
+$ docker-compose up pipeline # add the '-d' flag to daemonize and run in background
 ```
 
 Note that this will provide you with "out-of-the-box" Trellis, with no data in it. To spin up Trellis and its dependencies with the Sinopia container structure (root, repository, and group containers) and ACLs (declared on root container) pre-created, you can do using the `platformdata` docker-compose service:
 
 ```shell
-$ docker-compose up platformdata # add the '-d' flag to daemonize and run in background
+$ docker-compose run platformdata
 ```
 
 **NOTE**: In order for the above to work, you will need to set `COGNITO_ADMIN_PASSWORD`, `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY` in a file named `.env` in the sinopia_editor root.
+
+If you'd like to see how the indexing pipeline is indexing Trellis data into ElasticSearch, you can spy on the ElasticSearch indexes using the DejaVu app included in the `docker-compose` configuration:
+
+```shell
+$ docker-compose up searchui # add the '-d' flag to daemonize and run in background
+```
+
+To use DejaVu, browse to http://localhost:1358, and when prompted, enter `http://localhost:9200` as the ElasticSearch URL and `*` as the index name.
 
 ### Building latest Docker Image
 
@@ -207,6 +215,7 @@ $ aws ecs update-service --service sinopia-homepage --region us-west-2 --cluster
 ```
 
 ## Release Management
+
 The steps to create a tagged release of the Sinopia's Linked Data Editor are as follows:
 
 1. Update the version in `package.json`
@@ -218,7 +227,6 @@ The steps to create a tagged release of the Sinopia's Linked Data Editor are as 
 1. Build a tagged Docker image i.e. `docker build -t ld4p/sinopia_editor:{version} .`
 1. Push the tagged version to Dockerhub with `docker push ld4p/sinopia_editor:{version}`,
    See [documentation](#building-latest-docker-image) for more information
-
 
 
 # LD4P's fork of the BIBFRAME Editor

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,12 +10,39 @@ services:
       - 8000:8000
     depends_on:
       - platform
-  broker:
-    image: rmohr/activemq
+      - pipeline
+  pipeline:
+    image: ld4p/sinopia_indexing_pipeline:latest
+    environment:
+      INDEX_URL: http://search:9200
+      BROKER_HOST: broker
+    depends_on:
+      - broker
+      - search
+      - platform
+  search:
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.3.2
+    entrypoint:
+      - elasticsearch
+      - -Ehttp.port=9200
+      - -Ehttp.cors.enabled=true
+      - -Ehttp.cors.allow-origin=http://searchui:1358,http://localhost:1358,http://127.0.0.1:1358
+      - -Ehttp.cors.allow-headers=X-Requested-With,X-Auth-Token,Content-Type,Content-Length,Authorization
+      - -Ehttp.cors.allow-credentials=true
+      - -Etransport.host=localhost
+      - -Ebootstrap.system_call_filter=false
+    user: elasticsearch
     ports:
-      - 61613:61613
+      - 9200:9200
+      - 9300:9300
+  searchui:
+    image: appbaseio/dejavu:latest
+    ports:
+      - 1358:1358
+    depends_on:
+      - search
   platformdata:
-    image: ld4p/sinopia_acl:0.2
+    image: ld4p/sinopia_acl:latest
     environment:
       INSIDE_CONTAINER: 'true'
       TRELLIS_BASE_URL: http://platform:8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       context: .
       args:
         USE_FIXTURES: 'false'
-        TRELLIS_BASE_URL: http://platform:8080
+        TRELLIS_BASE_URL: http://localhost:8080
     ports:
       - 8000:8000
     depends_on:

--- a/server.js
+++ b/server.js
@@ -1,23 +1,20 @@
 /*
- * Copyright 2018, 2019 Stanford University see LICENSE for license
+ * Copyright 2019 Stanford University see LICENSE for license
  * Minimal BIBFRAME Editor Node.js server. To run from the command-line:
  *  npm start  or node server.js
  */
 
-const port = 8000
 const express = require('express')
+const versoSpoof = require('./src/versoSpoof')
 
+const port = 8000
 const app = express()
 
 app.use(express.static(`${__dirname}/`))
-app.listen(port)
-
-const versoSpoof = require('./src/versoSpoof.js')
 
 app.get('/api/search', (req, res) => {
   res.json({ foo: 'bar' })
 })
-
 
 app.all('/verso/api/configs', (req, res, next) => {
   if (req.query.filter.where.configType === 'profile') {
@@ -58,5 +55,7 @@ app.get('*', (req, res) => {
   res.sendFile(`${__dirname}/index.html`)
 })
 
-console.info(`BIBFRAME Editor running on ${port}`)
-console.info('Press Ctrl + C to stop.')
+app.listen(port, () => {
+  console.info(`Sinopia Linked Data Editor running on ${port}`)
+  console.info('Press Ctrl + C to stop.')
+})

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,6 @@
-// Copyright 2018 Stanford University see LICENSE for license
+// Copyright 2019 Stanford University see LICENSE for license
+
+/* eslint node/no-unpublished-require: ["off"] */
 const path = require('path')
 const webpack = require('webpack')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
@@ -12,42 +14,42 @@ module.exports = {
         test: /\.(js|jsx)$/,
         include: path.resolve(__dirname, './src'),
         exclude: /node_modules/,
-        use: ['babel-loader']
+        use: ['babel-loader'],
       },
       {
         test: /\.css$/,
-        use: [ 'style-loader', 'css-loader' ]
+        use: ['style-loader', 'css-loader'],
       },
       {
         test: /\.(png|jpg|gif)$/,
         use: [
-          'file-loader'
-        ]
+          'file-loader',
+        ],
       },
       {
         parser: {
-          amd: false
-        }
-      }
-    ]
+          amd: false,
+        },
+      },
+    ],
   },
   node: {
-    fs: "empty"
+    fs: 'empty',
   },
   resolve: {
-    extensions: ['*', '.js', '.jsx']
+    extensions: ['*', '.js', '.jsx'],
   },
   output: {
-    path: __dirname + '/dist',
+    path: path.join(__dirname, '/dist'),
     publicPath: '/dist/',
-    filename: 'bundle.js'
+    filename: 'bundle.js',
   },
   plugins: [
     new webpack.HotModuleReplacementPlugin(),
     new HtmlWebpackPlugin({
       template: path.resolve('./', 'index.html'),
       filename: 'index.html',
-      hash: true
+      hash: true,
     }),
     new webpack.EnvironmentPlugin(
       [
@@ -58,16 +60,16 @@ module.exports = {
         'SINOPIA_URI',
         'AWS_COGNITO_DOMAIN',
         'COGNITO_CLIENT_ID',
-        'COGNITO_USER_POOL_ID'
-      ]
-    )
+        'COGNITO_USER_POOL_ID',
+      ],
+    ),
   ],
   devServer: {
     historyApiFallback: true,
     hot: true,
     port: 8888,
     proxy: {
-      '/api/search': 'http://localhost:8000'
-    }
-  }
+      '/api/search': 'http://localhost:8000',
+    },
+  },
 }


### PR DESCRIPTION
Includes:
* Subject the webpack config to the useful oppression of the eslint regime
* Improve and correct typos in README
* Add indexing pipeline, ElasticSearch, and DejaVu (ES admin app) to docker-compose configuration.
* Organize server.js better.
* Add better documentation about docker-compose configuration
* Fix the editor service so that it can talk to Trellis
  * The editor runs locally (hello, client-side applications), thus must use `localhost` to hit Trellis, rather than `platform` which only works INSIDE containerland (and our browsers are not in containerland).