### PR TITLE
Add tls and net to the webpack node config so that request can be used

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -35,6 +35,8 @@ module.exports = {
   },
   node: {
     fs: 'empty',
+    net: 'empty',
+    tls: 'empty',
   },
   resolve: {
     extensions: ['*', '.js', '.jsx'],


### PR DESCRIPTION
This is something I ran into while working on search and may be an issue elsewhere so pulling into a separate PR.