### PR TITLE
Fix bad tests

### DIFF
--- a/__tests__/components/editor/property/InputListLOC.test.js
+++ b/__tests__/components/editor/property/InputListLOC.test.js
@@ -154,10 +154,13 @@ describe('<Typeahead /> component', () => {
     expect(wrapper.find('#targetComponent').props().required).toBe(false)
   })
 
-  it('displays RequiredSuperscript if mandatory from template is true', () => {
-    wrapper.instance().props.propertyTemplate.mandatory = 'true'
-    wrapper.instance().forceUpdate()
-    expect(wrapper.find('label > RequiredSuperscript')).toBeTruthy()
+  describe('when mandatory is true', () => {
+    const template = { ...propsOk.propertyTemplate, mandatory: 'true' }
+    const wrapper2 = shallow(<InputListLOC.WrappedComponent {...propsOk} propertyTemplate={template} />)
+
+    it('passes the "required" property to Typeahead', () => {
+      expect(wrapper2.find('#targetComponent').props().required).toBeTruthy()
+    })
   })
 
   it('displays a text label if remark from template is absent', () => {

--- a/__tests__/components/editor/property/InputLiteral.test.js
+++ b/__tests__/components/editor/property/InputLiteral.test.js
@@ -1,3 +1,4 @@
+
 // Copyright 2018, 2019 Stanford University see LICENSE for license
 import 'jsdom-global/register'
 import React from 'react'

--- a/__tests__/components/editor/property/InputLookupQA.test.js
+++ b/__tests__/components/editor/property/InputLookupQA.test.js
@@ -107,9 +107,13 @@ describe('<InputLookupQA />', () => {
     expect(wrapper.find('#lookupComponent').props().required).toBeFalsy()
   })
 
-  it('displays RequiredSuperscript if mandatory from template is true', () => {
-    wrapper.instance().props.propertyTemplate.mandatory = 'true'
-    expect(wrapper.find('label > RequiredSuperscript')).toBeTruthy()
+  describe('when mandatory is true', () => {
+    const template = { ...plProps.propertyTemplate, mandatory: 'true' }
+    const wrapper2 = shallow(<InputLookupQA.WrappedComponent {...plProps} propertyTemplate={template} />)
+
+    it('passes the "required" property to Typeahead', () => {
+      expect(wrapper2.find('#lookupComponent').props().required).toBeTruthy()
+    })
   })
 
   it('sets the typeahead component multiple attribute according to the repeatable property from the template', () => {

--- a/__tests__/components/editor/property/InputURI.test.js
+++ b/__tests__/components/editor/property/InputURI.test.js
@@ -36,7 +36,6 @@ describe('<InputURI />', () => {
     const formData = { formData: { errors: [{ id: 'Required' }] } }
     wrapper.setProps({ ...plProps, ...propertyTemplate, ...formData })
     expect(wrapper.find('input').prop('required')).toBeTruthy()
-    expect(wrapper.find('label > RequiredSuperscript')).toBeTruthy()
   })
 
   it('contains required="false" attribute on input tag when mandatory is false', () => {


### PR DESCRIPTION
The find statement always returns an object, which is always truthy.  In fact, since these are shallow renders, it's useless to look for a grandchild component