### PR TITLE
swap the group col for author and remark ("guiding statement") cols in the template list page (/templates)

### DIFF
--- a/__tests__/components/templates/SinopiaResourceTemplates.test.js
+++ b/__tests__/components/templates/SinopiaResourceTemplates.test.js
@@ -185,6 +185,22 @@ describe('<SinopiaResourceTemplates />', () => {
     })
   })
 
+  describe('display', () => {
+    const renderRoutes = () => mount(<SinopiaResourceTemplates messages={[]}/>)
+
+    it('renders the table of resource templates with name, id, author, and guiding statement columns', () => {
+      expect.assertions(1)
+
+      const component = renderRoutes()
+      const tableHeaderCellText = component.find('table#resource-template-list th').map(thWrapper => thWrapper.text())
+      expect(tableHeaderCellText).toEqual(['Template name', 'ID', 'Author', 'Guiding statement'])
+    })
+
+    afterAll(() => {
+      renderRoutes.unmount()
+    })
+  })
+
   describe('setStateFromServerResponse()', () => {
     it('calls getResourceTemplate() once when passed a string', async () => {
       expect.assertions(2)

--- a/__tests__/components/templates/SinopiaResourceTemplates.test.js
+++ b/__tests__/components/templates/SinopiaResourceTemplates.test.js
@@ -250,7 +250,8 @@ describe('<SinopiaResourceTemplates />', () => {
           name: 'baz',
           uri: 'template99',
           id: 'bar',
-          group: 'ld4p',
+          author: 'wright.lee.renønd',
+          remark: 'very salient information',
         },
       ]
 
@@ -274,7 +275,8 @@ describe('<SinopiaResourceTemplates />', () => {
       name: 'Note',
       uri: 'http://localhost:8080/repository/ld4p/Note',
       id: 'ld4p:resourceTemplate:bf2:Note',
-      group: 'ld4p',
+      author: 'wright.lee.renønd',
+      remark: 'very salient information',
     }
 
     const wrapper4 = shallow(<SinopiaResourceTemplates messages={messages}/>)

--- a/__tests__/components/templates/SinopiaResourceTemplates.test.js
+++ b/__tests__/components/templates/SinopiaResourceTemplates.test.js
@@ -6,7 +6,7 @@ import { mount, shallow } from 'enzyme'
 import SinopiaResourceTemplates from 'components/templates/SinopiaResourceTemplates'
 import { getEntityTagFromGroupContainer, getResourceTemplate, listResourcesInGroupContainer } from 'sinopiaServer'
 
-jest.mock('../../../src/sinopiaServer')
+jest.mock('sinopiaServer')
 
 describe('<SinopiaResourceTemplates />', () => {
   const messages = [

--- a/src/components/templates/SinopiaResourceTemplates.jsx
+++ b/src/components/templates/SinopiaResourceTemplates.jsx
@@ -89,6 +89,8 @@ class SinopiaResourceTemplates extends Component {
         uri: templateId,
         id: resourceTemplateBody.id,
         group: groupName,
+        author: resourceTemplateBody.author,
+        remark: resourceTemplateBody.remark,
       }
 
       const templates = [...this.state.resourceTemplates]
@@ -143,19 +145,25 @@ class SinopiaResourceTemplates extends Component {
       text: 'Template name',
       sort: true,
       formatter: this.linkFormatter,
-      headerStyle: { backgroundColor: '#F8F6EF', width: '25%' },
+      headerStyle: { backgroundColor: '#F8F6EF', width: '30%' },
     },
     {
       dataField: 'id',
       text: 'ID',
       sort: true,
-      headerStyle: { backgroundColor: '#F8F6EF', width: '50%' },
+      headerStyle: { backgroundColor: '#F8F6EF', width: '30%' },
     },
     {
-      dataField: 'group',
-      text: 'Group',
+      dataField: 'author',
+      text: 'Author',
       sort: true,
-      headerStyle: { backgroundColor: '#F8F6EF', width: '25%' },
+      headerStyle: { backgroundColor: '#F8F6EF', width: '10%' },
+    },
+    {
+      dataField: 'remark',
+      text: 'Guiding statement',
+      sort: false,
+      headerStyle: { backgroundColor: '#F8F6EF', width: '30%' },
     }]
 
     return (

--- a/src/components/templates/SinopiaResourceTemplates.jsx
+++ b/src/components/templates/SinopiaResourceTemplates.jsx
@@ -170,7 +170,7 @@ class SinopiaResourceTemplates extends Component {
       <div>
         { createResourceMessage }
         <h4>Available Resource Templates in Sinopia</h4>
-        <BootstrapTable keyField="key" data={ this.state.resourceTemplates } columns={ columns } />
+        <BootstrapTable id="resource-template-list" keyField="key" data={ this.state.resourceTemplates } columns={ columns } />
       </div>
     )
   }


### PR DESCRIPTION
~~starting this out in draft because i'd be interested in getting advice or pairing on writing a simple test for this... maybe an integration test?  maybe that's overkill?  but i'll note that the code change didn't fail any existing tests (and i only made the change i did to the component's unit tests so that the example there wouldn't be confusingly out of sync with the app code, even though lack of change would've left things passing).~~

<img width="1621" alt="Screen Shot 2019-06-21 at 8 01 38 PM" src="https://user-images.githubusercontent.com/7741604/59958733-fd100400-945f-11e9-8b79-8d495ae76d17.png">

closes #802 (remark)
closes #636 (author)