### PR TITLE
Clarify link to regular github issues in the issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE.md
@@ -1,0 +1,7 @@
+---
+name: Regular Issue
+about: The regular github issue form
+labels: ''
+assignees: ''
+
+---


### PR DESCRIPTION
Not entirely sure if this is helpful, but trying to make the "regular issue" link a little more obvious.