### PR TITLE
NewsItem: get the version number from package.json

### DIFF
--- a/__tests__/components/home/NewsItem.test.js
+++ b/__tests__/components/home/NewsItem.test.js
@@ -3,6 +3,7 @@
 import React from 'react'
 import { shallow } from 'enzyme'
 import NewsItem from 'components/home/NewsItem'
+import { version } from '../../../package.json'
 
 describe('<NewsItem />', () => {
   const wrapper = shallow(<NewsItem />)
@@ -15,5 +16,15 @@ describe('<NewsItem />', () => {
     wrapper.find('a[target="_blank"]').forEach((node) => {
       expect(node.prop('rel')).toEqual('noopener noreferrer')
     })
+  })
+
+  it('renders the currently released version', () => {
+    /*
+      not a concern here, since the input is ours:
+      "Detects RegExp(variable), which might allow an attacker to DOS your server with a long-running regular expression"
+      - https://github.com/nodesecurity/eslint-plugin-security#detect-non-literal-regexp
+     */
+    // eslint-disable-next-line security/detect-non-literal-regexp
+    expect(wrapper.text()).toMatch(new RegExp(`Release ${version} is live`))
   })
 })

--- a/src/components/home/NewsItem.jsx
+++ b/src/components/home/NewsItem.jsx
@@ -1,12 +1,13 @@
 // Copyright 2019 Stanford University see LICENSE for license
 
 import React from 'react'
+import { version } from '../../../package.json'
 
 const NewsItem = () => (
   <div className="news-item">
     <h1> What&#8217;s New </h1>
     <ul>
-      <li>Release 0.3.3 is live, including these features</li>
+      <li>Release {version} is live, including these features</li>
       <ul>
         <li>User login.
         </li>


### PR DESCRIPTION
so presentation on home page is always up to date, instead of hardcoding it independently

(noticed this when reviewing https://github.com/LD4P/sinopia_editor/pull/892/files#diff-5083dfea3973f64f536edf318a38b904R9, had it in my notes as a small todo)