### PR TITLE
Reload the resource tempaltes summaries after import

### DIFF
--- a/__tests__/components/templates/ImportResourceTemplate.test.js
+++ b/__tests__/components/templates/ImportResourceTemplate.test.js
@@ -315,7 +315,7 @@ describe('<ImportResourceTemplate />', () => {
       expect(updateResourceSpy).toHaveBeenCalledTimes(2)
       expect(updateStateSpy).toHaveBeenCalledTimes(1)
       expect(modalCloseSpy).toHaveBeenCalledTimes(1)
-      expect(mockFetchResourceTemplateSummaries).toHaveBeenCalledTimes(1)
+      expect(mockFetchResourceTemplateSummaries).toHaveBeenCalledTimes(2)
     })
   })
 })

--- a/src/components/templates/ImportResourceTemplate.jsx
+++ b/src/components/templates/ImportResourceTemplate.jsx
@@ -38,6 +38,7 @@ class ImportResourceTemplate extends Component {
       responses.push(response)
     }
     this.updateStateFromServerResponses(responses)
+    this.props.fetchResourceTemplateSummaries()
   }
 
   createResource = async (content, group) => {
@@ -87,7 +88,6 @@ class ImportResourceTemplate extends Component {
     if (newFlashMessages.length > 0) newState.flashMessages = [...this.state.flashMessages, ...newFlashMessages]
 
     if (showModal) newState.modalShow = true
-
 
     this.setState(newState)
   }


### PR DESCRIPTION
Fixes #1044 

Adds a call to `fetchResourceTemplateSummaries` after a template is imported/created.

NOTE: Integration test failures are unrelated to this PR and being worked on separately.