### PR TITLE
Set method complexity to fix eslint in build

### DIFF
--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,5 +1,5 @@
 // Copyright 2018, 2019 Stanford University see LICENSE for license
-/* eslint complexity: ["warn", 14] */
+/* eslint complexity: ["warn", 15] */
 
 import { combineReducers } from 'redux'
 import shortid from 'shortid'


### PR DESCRIPTION
The complexity of this method increased by one on the last merge with master so this wasn't noticed until merged. Fixes the master build.