### PR TITLE
Refactor so that PropertyResourceTemplate makes the child rows

### DIFF
--- a/__tests__/components/editor/ResourceTemplateForm.test.js
+++ b/__tests__/components/editor/ResourceTemplateForm.test.js
@@ -3,7 +3,6 @@
 import React from 'react'
 import 'jsdom-global/register'
 import { shallow } from 'enzyme'
-import shortid from 'shortid'
 import ResourceTemplateForm from 'components/editor/ResourceTemplateForm'
 
 describe('<ResourceTemplateForm /> functional testing', () => {
@@ -11,8 +10,6 @@ describe('<ResourceTemplateForm /> functional testing', () => {
   const basicWrapper = shallow(<ResourceTemplateForm.WrappedComponent propertyTemplates={[]}
                                                                       rtId={'myOrg:rt:myTemplate'}
                                                                       resourceTemplate={ basicRt } />)
-
-  shortid.generate = jest.fn().mockReturnValue('abcd45')
 
   describe('resourceTemplateFields expectations and outputs', () => {
     it('empty array, null, or undefined resource templates', () => {
@@ -55,9 +52,7 @@ describe('<ResourceTemplateForm /> functional testing', () => {
       expect(result[0].props.reduxPath).toEqual([
         'resource',
         'myOrg:rt:myTemplate',
-        'http://www.w3.org/2000/01/rdf-schema#label',
-        'abcd45',
-        'resourceTemplate:bf2:Note'])
+        'http://www.w3.org/2000/01/rdf-schema#label'])
     })
   })
 })

--- a/__tests__/components/editor/property/PropertyResourceTemplate.test.js
+++ b/__tests__/components/editor/property/PropertyResourceTemplate.test.js
@@ -6,10 +6,14 @@ import { mount, shallow } from 'enzyme'
 import { PropertyActionButtons } from 'components/editor/property/PropertyActionButtons'
 import PropertyResourceTemplate from 'components/editor/property/PropertyResourceTemplate'
 import PropertyTemplateOutline from 'components/editor/property/PropertyTemplateOutline'
+import shortid from 'shortid'
 
 describe('<PropertyResourceTemplate />', () => {
+  shortid.generate = jest.fn().mockReturnValue('AE6Be-DJGj')
+
   const propertyRtProps = {
     resourceTemplate: {
+      id: 'resourceTemplate:bf2:WorkTitle',
       resourceLabel: 'Test Schema Thing Template',
       propertyTemplates: [
         {
@@ -18,7 +22,7 @@ describe('<PropertyResourceTemplate />', () => {
         },
       ],
     },
-    reduxPath: ['resourceTemplate:test'],
+    reduxPath: ['http://id.loc.gov/ontologies/bibframe/title'],
   }
 
   const wrapper = shallow(<PropertyResourceTemplate {...propertyRtProps} />)
@@ -42,9 +46,11 @@ describe('<PropertyResourceTemplate />', () => {
   })
 
   it('<PropertyTemplateOutline /> has the expected Redux path', () => {
-    expect(propTemplateOutline.props().reduxPath).toEqual(
-      ['resourceTemplate:test'],
-    )
+    expect(propTemplateOutline.props().reduxPath).toEqual([
+      'http://id.loc.gov/ontologies/bibframe/title',
+      'AE6Be-DJGj',
+      'resourceTemplate:bf2:WorkTitle',
+    ])
   })
 
   describe('<PropertyResourceTemplate /> has the "Add" button', () => {

--- a/src/components/editor/ResourceTemplateForm.jsx
+++ b/src/components/editor/ResourceTemplateForm.jsx
@@ -82,11 +82,10 @@ export class ResourceTemplateForm extends Component {
       const rt = this.rtForPt(rtId)
 
       if (rt !== undefined) { // It may not be loaded yet
-        const keyId = shortid.generate()
-        const reduxPath = ['resource', this.props.rtId, property.propertyURI, keyId, rtId]
+        const reduxPath = ['resource', this.props.rtId, property.propertyURI]
 
         rtProperties.push(<PropertyResourceTemplate
-          key={keyId}
+          key={shortid.generate()}
           isRepeatable={property.repeatable}
           resourceTemplate={rt}
           reduxPath={reduxPath} />)

--- a/src/components/editor/property/PropertyResourceTemplate.jsx
+++ b/src/components/editor/property/PropertyResourceTemplate.jsx
@@ -6,12 +6,43 @@ import PropTypes from 'prop-types'
 import PropertyActionButtons from './PropertyActionButtons'
 import PropertyTemplateOutline from './PropertyTemplateOutline'
 
+/**
+ * Renders a sub-resource template (e.g. WorkTitle, WorkVariantTitle, TranscribedTitle)
+ * In Redux these are modeled like this:
+ *   http://id.loc.gov/ontologies/bibframe/title: {
+ *     'AE6Be-DJGj': {
+ *       'resourceTemplate:bf2:WorkTitle': {
+ *         'http://id.loc.gov/ontologies/bibframe/mainTitle: {
+ *
+ *         }
+ *       }
+ *     }
+ *     'Mxt-oGAg0s2': {
+ *       'resourceTemplate:bf2:WorkVariantTitle': {
+ *         'http://id.loc.gov/ontologies/bibframe/mainTitle: {
+ *
+ *         }
+ *       }
+ *     }
+ *     'dGMYKnhJhlG': {
+ *       'resourceTemplate:bf2:TranscribedTitle': {
+ *         'http://id.loc.gov/ontologies/bibframe/mainTitle: {
+ *
+ *         }
+ *       }
+ *     }
+ *   }
+ *
+ *  In the props we are passed the resourceTemplate, so we can get the rows from
+ *  the redux store by filtering path for items that have a key that matches
+ *  resourceTemplate.id
+ */
 class PropertyResourceTemplate extends Component {
   constructor(props) {
     super(props)
     this.state = {
       collapse: false,
-      output: this.populatePropertyTemplates(this.props.reduxPath),
+      output: this.populatePropertyTemplates(),
     }
   }
 
@@ -21,33 +52,26 @@ class PropertyResourceTemplate extends Component {
 
     existingOutputs.push(<h4 key={shortid.generate()}>{this.props.resourceTemplate.resourceLabel}</h4>)
 
-    const newReduxPath = [...this.props.reduxPath]
-
-    /*
-     * Replace the generated id so that this is a new resource.
-     * The redux path will be something like ..., "kV5fjX2b1", "resourceTemplate:bf2:Monograph:Work"
-     */
-    newReduxPath[newReduxPath.length - 2] = shortid.generate()
-    const result = this.populatePropertyTemplates(newReduxPath)
+    const result = this.populatePropertyTemplates()
 
     this.setState({ output: existingOutputs.concat(result) })
   }
 
-  populatePropertyTemplates = (reduxPath) => {
-    const newOutput = []
+  populatePropertyTemplates = () => this.props.resourceTemplate.propertyTemplates.map((property) => {
+    const keyId = shortid.generate()
 
-    this.props.resourceTemplate.propertyTemplates.map((property) => {
-      const keyId = shortid.generate()
+    /*
+     * Add the generated id so that this is a new resource.
+     * The redux path will be something like ..., "kV5fjX2b1", "resourceTemplate:bf2:Monograph:Work"
+     */
+    const reduxPath = [...this.props.reduxPath, keyId, this.props.resourceTemplate.id]
 
-      newOutput.push(<PropertyTemplateOutline
-                      propertyTemplate={property}
-                      rtId={this.props.resourceTemplate.id}
-                      reduxPath={reduxPath}
-                      key={keyId} />)
-    })
-
-    return newOutput
-  }
+    return (<PropertyTemplateOutline
+                    propertyTemplate={property}
+                    rtId={this.props.resourceTemplate.id}
+                    reduxPath={reduxPath}
+                    key={keyId} />)
+  })
 
   render() {
     // repeatable defaults to false, so isAddDisabled defaults to true


### PR DESCRIPTION
Since PropertyResourceTemplate has the add button it makes sense for it to be
responsible for generating reduxPath for the children.  This will enable the editor
to load up existing resources from Trellis.