### PR TITLE
Ignore .env file when building docker images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,3 +14,4 @@ junit.xml
 npm-debug.log
 static-analysis
 setupEnzyme.js
+.env


### PR DESCRIPTION
Because we should not include sensitive values in public assets.