### PR TITLE
Revert #924 - add index_url to build args

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,10 +3,10 @@ services:
   editor:
     build:
       context: .
-    environment:
+      args:
         USE_FIXTURES: 'false'
         TRELLIS_BASE_URL: http://platform:8080
-        INDEX_URL: http://search:9200/
+        INDEX_URL: http://search:9200
     ports:
       - 8000:8000
     depends_on:


### PR DESCRIPTION
The prior change was a result of a mismatch in what I had running in docker. the INDEX_URL needs to be a build argument as the editors env vars are not available at runtime (per @mjgiarlo)