### PR TITLE
fix repeated placeholder text for input literals in RT where propertyURI is repeated but propertyLabel differs

### DIFF
--- a/__tests__/__fixtures__/propertyURIRepeated.json
+++ b/__tests__/__fixtures__/propertyURIRepeated.json
@@ -1,0 +1,39 @@
+{
+  "propertyTemplates": [
+    {
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "resourceTemplates": [],
+      "valueConstraint": {
+        "valueTemplateRefs": [],
+        "useValuesFrom": [],
+        "defaults": [],
+        "valueDataType": {}
+      },
+      "propertyURI": "http://id.loc.gov/ontologies/bibframe/geographicCoverage",
+      "propertyLabel": "Geographic Coverage 1",
+      "remark": "tooltip 1"
+    },
+    {
+      "mandatory": "false",
+      "repeatable": "true",
+      "type": "literal",
+      "resourceTemplates": [],
+      "valueConstraint": {
+        "valueTemplateRefs": [],
+        "useValuesFrom": [],
+        "defaults": [],
+        "valueDataType": {}
+      },
+      "propertyURI": "http://id.loc.gov/ontologies/bibframe/geographicCoverage",
+      "propertyLabel": "Geographic Coverage 2",
+      "remark": "tooltip 2"
+    }
+  ],
+  "id": "rt:repeated:propertyURI:propertyLabel",
+  "resourceURI": "http://id.loc.gov/ontologies/bibframe/Work",
+  "author": "michelle",
+  "resourceLabel": "repeated propertyURI with differing propertyLabel",
+  "schema": "https://ld4p.github.io/sinopia/schemas/0.0.9/resource-template.json"
+}

--- a/__tests__/fixtureLoaderHelper.js
+++ b/__tests__/fixtureLoaderHelper.js
@@ -58,6 +58,7 @@ const rtFileNames = [
   'literalRepeatDefaultLiteralOnly.json',
   'literalRepeatDefaultUriOnly.json',
   'literalRepeatNoDefault.json',
+  'propertyURIRepeated.json',
   'rdaItemMonograph.json',
 ]
 

--- a/__tests__/integration/repeatedPropertyURI.js
+++ b/__tests__/integration/repeatedPropertyURI.js
@@ -1,0 +1,17 @@
+// Copyright 2019 Stanford University see LICENSE for license
+
+import pupExpect from 'expect-puppeteer'
+import { testUserLogin } from './loginHelper'
+
+describe('A repeated propertyURI', () => {
+  beforeAll(async () => {
+    await testUserLogin()
+  })
+
+  it('renders the form with the right propertyLabels as the placeholders', async () => {
+    expect.assertions(3)
+    await pupExpect(page).toClick('a', { text: 'repeated propertyURI with differing propertyLabel' })
+    await pupExpect(page).toMatchElement('div[data-label="Geographic Coverage 1"] input[placeholder="Geographic Coverage 1"]')
+    await pupExpect(page).toMatchElement('div[data-label="Geographic Coverage 2"] input[placeholder="Geographic Coverage 2"]')
+  })
+})

--- a/src/components/editor/property/InputLiteral.jsx
+++ b/src/components/editor/property/InputLiteral.jsx
@@ -7,7 +7,7 @@ import Modal from 'react-bootstrap/lib/Modal'
 import Button from 'react-bootstrap/lib/Button'
 import shortid from 'shortid'
 import { removeItem, setItems, setLang } from 'actions/index'
-import { findNode, getDisplayValidations, getPropertyTemplate } from 'selectors/resourceSelectors'
+import { findNode, getDisplayValidations } from 'selectors/resourceSelectors'
 import InputLang from './InputLang'
 import { booleanPropertyFromTemplate, defaultLangTemplate } from 'Utilities'
 
@@ -254,19 +254,15 @@ InputLiteral.propTypes = {
 
 const mapStateToProps = (state, props) => {
   const reduxPath = props.reduxPath
-  const resourceTemplateId = reduxPath[reduxPath.length - 2]
-  const propertyURI = reduxPath[reduxPath.length - 1]
   const displayValidations = getDisplayValidations(state)
   const formData = findNode(state.selectorReducer, reduxPath)
   // items has to be its own prop or rerendering won't occur when one is removed
   const items = formData.items
-  const propertyTemplate = getPropertyTemplate(state, resourceTemplateId, propertyURI)
 
   return {
     formData,
     items,
     reduxPath,
-    propertyTemplate,
     displayValidations,
   }
 }

--- a/src/components/editor/property/PropertyComponent.jsx
+++ b/src/components/editor/property/PropertyComponent.jsx
@@ -46,6 +46,7 @@ export class PropertyComponent extends Component {
         switch (property.type) {
           case 'literal':
             return (<InputLiteral key={keyId} id={keyId}
+                                  propertyTemplate = {property}
                                   reduxPath={reduxPath} />)
           case 'resource':
             return (<InputURI key={keyId} id={keyId}

--- a/src/components/editor/property/PropertyComponent.jsx
+++ b/src/components/editor/property/PropertyComponent.jsx
@@ -18,7 +18,7 @@ export class PropertyComponent extends Component {
     }
   }
 
-  inputComponentType = (property) => {
+  inputComponentType = (propertyTemplate) => {
     let config
 
     // We do not support mixed list and lookups, so we will just go with the value of the first config item found
@@ -30,7 +30,7 @@ export class PropertyComponent extends Component {
 
     const reduxPath = Object.assign([], this.props.reduxPath)
 
-    reduxPath.push(property.propertyURI)
+    reduxPath.push(propertyTemplate.propertyURI)
     const keyId = shortid.generate()
 
     switch (config) {
@@ -40,19 +40,19 @@ export class PropertyComponent extends Component {
       case 'list':
         return (<InputListLOC key = {this.props.index}
                               reduxPath={reduxPath}
-                              propertyTemplate = {property}
+                              propertyTemplate = {propertyTemplate}
                               lookupConfig = {this.state.configuration[0]} />)
       default:
-        switch (property.type) {
+        switch (propertyTemplate.type) {
           case 'literal':
             return (<InputLiteral key={keyId} id={keyId}
-                                  propertyTemplate = {property}
+                                  propertyTemplate = {propertyTemplate}
                                   reduxPath={reduxPath} />)
           case 'resource':
             return (<InputURI key={keyId} id={keyId}
                               reduxPath={reduxPath} />)
           default:
-            console.error(`Unknown property type (component=${config}, type=${property.type})`)
+            console.error(`Unknown propertyTemplate type (component=${config}, type=${propertyTemplate.type})`)
         }
     }
 


### PR DESCRIPTION
since fix is to pass the property template down from `PropertyComponent` to `InputLiteral`*, write a simple integration test that checks to see that a fixture RT renders as expected.

*parent already has the right instance, no need to look it up from the redux store, which just returns the property that first matches on propertyURI

closes #765