### PR TITLE
InputListLOC: changes redux state once again

### DIFF
--- a/src/components/editor/property/InputListLOC.jsx
+++ b/src/components/editor/property/InputListLOC.jsx
@@ -22,14 +22,9 @@ class InputListLOC extends Component {
   }
 
   componentDidMount() {
-    this._isMounted = true
     if (this.props.defaults?.length > 0) {
       this.selectionChanged(this.props.defaults)
     }
-  }
-
-  componentWillUnmount() {
-    this._isMounted = false
   }
 
   selectionChanged(items) {
@@ -169,9 +164,7 @@ const mapStateToProps = (state, ownProps) => {
 
 const mapDispatchToProps = dispatch => ({
   handleSelectedChange(selected) {
-    if (this._isMounted) {
-      dispatch(changeSelections(selected))
-    }
+    dispatch(changeSelections(selected))
   },
 })
 


### PR DESCRIPTION
connects to #772:   InputListLOC wasn't updating redux state.

This fixes the bug, but it has no tests:
- waiting for #832:  tests should not depend on network services -- this code is intimately tied to QA lookups.
- I couldn't figure out how to test this with a unit test - how to test that redux gets the right information when the component's actions, intertwined with Typeahead component, get user input.  I would be eager to see a PR or a pairing session that can show how to do this as a unit test -- it would be great to get it in my own wheelhouse.
- I've been getting pushback on the notion of integration tests ... so 🤷‍♀ .  why should I concern myself with writing tests that half of us never write, or don't find useful?

@jcoyne @jermnelson:  Note that this is very nearly an undo of c1dd019d99.  We do not have a safety net, and we are seemingly comfortable doing a lot of refactoring and breaking, and then subsequently spending developer time debugging stuff only to discover the code was correct before and we had no test to catch when a change broke it.

I don't consider #772 done without a test, but I don't know how to approach a test, either.  And I'm out of time and heading off on vacation.  

