### PR TITLE
tests: if setup or tear down is async, no need for explicit return

### DIFF
--- a/__tests__/integration/correctRdfInPreview/literalPropertyTemplates.test.js
+++ b/__tests__/integration/correctRdfInPreview/literalPropertyTemplates.test.js
@@ -9,12 +9,12 @@ import { testUserLogin } from '../loginHelper'
  */
 describe('RDF from literal property templates', () => {
   beforeAll(async () => {
-    return await testUserLogin()
+    await testUserLogin()
   })
 
   beforeEach(async () => {
     await page.goto('http://127.0.0.1:8888/templates')
-    return await page.waitForSelector('.react-bootstrap-table')
+    await page.waitForSelector('.react-bootstrap-table')
   })
 
   it('non-repeatable, no default value, default language', async () => {

--- a/__tests__/integration/landingPage.test.js
+++ b/__tests__/integration/landingPage.test.js
@@ -4,7 +4,7 @@ import 'isomorphic-fetch'
 
 describe('Basic end to end Sinopia Linked Data Editor', () => {
   beforeAll(async () => {
-    return await page.goto('http://127.0.0.1:8888/')
+    await page.goto('http://127.0.0.1:8888/')
   })
 
   it('displays "Linked Data Editor" and "Profile Editor" in menu', async () => {

--- a/__tests__/integration/nestedResources.test.js
+++ b/__tests__/integration/nestedResources.test.js
@@ -5,7 +5,7 @@ import { testUserLogin } from './loginHelper'
 
 describe('Expanding a resource property in a property panel', () => {
   beforeAll(async () => {
-    return await testUserLogin()
+    await testUserLogin()
   })
 
   it('loads up a resource template from the list of loaded templates', async () => {

--- a/__tests__/integration/previewSaveRDF.test.js
+++ b/__tests__/integration/previewSaveRDF.test.js
@@ -6,11 +6,11 @@ import { fillInRequredFieldsForBibframeInstance } from './previewRDFHelper'
 
 describe('Previewing the RDF', () => {
   beforeAll(async () => {
-    return await testUserLogin()
+    await testUserLogin()
   })
 
   beforeEach(async () => {
-    return await fillInRequredFieldsForBibframeInstance()
+    await fillInRequredFieldsForBibframeInstance()
   })
 
   it('builds the rdf and has dialog for saving', async () => {

--- a/__tests__/integration/repeatableResources.test.js
+++ b/__tests__/integration/repeatableResources.test.js
@@ -7,7 +7,7 @@ describe('Adding new embedded Resource Templates', () => {
   beforeAll(async () => {
     await testUserLogin()
     await pupExpect(page).toClick('a', { text: 'BIBFRAME Instance' })
-    return await pupExpect(page).toMatch('BIBFRAME Instance')
+    await pupExpect(page).toMatch('BIBFRAME Instance')
   })
 
   describe('one level of nested resourceTemplate (Notes about the Instance)', () => {

--- a/__tests__/integration/saveIncompleteRDF.test.js
+++ b/__tests__/integration/saveIncompleteRDF.test.js
@@ -6,12 +6,12 @@ import { incompleteFieldsForBibframeInstance } from './previewRDFHelper'
 
 describe('Previewing the RDF', () => {
   beforeAll(async () => {
-    return await testUserLogin()
+    await testUserLogin()
   })
 
   beforeEach(async () => {
     await page.goto('http://127.0.0.1:8888/templates')
-    return await incompleteFieldsForBibframeInstance()
+    await incompleteFieldsForBibframeInstance()
   })
 
   it('builds the rdf and displays validation errors after attempting to save', async () => {

--- a/__tests__/integration/schemaValidation.test.js
+++ b/__tests__/integration/schemaValidation.test.js
@@ -5,7 +5,7 @@ import { testUserLogin } from './loginHelper'
 
 describe('Importing a profile/template with bad JSON', () => {
   beforeAll(async () => {
-    return await testUserLogin()
+    await testUserLogin()
   })
 
   it('Displays an error message', async () => {

--- a/__tests__/integration/unauthenticatedNavigation.test.js
+++ b/__tests__/integration/unauthenticatedNavigation.test.js
@@ -13,7 +13,7 @@ describe('When an unauthenticated user tries to access resource templates', () =
     } catch (error) {
       // Avoid failing after logout
     }
-    return await page.waitForSelector('form.login-form') // Waiting for login form
+    await page.waitForSelector('form.login-form') // Waiting for login form
   })
 
   it('does not display "Available Resource Templates in Sinopia"', async () => {

--- a/__tests__/integration/verifyPreviewRDF.test.js
+++ b/__tests__/integration/verifyPreviewRDF.test.js
@@ -6,11 +6,11 @@ import { fillInRequredFieldsForBibframeInstance } from './previewRDFHelper'
 
 describe('Previewing the RDF', () => {
   beforeAll(async () => {
-    return await testUserLogin()
+    await testUserLogin()
   })
 
   beforeEach(async () => {
-    return await fillInRequredFieldsForBibframeInstance()
+    await fillInRequredFieldsForBibframeInstance()
   })
 
   it('builds the rdf and verifies the expected content', async () => {


### PR DESCRIPTION
fixes #840

This PR adapts our tests to have better syntax for async setup and teardown methods. 

from https://jestjs.io/docs/en/setup-teardown

> beforeEach and afterEach can handle asynchronous code in the same ways that tests can  handle asynchronous code - they can either take a done parameter or return a promise. For example, if [ promiseFromFunction() ] returned a promise that resolved when the database was initialized, we would want to return that promise:

```js
beforeEach(() => {
  return promiseFromFunction()
})
```

As @jmartin-sul points out in #840 and also in [this PR comment](https://github.com/LD4P/sinopia_editor/pull/820#discussion_r297858708), an `async` method, by definition, returns a promise.  So this is also an appropriate way for a setup/teardown method to handle asynchronous code:

```js
beforeEach(async () => {
  await promiseFromFunction()
})
```

The benefit of the second approach is it also allows for multiple await statements, and makes the asynchronous code more obviously async:

```js
beforeEach(async () => {
  await promiseToReviewThisPR()
  await promiseToMergeThisPR()
  await promiseToFinishSinopiaWorkCycle()
})
```


