### PR TITLE
simplify findNode conditional logic

### DIFF
--- a/src/selectors/resourceSelectors.js
+++ b/src/selectors/resourceSelectors.js
@@ -4,7 +4,7 @@ export const rootResource = state => Object.values(state.selectorReducer.resourc
 export const rootResourceId = state => rootResource(state)?.resourceURI
 
 export const findNode = (selectorReducer, reduxPath) => {
-  const items = reduxPath.reduce((obj, key) => (obj && obj[key] !== 'undefined' ? obj[key] : undefined), selectorReducer)
+  const items = reduxPath.reduce((obj, key) => obj?.[key], selectorReducer)
 
   return items || {}
 }


### PR DESCRIPTION
the current intent seems to be safe access to `obj`, and return of `undefined` if `obj[key]` is undefined.  it seems like the logic replaced by this commit does that, albeit likely in an unintended way (if `obj[key]` was undefined, it'd have been returned, but by the if branch of the replaced ternary operation instead of the else branch)..