### PR TITLE
Avoid rendering into the state

### DIFF
--- a/__tests__/components/editor/property/PropertyTemplateOutline.test.js
+++ b/__tests__/components/editor/property/PropertyTemplateOutline.test.js
@@ -161,12 +161,11 @@ describe('<PropertyTemplateOutline />', () => {
       expect(wrapper.find('div PropertyTypeRow').length).toEqual(1)
       expect(wrapper.find('div PropertyComponent').length).toEqual(1)
 
-      // This tests to ensure that we are not adding an addition property row when we click to collapse the row
+      // This tests that rows are not rendered when the component is collapsed
       wrapper.setState({ collapsed: true })
-      wrapper.instance().outlineRowClass()
-      wrapper.instance().addPropertyTypeRows(propertyRtPropsLiteral.propertyTemplate)
-      expect(wrapper.find('div PropertyTypeRow').length).toEqual(1)
-      expect(wrapper.find('div PropertyComponent').length).toEqual(1)
+      wrapper.update()
+      expect(wrapper.find('div PropertyTypeRow').length).toEqual(0)
+      expect(wrapper.find('div PropertyComponent').length).toEqual(0)
     })
   })
 })

--- a/src/components/editor/property/PropertyTemplateOutline.jsx
+++ b/src/components/editor/property/PropertyTemplateOutline.jsx
@@ -65,37 +65,39 @@ export class PropertyTemplateOutline extends Component {
 
   addPropertyTypeRows = (property) => {
     const newOutput = [...this.state.propertyTypeRow]
-    let propertyJsx
+    newOutput.push(property)
+    this.setState({ propertyTypeRow: newOutput, rowAdded: true })
+  }
 
+  renderPropertyRows = () => {
     if (this.state.collapsed) {
       return
     }
-
-    if (isResourceWithValueTemplateRef(property)) {
-      const isAddDisabled = !booleanPropertyFromTemplate(property, 'repeatable', false) || newOutput.length > 0
-
-      propertyJsx = <ResourceProperty key={shortid.generate()}
-                                      propertyTemplate={property}
-                                      reduxPath={this.props.reduxPath}
-                                      nestedResourceTemplates={this.state.nestedResourceTemplates}
-                                      handleAddClick={this.handleAddClick}
-                                      addButtonDisabled={isAddDisabled} />
-    } else {
-      propertyJsx = <PropertyComponent key={shortid.generate()} propertyTemplate={property} reduxPath={this.props.reduxPath} />
-    }
-
-    newOutput.push(
+    return this.state.propertyTypeRow.map((property, index) => (
       <PropertyTypeRow
         key={shortid.generate()}
         handleAddClick={this.props.handleAddClick}
         reduxPath={this.props.reduxPath}
         addButtonDisabled={this.props.addButtonDisabled}
         propertyTemplate={property}>
-        {propertyJsx}
-      </PropertyTypeRow>,
-    )
+        { this.renderOneProperty(property, index) }
+      </PropertyTypeRow>
+    ))
+  }
 
-    this.setState({ propertyTypeRow: newOutput, rowAdded: true })
+  renderOneProperty = (property, index) => {
+    if (isResourceWithValueTemplateRef(property)) {
+      const isAddDisabled = !booleanPropertyFromTemplate(property, 'repeatable', false) || index > 0
+
+      return (<ResourceProperty key={shortid.generate()}
+                                propertyTemplate={property}
+                                reduxPath={this.props.reduxPath}
+                                nestedResourceTemplates={this.state.nestedResourceTemplates}
+                                handleAddClick={this.handleAddClick}
+                                addButtonDisabled={isAddDisabled} />)
+    }
+
+    return (<PropertyComponent key={shortid.generate()} propertyTemplate={property} reduxPath={this.props.reduxPath} />)
   }
 
   render() {
@@ -107,7 +109,7 @@ export class PropertyTemplateOutline extends Component {
                        key={shortid.generate()}
                        handleCollapsed={this.handleClick(this.props.propertyTemplate)} />
         <div className={this.outlineRowClass()}>
-          {this.state.propertyTypeRow}
+          {this.renderPropertyRows()}
         </div>
       </div>
     )


### PR DESCRIPTION
Rather, the rendering should be a projection of the state.