### PR TITLE
make "required" asterisk same color as text

### DIFF
--- a/__tests__/components/editor/property/RequiredSuperscript.test.js
+++ b/__tests__/components/editor/property/RequiredSuperscript.test.js
@@ -18,6 +18,6 @@ describe('<RequiredSuperscript />', () => {
 
   it('has an OverlayTrigger for the asterick (that displays a popover tooltip)', () => {
     expect(wrapper.find(OverlayTrigger).length).toEqual(1)
-    expect(wrapper.find('OverlayTrigger FontAwesomeIcon').prop('className')).toEqual('asterick text-danger')
+    expect(wrapper.find('OverlayTrigger FontAwesomeIcon').prop('className')).toEqual('asterick')
   })
 })

--- a/src/components/editor/property/RequiredSuperscript.jsx
+++ b/src/components/editor/property/RequiredSuperscript.jsx
@@ -16,7 +16,7 @@ const RequiredSuperscript = () => {
   return (
     <OverlayTrigger trigger={['hover', 'focus']} placement="right" overlay={popover} key={shortid.generate()} >
       <sup aria-label="required" >
-        <FontAwesomeIcon className="asterick text-danger" icon={faAsterisk} />
+        <FontAwesomeIcon className="asterick" icon={faAsterisk} />
       </sup>
     </OverlayTrigger>
   )


### PR DESCRIPTION
Fixes #1024 

## Before

![before](https://user-images.githubusercontent.com/96775/62093082-b961a480-b22c-11e9-9062-2d64df25a497.png)

## After

![after](https://user-images.githubusercontent.com/96775/62093091-c1214900-b22c-11e9-9832-64e53252e513.png)

(note - tooltip still works, of course)