### PR TITLE
InputListLOC uses redux state for propertyTemplate and lookupConfig 

### DIFF
--- a/__tests__/components/editor/property/InputListLOC.test.js
+++ b/__tests__/components/editor/property/InputListLOC.test.js
@@ -5,7 +5,7 @@ import { shallow } from 'enzyme'
 import { Typeahead } from 'react-bootstrap-typeahead'
 import InputListLOC from 'components/editor/property/InputListLOC'
 
-const plProps = {
+const propsOk = {
   propertyTemplate:
     {
       propertyURI: 'http://id.loc.gov/ontologies/bflc/target',
@@ -19,7 +19,6 @@ const plProps = {
           defaultURI: 'http://id.loc.gov/vocabulary/carriers/nc',
           defaultLiteral: 'volume',
         }],
-        valueTemplateRefs: [],
         useValuesFrom: [
           'vocabulary:bf2:frequencies',
         ],
@@ -28,20 +27,87 @@ const plProps = {
         },
       },
     },
+  lookupConfig: [
+    {
+      label: 'carriers',
+      uri: 'https://id.loc.gov/vocabulary/carriers',
+      component: 'list',
+    },
+  ],
+  defaults: [
+    {
+      defaultURI: 'http://id.loc.gov/vocabulary/carriers/nc',
+      defaultLiteral: 'volume',
+    },
+  ],
 }
 
-const mockLookupConfig = [
-  {
-    label: 'carriers',
-    uri: 'https://id.loc.gov/vocabulary/carriers',
-    component: 'list',
-  },
-  {
-    label: 'frequency',
-    uri: undefined,
-    component: 'list',
-  },
-]
+const propsUndefLookupURI = {
+  propertyTemplate:
+    {
+      propertyURI: 'http://id.loc.gov/ontologies/bflc/target',
+      propertyLabel: 'Frequency (RDA 2.14)',
+      remark: 'http://access.rdatoolkit.org/2.14.html',
+      mandatory: 'false',
+      repeatable: 'true',
+      type: 'lookup',
+      valueConstraint: {
+        defaults: [{
+          defaultURI: 'http://id.loc.gov/vocabulary/carriers/nc',
+          defaultLiteral: 'volume',
+        }],
+        useValuesFrom: [
+          'vocabulary:bf2:frequencies',
+        ],
+        valueDataType: {
+          dataTypeURI: 'http://id.loc.gov/ontologies/bibframe/Frequency',
+        },
+      },
+    },
+  lookupConfig: [
+    {
+      label: 'frequency',
+      uri: undefined,
+      component: 'list',
+    },
+  ],
+}
+
+const propsMultLookup = {
+  propertyTemplate:
+    {
+      propertyURI: 'http://id.loc.gov/ontologies/bflc/target',
+      propertyLabel: 'Frequency (RDA 2.14)',
+      remark: 'http://access.rdatoolkit.org/2.14.html',
+      mandatory: 'false',
+      repeatable: 'true',
+      type: 'lookup',
+      valueConstraint: {
+        defaults: [{
+          defaultURI: 'http://id.loc.gov/vocabulary/carriers/nc',
+          defaultLiteral: 'volume',
+        }],
+        useValuesFrom: [
+          'vocabulary:bf2:frequencies',
+        ],
+        valueDataType: {
+          dataTypeURI: 'http://id.loc.gov/ontologies/bibframe/Frequency',
+        },
+      },
+    },
+  lookupConfig: [
+    {
+      label: 'carriers',
+      uri: 'https://id.loc.gov/vocabulary/carriers',
+      component: 'list',
+    },
+    {
+      label: 'frequency',
+      uri: undefined,
+      component: 'list',
+    },
+  ],
+}
 
 describe('<InputListLOC /> configuration', () => {
   // Our mock formData function to replace the one provided by mapDispatchToProps
@@ -56,17 +122,17 @@ describe('<InputListLOC /> configuration', () => {
   })
 
   it('expects a single lookupConfig object', () => {
-    shallow(<InputListLOC.WrappedComponent {...plProps} handleSelectedChange={mockFormDataFn} lookupConfig={mockLookupConfig[0]} />)
+    shallow(<InputListLOC.WrappedComponent {...propsOk} handleSelectedChange={mockFormDataFn} />)
     expect(global.alert.mock.calls.length).toEqual(0)
   })
 
   it('displays a browser alert if the lookupConfig is undefined', () => {
-    shallow(<InputListLOC.WrappedComponent {...plProps} handleSelectedChange={mockFormDataFn} lookupConfig={mockLookupConfig[1]} />)
+    shallow(<InputListLOC.WrappedComponent {...propsUndefLookupURI} handleSelectedChange={mockFormDataFn} />)
     expect(global.alert.mock.calls.length).toEqual(1)
   })
 
   it('displays a browser alert if the lookupConfig is an array of objects and not a single object', () => {
-    shallow(<InputListLOC.WrappedComponent {...plProps} handleSelectedChange={mockFormDataFn} lookupConfig={mockLookupConfig} />)
+    shallow(<InputListLOC.WrappedComponent {...propsMultLookup} handleSelectedChange={mockFormDataFn} />)
     expect(global.alert.mock.calls.length).toEqual(1)
   })
 })
@@ -74,7 +140,7 @@ describe('<InputListLOC /> configuration', () => {
 describe('<Typeahead /> component', () => {
   // Our mock formData function to replace the one provided by mapDispatchToProps
   const mockFormDataFn = jest.fn()
-  const wrapper = shallow(<InputListLOC.WrappedComponent {...plProps} handleSelectedChange={mockFormDataFn} lookupConfig={mockLookupConfig[0]} />)
+  const wrapper = shallow(<InputListLOC.WrappedComponent {...propsOk} handleSelectedChange={mockFormDataFn} />)
 
   it('contains a placeholder with the value of propertyLabel', () => {
     expect(wrapper.find(Typeahead).props().placeholder).toMatch('Frequency (RDA 2.14)')
@@ -106,52 +172,6 @@ describe('<Typeahead /> component', () => {
 
   it('sets the typeahead component placeholder attribute', () => {
     expect(wrapper.find('#targetComponent').props().placeholder).toMatch('Frequency (RDA 2.14)')
-  })
-
-  describe('default values', () => {
-    afterAll(() => {
-      jest.restoreAllMocks()
-    })
-
-    const defaults = [{
-      defaultLiteral: 'volume',
-      defaultURI: 'http://id.loc.gov/vocabulary/carriers/nc',
-    }]
-
-    it('sets the default values according to the property template if they exist', () => {
-      expect(wrapper.instance().props.propertyTemplate.valueConstraint.defaults).toEqual(defaults)
-    })
-
-    it('sets the defaults state as the defaults array', () => {
-      expect(wrapper.state('defaults').length).toEqual(1)
-    })
-
-    it('logs an error when no defaults are set', () => {
-      const plProps = {
-        propertyTemplate: {
-          propertyURI: 'http://id.loc.gov/ontologies/bflc/target',
-          propertyLabel: 'Frequency (RDA 2.14)',
-          remark: 'http://access.rdatoolkit.org/2.14.html',
-          mandatory: 'false',
-          repeatable: 'true',
-          type: 'lookup',
-          valueConstraint: {
-            valueTemplateRefs: [],
-            useValuesFrom: [
-              'vocabulary:bf2:frequencies',
-            ],
-            valueDataType: {
-              dataTypeURI: 'http://id.loc.gov/ontologies/bibframe/Frequency',
-            },
-          },
-        },
-      }
-      const infoSpy = jest.spyOn(console, 'info').mockReturnValue(null)
-      const wrapper2 = shallow(<InputListLOC.WrappedComponent {...plProps} handleSelectedChange={mockFormDataFn} />)
-
-      expect(wrapper2.state('defaults')).toEqual([])
-      expect(infoSpy).toBeCalledWith(`no defaults defined in property template: ${JSON.stringify(plProps.propertyTemplate)}`)
-    })
   })
 
   it('should call the onFocus event and set the selected option', () => {

--- a/__tests__/integration/previewRDFHelper.js
+++ b/__tests__/integration/previewRDFHelper.js
@@ -3,7 +3,7 @@
 import pupExpect from 'expect-puppeteer'
 
 export async function fillInRequredFieldsForBibframeInstance() {
-  // This assertion adds 1 to each it blocks assertion count
+  // This will add 1 assertion to each it block's assertion count
   await pupExpect(page).toClick('a', { text: 'BIBFRAME Instance' })
 
   // Click on one of the property type rows to expand a nested resource
@@ -29,6 +29,6 @@ export async function fillInRequredFieldsForBibframeInstance() {
 }
 
 export async function incompleteFieldsForBibframeInstance() {
-  // This assertion adds 1 to each it blocks assertion count
+  // This will add 1 assertion to each it block's assertion count
   await pupExpect(page).toClick('a', { text: 'BIBFRAME Instance' })
 }

--- a/src/components/editor/property/InputListLOC.jsx
+++ b/src/components/editor/property/InputListLOC.jsx
@@ -65,6 +65,10 @@ class InputListLOC extends Component {
       return null
     }
 
+    if (this.props.lookupConfig?.length > 1) {
+      alert(`There are multiple configured list lookups for ${this.props.propertyTemplate.propertyURI}`)
+    }
+
     if (this.props.lookupConfig[0]?.uri === undefined) {
       alert(`There is no configured list lookup for ${this.props.propertyTemplate.propertyURI}`)
     }

--- a/src/components/editor/property/InputLookupQA.jsx
+++ b/src/components/editor/property/InputLookupQA.jsx
@@ -14,6 +14,9 @@ import Config from 'Config'
 
 const AsyncTypeahead = asyncContainer(Typeahead)
 
+// propertyTemplate of type 'lookup' does live QA lookup via API
+//  based on values in propertyTemplate.valueConstraint.useValuesFrom
+//  and the lookupConfig for the URIs has component value of 'lookup'
 class InputLookupQA extends Component {
   constructor(props) {
     super(props)
@@ -164,7 +167,7 @@ class InputLookupQA extends Component {
   }
 
   render() {
-    // Don't render if don't have property templates yet.
+    // Don't render if no property template yet
     if (!this.props.propertyTemplate) {
       return null
     }
@@ -231,8 +234,8 @@ InputLookupQA.propTypes = {
   lookupConfig: PropTypes.arrayOf(PropTypes.object).isRequired,
 }
 
-const mapStateToProps = (state, props) => {
-  const reduxPath = props.reduxPath
+const mapStateToProps = (state, ownProps) => {
+  const reduxPath = ownProps.reduxPath
   const resourceTemplateId = reduxPath[reduxPath.length - 2]
   const propertyURI = reduxPath[reduxPath.length - 1]
   const displayValidations = getDisplayValidations(state)
@@ -240,7 +243,7 @@ const mapStateToProps = (state, props) => {
   const lookupConfig = getLookupConfigItems(propertyTemplate)
 
   return {
-    selected: itemsForProperty(state.selectorReducer, props.reduxPath),
+    selected: itemsForProperty(state.selectorReducer, ownProps.reduxPath),
     reduxPath,
     propertyTemplate,
     displayValidations,

--- a/src/components/editor/property/PropertyComponent.jsx
+++ b/src/components/editor/property/PropertyComponent.jsx
@@ -39,9 +39,7 @@ export class PropertyComponent extends Component {
                                reduxPath={reduxPath} />)
       case 'list':
         return (<InputListLOC key = {this.props.index}
-                              reduxPath={reduxPath}
-                              propertyTemplate = {propertyTemplate}
-                              lookupConfig = {this.state.configuration[0]} />)
+                              reduxPath={reduxPath} />)
       default:
         switch (propertyTemplate.type) {
           case 'literal':


### PR DESCRIPTION
Closes #604.  Note that #604 was at the top of the ready column when I started the work.

In addition to getting propertyTemplate and lookupConfig from redux, we also retrieve the propertyTemplate defaults from the selectorReducer.

Lastly, saw an opportunity to tweak some comments in 2 other spots, so I took it.  Happy to break those into separate PRs if they are controversial.