### PR TITLE
Patch 0.3.8

### DIFF
--- a/.github/ISSUE_TEMPLATE/tagged-release.md
+++ b/.github/ISSUE_TEMPLATE/tagged-release.md
@@ -9,15 +9,19 @@ assignees: ''
 
 - [ ] Update the version in *package.json*
 - [ ] `npm i` to regenerate *package-lock.json*
+- [ ] Create a feature branch in git for the version
 - [ ] `npm publish` to publish the version to [npm registry](https://npmjs.com).
 - [ ] Git annotated tag and push to Github
-  - [ ] `git tag -a v{version} -m "{your message}"` to create an annotated tag 
+  - [ ] `git tag -a v{version} -m "{your message}"` to create an annotated tag
   - [ ] `git push origin v{version}` to push up to the project's
    [releases](https://github.com/LD4P/sinopia_editor/releases)
 - [ ] Docker build and publish tagged Image, see See [documentation](https://github.com/LD4P/sinopia_editor/#building-latest-docker-image) for more information
   - [ ] Build a tagged Docker image i.e. `docker build -t ld4p/sinopia_editor:{version} .`
   - [ ] Push the tagged version to Dockerhub with `docker push ld4p/sinopia_editor:{version}`
-- [ ] Create Release notes for the tagged version on Github
+- [ ] Product owner assigned Release notes
+  - [ ] Updates `NewsItem.js` component
+  - [ ] Sinopia [Wiki](https://github.com/LD4P/sinopia/wiki/Latest-Release,-What's-Next) 
+  - [ ] Adds wiki link to the tagged version in Github
 - [ ] Once tagged release is live on https://development.sinopia.io, this ticket will be assigned to the product owner who will approve the tagged release for deployment on
   - [ ] Staging at https://stage.sinopia.io/
   - [ ] Production at https://sinopia.io

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sinopia_editor",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "editor",
     "rdf"
   ],
-  "version": "0.3.7",
+  "version": "0.3.8",
   "homepage": "http://github.com/LD4P/sinopia_editor/",
   "repository": {
     "type": "git",
@@ -26,7 +26,8 @@
     "Justin Coyne",
     "Peter Mangiafico",
     "Justin Littman",
-    "Aaron Collier"
+    "Aaron Collier",
+    "Huda Khan"
   ],
   "devDependencies": {
     "@babel/core": "^7.5.4",


### PR DESCRIPTION
UI and bug fixes in this tagged release. Updated with Github issue template with steps in future tagged releases. Keeping current NewsItem from `0.3.7` and earlier releases. 

Closes #1059 