### PR TITLE
Fix docker-compose: move build args into env vars

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,9 +3,10 @@ services:
   editor:
     build:
       context: .
-      args:
+    environment:
         USE_FIXTURES: 'false'
-        TRELLIS_BASE_URL: http://localhost:8080
+        TRELLIS_BASE_URL: http://platform:8080
+        INDEX_URL: http://search:9200/
     ports:
       - 8000:8000
     depends_on:


### PR DESCRIPTION
This fixes the link between the editor and trellis and elasticsearch when using dockder compose.

If the build args are necessary, I can add those back in, but without ENV vars on the editor block I was unable to make much use of docker-compose.

Not this is necessary for #442 development