### PR TITLE
Remove defaults on template that has valueTemplateRefs

### DIFF
--- a/__tests__/__fixtures__/MonographInstance.json
+++ b/__tests__/__fixtures__/MonographInstance.json
@@ -133,12 +133,7 @@
       "resourceTemplates": [],
       "type": "resource",
       "valueConstraint": {
-        "defaults": [
-          {
-            "defaultLiteral": "DEFAULT",
-            "defaultURI": "http://default"
-          }
-        ],
+        "defaults": [],
         "editable": "true",
         "remark": "REMARK",
         "repeatable": "false",


### PR DESCRIPTION
It doesn't make sense to have both properties set for a template