### PR TITLE
Don't mutate the state of objects in the store

### DIFF
--- a/src/components/editor/ResourceTemplateForm.jsx
+++ b/src/components/editor/ResourceTemplateForm.jsx
@@ -39,7 +39,6 @@ export class ResourceTemplateForm extends Component {
         // Add the resource template into the store
         store.dispatch(resourceTemplateLoaded(fulfilledResourceTemplateRequest.response.body))
       })
-      this.setState({ templateError: false }) // Force a re-render
     }).catch((err) => {
       this.setState({ templateError: err })
     })

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -89,8 +89,10 @@ export const rootResourceTemplateLoaded = (state, action) => {
 export const resourceTemplateLoaded = (state, action) => {
   const resourceTemplateId = action.payload.id
   const newState = { ...state }
+  const newResourceTemplates = { ...newState.entities.resourceTemplates }
 
-  newState.entities.resourceTemplates[resourceTemplateId] = action.payload
+  newResourceTemplates[resourceTemplateId] = action.payload
+  newState.entities.resourceTemplates = newResourceTemplates
 
   return newState
 }


### PR DESCRIPTION
Mutation isn't picked up as a change by redux, so the component is not re-rendered.  This allows us to stop using the state change hack