### PR TITLE
Get rid of items in redux state

### DIFF
--- a/__tests__/GraphBuilder.test.js
+++ b/__tests__/GraphBuilder.test.js
@@ -23,53 +23,40 @@ describe('GraphBuilder', () => {
           'http://id.loc.gov/ontologies/bibframe/temporalCoverage': {},
           'http://id.loc.gov/ontologies/bibframe/note': {},
           'http://id.loc.gov/ontologies/bibframe/content': {
-            items: [
-              {
-                id: 'http://id.loc.gov/vocabulary/contentTypes/txt',
-                label: 'text',
-                uri: 'http://id.loc.gov/vocabulary/contentTypes/txt',
-              },
-            ],
+            abc123: {
+              label: 'text',
+              uri: 'http://id.loc.gov/vocabulary/contentTypes/txt',
+            },
           },
           'http://id.loc.gov/ontologies/bibframe/illustrativeContent': {
-            items: [
-              {
-                id: '2_RmnVrDkk9',
-                label: 'Genealogical tables',
-                uri: 'http://id.loc.gov/vocabulary/millus/gnt',
-              },
-            ],
+            '2_RmnVrDkk9': {
+              label: 'Genealogical tables',
+              uri: 'http://id.loc.gov/vocabulary/millus/gnt',
+            },
           },
           'http://id.loc.gov/ontologies/bibframe/colorContent': {
             '-KACHlqQ4A': {
               'resourceTemplate:bf2:Note': {
                 'http://www.w3.org/2000/01/rdf-schema#label': {
-                  items: [
-                    {
-                      content: 'Very colorful',
-                      id: '3TzRpgv65',
-                      lang: {
-                        id: 'en',
-                        label: 'English',
-                      },
+                  '3TzRpgv65': {
+                    content: 'Very colorful',
+                    lang: {
+                      id: 'en',
+                      label: 'English',
                     },
-                    {
-                      content: 'Sparkly',
-                      id: '5TzRpgv72',
-                    },
-                  ],
+                  },
+                  '5TzRpgv72': {
+                    content: 'Sparkly',
+                  },
                 },
               },
             },
             gdndfCHlqQ4z: {
               'resourceTemplate:bf2:Note': {
                 'http://www.w3.org/2000/01/rdf-schema#label': {
-                  items: [
-                    {
-                      content: 'Shiney',
-                      id: '4dzRpgv42',
-                    },
-                  ],
+                  '4dzRpgv42': {
+                    content: 'Shiney',
+                  },
                 },
               },
             },
@@ -136,37 +123,27 @@ describe('GraphBuilder', () => {
           'http://id.loc.gov/ontologies/bibframe/temporalCoverage': {},
           'http://id.loc.gov/ontologies/bibframe/note': {},
           'http://id.loc.gov/ontologies/bibframe/content': {
-            items: [
-              {
-                id: 'http://id.loc.gov/vocabulary/contentTypes/txt',
-                label: 'text',
-                uri: 'http://id.loc.gov/vocabulary/contentTypes/txt',
-              },
-            ],
+            abc123: {
+              label: 'text',
+              uri: 'http://id.loc.gov/vocabulary/contentTypes/txt',
+            },
           },
           'http://id.loc.gov/ontologies/bibframe/illustrativeContent': {
-            items: [
-              {
-                id: '2_RmnVrDkk9',
-                label: 'Genealogical tables',
-                uri: 'http://id.loc.gov/vocabulary/millus/gnt',
-              },
-            ],
+            '2_RmnVrDkk9': {
+              label: 'Genealogical tables',
+              uri: 'http://id.loc.gov/vocabulary/millus/gnt',
+            },
           },
           'http://id.loc.gov/ontologies/bibframe/colorContent': {
             '-KACHlqQ4A': {
               'resourceTemplate:bf2:Note': {
                 'http://www.w3.org/2000/01/rdf-schema#label': {
-                  items: [
-                    {
-                      content: 'Very colorful',
-                      id: '3TzRpgv65',
-                    },
-                    {
-                      content: 'Sparkly',
-                      id: '3TzRpgv65',
-                    },
-                  ],
+                  '3TzRpgv65': {
+                    content: 'Very colorful',
+                  },
+                  zvwwe8321: {
+                    content: 'Sparkly',
+                  },
                 },
               },
             },
@@ -273,9 +250,7 @@ describe('GraphBuilder', () => {
           'http://id.loc.gov/ontologies/bibframe/colorContent': {
             '-KACHlqQ4A': {
               'resourceTemplate:bf2:Note': {
-                'http://www.w3.org/2000/01/rdf-schema#label': {
-                  items: [],
-                },
+                'http://www.w3.org/2000/01/rdf-schema#label': {},
               },
             },
           },
@@ -286,7 +261,6 @@ describe('GraphBuilder', () => {
     }
 
     const builder = new GraphBuilder(state)
-
 
     it('returns the graph without blank node', () => {
       const graph = builder.graph

--- a/__tests__/ResourceStateBuilder.test.js
+++ b/__tests__/ResourceStateBuilder.test.js
@@ -13,37 +13,33 @@ describe('ResourceStateBuilder', () => {
 
     const dataset = await rdfDatasetFromN3(resource)
 
-    shortid.generate = jest.fn().mockReturnValue('abc123')
+    shortid.generate = jest.fn().mockReturnValueOnce('abc123').mockReturnValueOnce('def456').mockReturnValueOnce('ghi789')
 
     const builder = new ResourceStateBuilder(dataset, 'http://example/123')
     const resourceState = builder.state
     expect(resourceState).toEqual({
       'resourceTemplate:bf2:Note': {
         'http://www.w3.org/2000/01/rdf-schema#label': {
-          items: [
-            {
-              id: 'abc123',
-              content: 'foo',
-              lang: {
-                items: [
-                  {
-                    id: 'en',
-                  },
-                ],
-              },
+          abc123: {
+            content: 'foo',
+            lang: {
+              items: [
+                {
+                  id: 'en',
+                },
+              ],
             },
-            {
-              id: 'abc123',
-              content: 'bar',
-              lang: {
-                items: [
-                  {
-                    id: 'en',
-                  },
-                ],
-              },
+          },
+          def456: {
+            content: 'bar',
+            lang: {
+              items: [
+                {
+                  id: 'en',
+                },
+              ],
             },
-          ],
+          },
         },
       },
     })
@@ -56,7 +52,7 @@ describe('ResourceStateBuilder', () => {
 
     const dataset = await rdfDatasetFromN3(resource)
 
-    shortid.generate = jest.fn().mockReturnValue('abc123')
+    shortid.generate = jest.fn().mockReturnValueOnce('abc123').mockReturnValueOnce('def456').mockReturnValueOnce('ghi789')
 
     const builder = new ResourceStateBuilder(dataset, 'http://example/123')
     const resourceState = builder.state
@@ -64,12 +60,9 @@ describe('ResourceStateBuilder', () => {
     expect(resourceState).toEqual({
       'resourceTemplate:bf2:Note': {
         'http://rdaregistry.info/Elements/i/P40021': {
-          items: [
-            {
-              id: 'abc123',
-              uri: 'http://id.loc.gov/vocabulary/organizations/wauar',
-            },
-          ],
+          abc123: {
+            uri: 'http://id.loc.gov/vocabulary/organizations/wauar',
+          },
         },
       },
     })
@@ -85,7 +78,7 @@ describe('ResourceStateBuilder', () => {
 
     const dataset = await rdfDatasetFromN3(resource)
 
-    shortid.generate = jest.fn().mockReturnValue('abc123')
+    shortid.generate = jest.fn().mockReturnValueOnce('abc123').mockReturnValueOnce('def456')
 
     const builder = new ResourceStateBuilder(dataset, 'http://example/123')
     const resourceState = builder.state
@@ -96,19 +89,16 @@ describe('ResourceStateBuilder', () => {
           abc123: {
             'resourceTemplate:bf2:Note': {
               'http://www.w3.org/2000/01/rdf-schema#label': {
-                items: [
-                  {
-                    id: 'abc123',
-                    content: 'foobar',
-                    lang: {
-                      items: [
-                        {
-                          id: 'en',
-                        },
-                      ],
-                    },
+                def456: {
+                  content: 'foobar',
+                  lang: {
+                    items: [
+                      {
+                        id: 'en',
+                      },
+                    ],
                   },
-                ],
+                },
               },
             },
           },
@@ -129,7 +119,7 @@ _:B01cf1817X2Dd2e4X2D485bX2Dbd9aX2Df72c02976ec02895d12a7118e91a94f5a4808a49140a 
 
   const dataset = await rdfDatasetFromN3(resource)
 
-  shortid.generate = jest.fn().mockReturnValue('abc123')
+  shortid.generate = jest.fn().mockReturnValueOnce('abc123').mockReturnValueOnce('def456').mockReturnValueOnce('ghi789')
 
   const builder = new ResourceStateBuilder(dataset, null)
   const resourceState = builder.state
@@ -142,37 +132,31 @@ _:B01cf1817X2Dd2e4X2D485bX2Dbd9aX2Df72c02976ec02895d12a7118e91a94f5a4808a49140a 
         abc123: {
           'sinopia:resourceTemplate:bf2:Identifiers:Note': {
             'http://www.w3.org/2000/01/rdf-schema#label': {
-              items: [
-                {
-                  id: 'abc123',
-                  content: 'foo note',
-                  lang: {
-                    items: [
-                      {
-                        id: 'en',
-                      },
-                    ],
-                  },
+              def456: {
+                content: 'foo note',
+                lang: {
+                  items: [
+                    {
+                      id: 'en',
+                    },
+                  ],
                 },
-              ],
+              },
             },
           },
         },
       },
       'http://www.w3.org/1999/02/22-rdf-syntax-ns#value': {
-        items: [
-          {
-            id: 'abc123',
-            content: 'foo',
-            lang: {
-              items: [
-                {
-                  id: 'en',
-                },
-              ],
-            },
+        ghi789: {
+          content: 'foo',
+          lang: {
+            items: [
+              {
+                id: 'en',
+              },
+            ],
           },
-        ],
+        },
       },
     },
   })

--- a/__tests__/reducers/inputs.test.js
+++ b/__tests__/reducers/inputs.test.js
@@ -98,7 +98,7 @@ describe('setItemsOrSelections with action type: ITEMS_SELECTED', () => {
   it('adds item to state', () => {
     initialState.resource = {
       'resourceTemplate:Monograph:Instance': {
-        'http://schema.org/name': { items: [] },
+        'http://schema.org/name': {},
       },
     }
 
@@ -109,12 +109,12 @@ describe('setItemsOrSelections with action type: ITEMS_SELECTED', () => {
         rtId: 'resourceTemplate:Monograph:Instance',
         uri: 'http://schema.org/name',
         reduxPath,
-        items: [{ id: 0, content: 'Run the tests' }],
+        abc1233: { content: 'Run the tests' },
       },
     })
 
     expect(findNode(result, reduxPath)).toEqual({
-      items: [{ id: 0, content: 'Run the tests' }],
+      abc1233: { content: 'Run the tests' },
     })
   })
 
@@ -127,12 +127,12 @@ describe('setItemsOrSelections with action type: ITEMS_SELECTED', () => {
           rtId: 'resourceTemplate:Monograph:Instance',
           uri: 'http://schema.org/name',
           reduxPath,
-          items: [{ id: 0, content: 'Run the tests' }],
+          abc1233: { content: 'Run the tests' },
         },
       })
 
     expect(findNode(result, reduxPath)).toEqual({
-      items: [{ id: 0, content: 'Run the tests' }],
+      abc1233: { content: 'Run the tests' },
     })
   })
 
@@ -149,12 +149,16 @@ describe('setItemsOrSelections with action type: ITEMS_SELECTED', () => {
           rtId: 'resourceTemplate:Monograph:Instance',
           uri: 'http://schema.org/description',
           reduxPath,
-          items: [{ id: 2, content: 'add this!' }],
+          items: {
+            abc123: { content: 'add this!' },
+          },
         },
       })
 
     expect(findNode(result, reduxPath)).toEqual({
-      items: [{ id: 2, content: 'add this!' }],
+      abc123: {
+        content: 'add this!',
+      },
     })
   })
 
@@ -181,12 +185,14 @@ describe('setItemsOrSelections with action type: ITEMS_SELECTED', () => {
           rtId: 'resourceTemplate:Monograph:Instance',
           uri: 'http://id.loc.gov/ontologies/bibframe/mainTitle',
           reduxPath,
-          items: [{ id: 'ghwixOwWI', content: 'Melissa' }],
+          items: {
+            ghwixOwWI: { content: 'Melissa' },
+          },
         },
       })
 
     expect(findNode(result, reduxPath)).toEqual({
-      items: [{ id: 'ghwixOwWI', content: 'Melissa' }],
+      ghwixOwWI: { content: 'Melissa' },
     })
   })
 
@@ -194,12 +200,11 @@ describe('setItemsOrSelections with action type: ITEMS_SELECTED', () => {
     initialState.resource = {
       'resourceTemplate:Monograph:Instance': {
         'http://schema.org/name': {
-          items: [{ id: 1, content: 'Run the tests' }],
-          reduxPath: ['resourceTemplate:Monograph:Instance', 'http://schema.org/name'],
+          abc123: { content: 'Run the tests' },
+          def234: { content: 'Keep this' },
         },
         'http://schema.org/description': {
-          items: [],
-          reduxPath: ['resourceTemplate:Monograph:Instance', 'http://schema.org/description'],
+          ghi567: { content: 'Keep this' },
         },
       },
     }
@@ -212,18 +217,22 @@ describe('setItemsOrSelections with action type: ITEMS_SELECTED', () => {
           rtId: 'resourceTemplate:Monograph:Instance',
           uri: 'http://schema.org/description',
           reduxPath,
-          items: [{ id: 2, content: 'add this!' }],
+          items: {
+            cde987: {
+              content: 'add this!',
+            },
+          },
         },
       })
 
     expect(findNode(result, reduxPath)).toEqual({
-      items: [{ id: 2, content: 'add this!' }],
-      reduxPath: ['resourceTemplate:Monograph:Instance', 'http://schema.org/description'],
+      cde987: { content: 'add this!' },
+      ghi567: { content: 'Keep this' },
     })
 
     expect(findNode(result, ['resource', 'resourceTemplate:Monograph:Instance', 'http://schema.org/name'])).toEqual({
-      items: [{ id: 1, content: 'Run the tests' }],
-      reduxPath: ['resourceTemplate:Monograph:Instance', 'http://schema.org/name'],
+      abc123: { content: 'Run the tests' },
+      def234: { content: 'Keep this' },
     })
   })
 })
@@ -243,19 +252,23 @@ describe('setItemsOrSelections with action type: CHANGE_SELECTIONS', () => {
         id: 'abc123',
         uri: 'http://schema.org/name',
         reduxPath,
-        items: [{ id: 0, label: 'Run the tests', uri: 'http://schema.org/abc' }],
+        items: {
+          'def123': { label: 'Run the tests', uri: 'http://schema.org/abc' }
+        },
       },
     })
 
     expect(findNode(result, reduxPath)).toEqual({
-      items: [{ id: 0, label: 'Run the tests', uri: 'http://schema.org/abc' }],
+      def123: {label: 'Run the tests', uri: 'http://schema.org/abc' },
     })
   })
 
   it('overwrites items in  current state', () => {
     initialState.resource = {
       'resourceTemplate:Monograph:Instance': {
-        'http://schema.org/name': { items: [{ id: 0, label: 'Run the tests', uri: 'http://schema.org/abc' }] },
+        'http://schema.org/name': {
+          cde678: { label: 'Run the tests', uri: 'http://schema.org/abc' }
+        },
       },
     }
 
@@ -266,18 +279,16 @@ describe('setItemsOrSelections with action type: CHANGE_SELECTIONS', () => {
         id: 'def456',
         uri: 'http://schema.org/name',
         reduxPath,
-        items: [
-          { id: 0, label: 'Run the tests', uri: 'http://schema.org/abc' },
-          { id: 1, label: 'See if they pass', uri: 'http://schema.org/def' },
-        ],
+        items: {
+          cde678: { label: 'Run the tests', uri: 'http://schema.org/abc' },
+          fgh999: { label: 'See if they pass', uri: 'http://schema.org/def' },
+        },
       },
     })
 
     expect(findNode(result, reduxPath)).toEqual({
-      items: [
-        { id: 0, label: 'Run the tests', uri: 'http://schema.org/abc' },
-        { id: 1, label: 'See if they pass', uri: 'http://schema.org/def' },
-      ],
+      cde678: { label: 'Run the tests', uri: 'http://schema.org/abc' },
+      fgh999: { label: 'See if they pass', uri: 'http://schema.org/def' },
     })
   })
 
@@ -285,10 +296,8 @@ describe('setItemsOrSelections with action type: CHANGE_SELECTIONS', () => {
     initialState.resource = {
       'resourceTemplate:Monograph:Instance': {
         'http://schema.org/name': {
-          items: [
-            { id: 0, label: 'Run the tests', uri: 'http://schema.org/abc' },
-            { id: 1, label: 'See if they pass', uri: 'http://schema.org/def' },
-          ],
+          abc123: { label: 'Run the tests', uri: 'http://schema.org/abc' },
+          def456: { label: 'See if they pass', uri: 'http://schema.org/def' },
         },
       },
     }
@@ -300,11 +309,11 @@ describe('setItemsOrSelections with action type: CHANGE_SELECTIONS', () => {
         id: 'nomatter',
         uri: 'http://not.important',
         reduxPath,
-        items: [],
+        items: {},
       },
     })
 
-    expect(findNode(result, reduxPath)).toEqual({ items: [] })
+    expect(findNode(result, reduxPath)).toEqual({})
   })
 
   it('adds an empty object for a key if the key does not contain an object by default', () => {
@@ -319,12 +328,17 @@ describe('setItemsOrSelections with action type: CHANGE_SELECTIONS', () => {
       type: 'CHANGE_SELECTIONS',
       payload: {
         uri: 'http://not.important/now',
-        items: [{ id: 'http://lookup.source/1', label: 'Something looked up', uri: 'http://lookup.source/1' }],
+        items: {
+          abc123: {
+            label: 'Something looked up',
+            uri: 'http://lookup.source/1',
+          },
+        },
         reduxPath,
       },
     })
 
-    expect(findNode(result, reduxPath)).toEqual({ items: [{ id: 'http://lookup.source/1', label: 'Something looked up', uri: 'http://lookup.source/1' }] })
+    expect(findNode(result, reduxPath)).toEqual({ abc123: { label: 'Something looked up', uri: 'http://lookup.source/1' } })
   })
 })
 
@@ -333,7 +347,11 @@ describe('setBaseURL', () => {
     initialState.resource = {
       'resourceTemplate:Monograph:Instance': {
         'http://schema.org/name': {
-          items: [{ id: 1, content: 'more content' }],
+          items: {
+            abc123: {
+              content: 'more content',
+            },
+          },
         },
       },
     }
@@ -370,10 +388,8 @@ describe('removeMyItem', () => {
     initialState.resource = {
       'resourceTemplate:Monograph:Instance': {
         'http://schema.org/name': {
-          items: [
-            { content: 'test content', id: 0 },
-            { content: 'more content', id: 1 },
-          ],
+          abc123: { content: 'test content' },
+          def456: { content: 'more content' },
         },
       },
     }
@@ -382,7 +398,7 @@ describe('removeMyItem', () => {
       {
         type: 'REMOVE_ITEM',
         payload: {
-          id: 0,
+          id: 'abc123',
           rtId: 'resourceTemplate:Monograph:Instance',
           reduxPath,
           uri: 'http://schema.org/name',
@@ -391,7 +407,7 @@ describe('removeMyItem', () => {
       })
 
     expect(findNode(result, reduxPath)).toEqual({
-      items: [{ id: 1, content: 'more content' }],
+      def456: { content: 'more content' },
     })
   })
 
@@ -399,10 +415,8 @@ describe('removeMyItem', () => {
     initialState.resource = {
       'resourceTemplate:Monograph:Instance': {
         'http://schema.org/name': {
-          items: [
-            { content: 'Test', id: 1 },
-            { content: 'Statement', id: 2 },
-          ],
+          abc123: { content: 'Test' },
+          def456: { content: 'Statement' },
         },
       },
     }
@@ -419,10 +433,8 @@ describe('removeMyItem', () => {
       })
 
     expect(findNode(result, reduxPath)).toEqual({
-      items: [
-        { content: 'Test', id: 1 },
-        { content: 'Statement', id: 2 },
-      ],
+      abc123: { content: 'Test' },
+      def456: { content: 'Statement' },
     })
   })
 })

--- a/src/ResourceStateBuilder.js
+++ b/src/ResourceStateBuilder.js
@@ -54,11 +54,10 @@ export default class ResourceStateBuilder {
         thisResourceState[rtId][propertyURI][shortid.generate()] = this.buildResource(quad.object)
       } else {
         if (!_.has(thisResourceState[rtId], propertyURI)) {
-          thisResourceState[rtId][propertyURI] = { items: [] }
+          thisResourceState[rtId][propertyURI] = {}
         }
         const item = this.buildItem(quad)
-
-        thisResourceState[rtId][propertyURI].items.push(item)
+        thisResourceState[rtId][propertyURI][shortid.generate()] = item
       }
     })
     return thisResourceState
@@ -92,7 +91,7 @@ export default class ResourceStateBuilder {
    * @return {Object} item state structure
    */
   buildItem(quad) {
-    const item = { id: shortid.generate() }
+    const item = { }
     if (quad.object.termType === 'NamedNode') {
       item.uri = quad.object.value
     } else {

--- a/src/components/editor/property/InputLiteral.jsx
+++ b/src/components/editor/property/InputLiteral.jsx
@@ -36,26 +36,25 @@ export class InputLiteral extends Component {
     this.setState({ content_add: userInput })
   }
 
-  addUserInput = (userInputArray, currentcontent) => {
-    userInputArray.push({
+  addUserInput = (input, currentcontent) => {
+    input[shortid.generate()] = {
       content: currentcontent,
-      id: shortid.generate(),
       lang: defaultLangTemplate(),
     })
   }
 
   handleKeypress = (event) => {
     if (event.key === 'Enter') {
-      const userInputArray = []
+      const userInput = {}
       const currentcontent = this.state.content_add.trim()
 
       if (!currentcontent) {
         return
       }
-      this.addUserInput(userInputArray, currentcontent)
-      const userInput = {
+      this.addUserInput(userInput, currentcontent)
+      const payload = {
         reduxPath: this.props.reduxPath,
-        items: userInputArray,
+        items: userInput,
       }
 
       this.props.handleMyItemsChange(userInput)

--- a/src/reducers/inputs.js
+++ b/src/reducers/inputs.js
@@ -71,21 +71,22 @@ export const setItemsOrSelections = (state, action) => {
       /* there is an empty object at the end of the reduxPath,
        * so make an object with items to be filled in by the actions below
        */
-      if ((key in obj) !== true || !Object.keys(obj[key]).includes('items')) {
-        obj[key] = { items: [] }
+      if ((key in obj) !== true) {
+        obj[key] = {}
       }
 
       if (action.type === 'ITEMS_SELECTED') {
+        console.log('foo',  action.payload)
         // here we are setting the items for repeatable user input, so push back each input item
-        action.payload.items.map((row) => {
-          obj[key].items.push(row)
+        Object.keys(action.payload.items).forEach((rowId) => {
+          obj[key][rowId] = action.payload.items[rowId]
         })
       }
       else if (action.type === 'CHANGE_SELECTIONS') {
       /* here we are setting the selections from one of the typeahead components
        * and the component keeps the state of all its selections
        */
-        obj[key].items = action.payload.items
+        obj[key] = action.payload.items
       }
     }
 
@@ -156,9 +157,7 @@ export const removeMyItem = (state, action) => {
   reduxPath.reduce((obj, key) => {
     level++
     if (level === reduxPath.length) {
-      obj[key].items = obj[key].items.filter(
-        row => row.id !== action.payload.id,
-      )
+      delete obj[key][action.payload.id]
     }
 
     return obj[key]


### PR DESCRIPTION
This would allow us to address individual literal items using redux path (without `find()`)

This is only 1/2 done.