### PR TITLE
Do not copy the dist and nodmodules into the image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,4 +13,6 @@ jest-puppeteer.config.js
 junit.xml
 npm-debug.log
 setupEnzyme.js
+dist
+node_modules
 .env

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,9 @@ WORKDIR /home/circleci
 # Everything that isn't in .dockerignore ships
 COPY . .
 
+RUN mkdir dist
+RUN mkdir node_modules
+
 # Allow circleci user to run npm build
 USER root
 RUN /bin/bash -c 'chown -R circleci dist node_modules'


### PR DESCRIPTION
... these are built during the `npm run build` command so it seems redundant. I've got this version deployed in dev (for now) to ensure there are no major differences and can be used as a test.

This also improves the speed of builds.