### PR TITLE
Provide a sensible default for Config.searchHost

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM circleci/node:12.6
 
-# Allow build-time arguments (for, e.g., docker-compose)
+# Allow build-time arguments (for, environment variables that need to be encoded into the webpack distribution)
 ARG USE_FIXTURES
 ARG TRELLIS_BASE_URL
 ARG DEFAULT_PROFILE_SCHEMA_VERSION

--- a/src/Config.js
+++ b/src/Config.js
@@ -45,12 +45,14 @@ class Config {
   }
 
   /*
-   * This is the host for the public endpont for the sinopia search.  This is different than
-   * the indexURL because it's the path to the proxy, not directly to elasticsearch.
-   * We can't use '/' here because in development search might be on a different port.
+   * The host for the public endpoint for the Sinopia search.  This is different than
+   * the indexURL because it's the path to the public proxy endpoint, not directly to elasticsearch.
+   * In development we may want to set this to `//localhost:8000`, but when deployed typically
+   * the default (empty string) will work as the search is proxied through the same server
+   * that hosts the client javascript.
    */
   static get searchHost() {
-    return process.env.SEARCH_HOST || 'http://localhost:8000'
+    return process.env.SEARCH_HOST || ''
   }
 
   /*


### PR DESCRIPTION
This default should work in production, and when developing locally one could set SEARCH_HOST

Fixes #1001 