### PR TITLE
Get resource template title for display in editor

### DIFF
--- a/__tests__/components/editor/ResourceTemplate.test.js
+++ b/__tests__/components/editor/ResourceTemplate.test.js
@@ -13,7 +13,7 @@ describe('<ResourceTemplate />', () => {
   const wrapper = shallow(<ResourceTemplate.WrappedComponent resourceTemplateId="resourceTemplate:bf2:Note"
                                                              resourceTemplate={reduxState}
                                                              retrieveResourceTemplate={jest.fn()}
-                                                             rtLabel="BF2 Work"/>)
+                                                             resourceTemplateLabel="BF2 Work"/>)
 
   it('has div with class "ResourceTemplate"', () => {
     expect(wrapper.find('div.ResourceTemplate').length).toEqual(1)

--- a/__tests__/integration/verifyTemplateTitle.test.js
+++ b/__tests__/integration/verifyTemplateTitle.test.js
@@ -2,7 +2,6 @@
 
 import pupExpect from 'expect-puppeteer'
 import { testUserLogin } from './loginHelper'
-import { fillInRequredFieldsForBibframeInstance } from './previewRDFHelper'
 
 describe('Verify the resource template title is displayed in the editor', () => {
   beforeAll(async () => {
@@ -14,6 +13,5 @@ describe('Verify the resource template title is displayed in the editor', () => 
 
     await pupExpect(page).toClick('a', { text: 'Note' })
     await pupExpect(page).toMatchElement('h1', { text: 'Note' })
-
   })
 })

--- a/__tests__/integration/verifyTemplateTitle.test.js
+++ b/__tests__/integration/verifyTemplateTitle.test.js
@@ -1,0 +1,19 @@
+// Copyright 2019 Stanford University see LICENSE for license
+
+import pupExpect from 'expect-puppeteer'
+import { testUserLogin } from './loginHelper'
+import { fillInRequredFieldsForBibframeInstance } from './previewRDFHelper'
+
+describe('Verify the resource template title is displayed in the editor', () => {
+  beforeAll(async () => {
+    await testUserLogin()
+  })
+
+  it('verifies that the title is in the header', async () => {
+    expect.assertions(2)
+
+    await pupExpect(page).toClick('a', { text: 'Note' })
+    await pupExpect(page).toMatchElement('h1', { text: 'Note' })
+
+  })
+})

--- a/src/components/editor/ResourceTemplate.jsx
+++ b/src/components/editor/ResourceTemplate.jsx
@@ -27,6 +27,7 @@ class ResourceTemplate extends Component {
     if (!this.props.resourceTemplate) {
       return errorMessage
     }
+
     return (
       <div className="ResourceTemplate">
         <div id="resourceTemplate" style={{ marginTop: '-30px' }}>
@@ -51,6 +52,7 @@ ResourceTemplate.propTypes = {
 
 const mapStateToProps = state => ({
   resourceTemplate: rootResource(state),
+  title: state.selectorReducer.resource.title,
   error: state.selectorReducer.editor.serverError,
 })
 

--- a/src/components/editor/ResourceTemplate.jsx
+++ b/src/components/editor/ResourceTemplate.jsx
@@ -52,7 +52,7 @@ ResourceTemplate.propTypes = {
 
 const mapStateToProps = state => ({
   resourceTemplate: rootResource(state),
-  title: state.selectorReducer.editor.resourceTitle,
+  title: state.selectorReducer.editor.rootResourceTitle,
   error: state.selectorReducer.editor.serverError,
 })
 

--- a/src/components/editor/ResourceTemplate.jsx
+++ b/src/components/editor/ResourceTemplate.jsx
@@ -52,7 +52,7 @@ ResourceTemplate.propTypes = {
 
 const mapStateToProps = state => ({
   resourceTemplate: rootResource(state),
-  title: state.selectorReducer.resource.title,
+  title: state.selectorReducer.editor.resourceTitle,
   error: state.selectorReducer.editor.serverError,
 })
 

--- a/src/components/editor/ResourceTemplate.jsx
+++ b/src/components/editor/ResourceTemplate.jsx
@@ -32,7 +32,7 @@ class ResourceTemplate extends Component {
       <div className="ResourceTemplate">
         <div id="resourceTemplate" style={{ marginTop: '-30px' }}>
           <section className="col-md-9">
-            <h1><em>{this.props.rtLabel}</em></h1>
+            <h1><em>{this.props.resourceTemplateLabel}</em></h1>
             <ResourceURIMessage />
           </section>
           <ResourceTemplateForm rtId = {this.props.resourceTemplateId} />
@@ -46,17 +46,17 @@ ResourceTemplate.propTypes = {
   retrieveResourceTemplate: PropTypes.func,
   resourceTemplateId: PropTypes.string,
   resourceTemplate: PropTypes.object,
-  rtLabel: PropTypes.string,
+  resourceTemplateLabel: PropTypes.string,
   error: PropTypes.string,
 }
 
 const mapStateToProps = (state, ownProps) => {
   const resourceTemplate = rootResource(state)
-  const rtLabel = state.selectorReducer.entities.resourceTemplates[ownProps.resourceTemplateId]?.resourceLabel
+  const resourceTemplateLabel = state.selectorReducer.entities.resourceTemplates[ownProps.resourceTemplateId]?.resourceLabel
   const error = state.selectorReducer.editor.serverError
   return {
     resourceTemplate,
-    rtLabel,
+    resourceTemplateLabel,
     error,
   }
 }

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -81,7 +81,7 @@ export const rootResourceTemplateLoaded = (state, action) => {
   })
 
   if (action.payload.resourceLabel) {
-    newState.resource.title = action.payload.resourceLabel
+    newState.editor.resourceTitle = action.payload.resourceLabel
   }
 
   // Clear any existing validation errors when we load a resource template

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -80,6 +80,10 @@ export const rootResourceTemplateLoaded = (state, action) => {
     newState = refreshResourceTemplate(newState, propertyAction)
   })
 
+  if (action.payload.resourceLabel) {
+    newState.resource.title = action.payload.resourceLabel
+  }
+
   // Clear any existing validation errors when we load a resource template
   newState.editor.errors = []
   newState.editor.displayValidations = false

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -81,7 +81,7 @@ export const rootResourceTemplateLoaded = (state, action) => {
   })
 
   if (action.payload.resourceLabel) {
-    newState.editor.resourceTitle = action.payload.resourceLabel
+    newState.editor.rootResourceTitle = action.payload.resourceLabel
   }
 
   // Clear any existing validation errors when we load a resource template


### PR DESCRIPTION
Fixes #844 

This sets the title of the resource Template into `resourceTemplateLabel` in order to be displayed on the editor page.

Note: This bug was missed by the simple unit test due to the injection of the title guaranteeing it's availability in the display. Basic integration tests like the one below are critical in surfacing these kinds of bugs by using fixtures that are compared to the output.