### PR TITLE
MonographInstance fixture: remove duplicate property

### DIFF
--- a/__tests__/__fixtures__/MonographInstance.json
+++ b/__tests__/__fixtures__/MonographInstance.json
@@ -198,23 +198,6 @@
       }
     },
     {
-      "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-      "propertyLabel": "Note on Frequency (RDA 2.17.12)",
-      "remark": "http://access.rdatoolkit.org/2.17.12.html",
-      "mandatory": "false",
-      "repeatable": "true",
-      "type": "resource",
-      "resourceTemplates": [],
-      "valueConstraint": {
-        "valueTemplateRefs": [
-          "resourceTemplate:bf2:Note"
-        ],
-        "useValuesFrom": [],
-        "valueDataType": {},
-        "defaults": []
-      }
-    },
-    {
       "propertyLabel": "Holdings",
       "propertyURI": "http://id.loc.gov/ontologies/bibframe/heldBy",
       "resourceTemplates": [],


### PR DESCRIPTION
Fixes #837 

Remove "Notes on Frequency" propertyTemplate as it isn't used in any tests.