### PR TITLE
Remove tests for PropertyRemark

### DIFF
--- a/__tests__/components/editor/ResourceTemplateForm.test.js
+++ b/__tests__/components/editor/ResourceTemplateForm.test.js
@@ -204,12 +204,4 @@ describe('<ResourceTemplateForm /> after fetching data from sinopia server', () 
     expect(rtProps.propertyTemplates[1].repeatable).toBe('do not override me!')
     expect(rtProps.propertyTemplates[1].editable).toBe('do not override me!')
   })
-
-  it('displays a PropertyRemark when a remark is present', () => {
-    wrapper.instance().props.propertyTemplates[2].remark = 'https://www.youtube.com/watch?v=jWkMhCLkVOg'
-    wrapper.instance().forceUpdate()
-    const propertyRemark = wrapper.find('label > PropertyRemark')
-
-    expect(propertyRemark).toBeTruthy()
-  })
 })

--- a/__tests__/components/editor/property/InputLiteral.test.js
+++ b/__tests__/components/editor/property/InputLiteral.test.js
@@ -55,14 +55,6 @@ describe('<InputLiteral />', () => {
     wrapper.instance().forceUpdate()
     expect(wrapper.find('input').prop('required')).toBeFalsy()
   })
-
-  it('label contains a PropertyRemark when a remark is added', () => {
-    wrapper.instance().props.propertyTemplate.remark = 'http://rda.test.org/1.1'
-    wrapper.instance().forceUpdate()
-    const propertyRemark = wrapper.find('label > PropertyRemark')
-
-    expect(propertyRemark).toBeTruthy()
-  })
 })
 
 describe('checkMandatoryRepeatable', () => {

--- a/__tests__/components/editor/property/InputLookupQA.test.js
+++ b/__tests__/components/editor/property/InputLookupQA.test.js
@@ -141,14 +141,6 @@ describe('<InputLookupQA />', () => {
     expect(mockFormDataFn.mock.calls.length).toBe(2)
   })
 
-  it('has a PropertyRemark when a remark is present', () => {
-    wrapper.instance().props.propertyTemplate.remark = 'http://rda.test.org/1.1'
-    wrapper.instance().forceUpdate()
-    const propertyRemark = wrapper.find('label > PropertyRemark')
-
-    expect(propertyRemark).toBeTruthy()
-  })
-
   // Institute wrapper with multiple lookup options
   const multipleWrapper = shallow(<InputLookupQA.WrappedComponent {...p2Props} handleSelectedChange={mockFormDataFn} />)
 

--- a/__tests__/components/editor/property/InputURI.test.js
+++ b/__tests__/components/editor/property/InputURI.test.js
@@ -44,14 +44,6 @@ describe('<InputURI />', () => {
     wrapper.setProps({ ...plProps, ...propertyTemplate })
     expect(wrapper.find('input').prop('required')).toBeFalsy()
   })
-
-  it('label contains a PropertyRemark when a remark is added', () => {
-    const propertyTemplate = { propertyTemplate: { ...plProps.propertyTemplate, remark: 'http://rda.test.org/1.1' } }
-    wrapper.setProps({ ...plProps, ...propertyTemplate })
-    const propertyRemark = wrapper.find('label > PropertyRemark')
-
-    expect(propertyRemark).toBeTruthy()
-  })
 })
 
 describe('When the user enters input into field', () => {


### PR DESCRIPTION
There is no PropertyRemark element.  These tests were only passing because the find returns an empty object, which is a truthy value