### PR TITLE
Make the layout responsive.

### DIFF
--- a/src/components/editor/ResourceTemplate.jsx
+++ b/src/components/editor/ResourceTemplate.jsx
@@ -32,7 +32,7 @@ class ResourceTemplate extends Component {
     return (
       <div className="ResourceTemplate">
         <div id="resourceTemplate" style={{ marginTop: '-30px' }}>
-          <section className="col-md-9">
+          <section>
             <h1><em>{this.props.resourceTemplate.resourceLabel}</em></h1>
             <ResourceURIMessage />
             <SaveAlert />

--- a/src/components/editor/ResourceTemplateForm.jsx
+++ b/src/components/editor/ResourceTemplateForm.jsx
@@ -62,7 +62,7 @@ export class ResourceTemplateForm extends Component {
   renderComponentForm = () => (
     <div>
       <form>
-        <div className="ResourceTemplateForm row">
+        <div className="ResourceTemplateForm">
           {
             this.props.propertyTemplates.map((propertyTemplate, index) => {
               const newReduxPath = [...this.props.reduxPath, propertyTemplate.propertyURI]

--- a/src/components/editor/property/PropertyPanel.jsx
+++ b/src/components/editor/property/PropertyPanel.jsx
@@ -10,15 +10,12 @@ import { expandResource } from 'actionCreators/resources'
 import _ from 'lodash'
 
 const PropertyPanel = (props) => {
-  const floatClass = props.float > 0 && props.float % 0 > 0 ? 'pull-right' : 'pull-left'
-  const cssClasses = `panel panel-property ${floatClass}`
-
   const isAdd = _.isEmpty(props.resourceModel)
   const isMandatory = props.propertyTemplate.mandatory === 'true'
   const nbsp = '\u00A0'
 
   return (
-    <div className={ cssClasses } data-label={ props.propertyTemplate.propertyLabel }>
+    <div className="panel panel-property" data-label={ props.propertyTemplate.propertyLabel }>
       <div className="panel-heading prop-heading">
         <PropertyLabel propertyTemplate={ props.propertyTemplate } />{nbsp}
         { isAdd && (

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -49,6 +49,15 @@ body {
   font-size: 30px;
 }
 
+.ResourceTemplateForm {
+  column-count: 2;
+}
+
+@media only screen and (max-width: 768px) {
+  .ResourceTemplateForm {
+    column-count: 1;
+  }
+}
 
 
 .desc-panel{
@@ -87,12 +96,12 @@ body {
 }
 
 .panel-property {
-  margin: 1em;
-  width: 40%;
+  width: 100%;
   border-color: #8C8A83;
   border-style: solid;
   border-width: 1px;
   background-color: #F8F6EF;
+  break-inside: avoid;
 }
 
 .group-panel {


### PR DESCRIPTION
Use a balanced 2-column layout on large screens and a single column layout on small screens.
Avoid having to precalculate left or right


Before:
<img width="568" alt="Screen Shot 2019-07-30 at 12 24 25 PM" src="https://user-images.githubusercontent.com/92044/62151281-933c1300-b2c5-11e9-964c-1793c87d9b50.png">

After:
<img width="609" alt="Screen Shot 2019-07-30 at 12 26 52 PM" src="https://user-images.githubusercontent.com/92044/62151282-9505d680-b2c5-11e9-9ae6-0faeea951493.png">


