### PR TITLE
"Add another" button for property is hidden rather than disabled

### DIFF
--- a/__tests__/components/editor/property/PropertyActionButtons.test.js
+++ b/__tests__/components/editor/property/PropertyActionButtons.test.js
@@ -20,19 +20,8 @@ describe('<PropertyActionButtons />', () => {
       expect(button.text()).toEqual('Add another Note')
     })
 
-    it('is not disabled by default', () => {
-      expect(button.prop('disabled')).toBeUndefined()
-    })
-
-    describe('when addButtonDisabled is true', () => {
-      beforeEach(() => {
-        propertyActionWrapper = shallow(<PropertyActionButtons.WrappedComponent addButtonDisabled={true}/>)
-        button = propertyActionWrapper.find('button.btn-add-another')
-      })
-
-      it('is set to disabled', () => {
-        expect(button.prop('disabled')).toBe(true)
-      })
+    it('is not hidden by default', () => {
+      expect(button.prop('hidden')).toBeUndefined()
     })
 
     describe('when addButtonHidden is true', () => {

--- a/__tests__/components/editor/property/PropertyResourceTemplate.test.js
+++ b/__tests__/components/editor/property/PropertyResourceTemplate.test.js
@@ -66,32 +66,31 @@ describe('<PropertyResourceTemplate />', () => {
     })
   })
 
-  describe('<PropertyActionButtons /> addButtonDisabled prop value', () => {
-    it('isRepeatable false:  addButtonDisabled prop is true', () => {
-      const wrapper = shallow(<PropertyResourceTemplate.WrappedComponent isRepeatable={'false'} {...propertyRtProps} />)
-      const actionButtons = wrapper.find(PropertyActionButtons)
-
-      expect(actionButtons.props().addButtonDisabled).toBeTruthy()
-    })
-
-    it('isRepeatable true:  addButtonDisabled prop is false', () => {
-      const wrapper = shallow(<PropertyResourceTemplate.WrappedComponent isRepeatable={'true'} {...propertyRtProps} />)
-      const actionButtons = wrapper.find(PropertyActionButtons)
-
-      expect(actionButtons.props().addButtonDisabled).toBeFalsy()
-    })
-  })
-
   describe('<PropertyActionButtons /> addButtonHidden prop value', () => {
-    it('addButtonHidden prop is true', () => {
-      const wrapper = shallow(<PropertyResourceTemplate.WrappedComponent index={1} {...propertyRtProps} />)
+    // true when either addButtonHidden is true or repeatable is false
+    it('true when addButtonHidden prop is true and isRepeatable is false', () => {
+      const wrapper = shallow(<PropertyResourceTemplate.WrappedComponent index={1} isRepeatable={'false'} {...propertyRtProps} />)
       const actionButtons = wrapper.find(PropertyActionButtons)
 
       expect(actionButtons.props().addButtonHidden).toBeTruthy()
     })
 
-    it('addButtonHidden prop is false', () => {
-      const wrapper = shallow(<PropertyResourceTemplate.WrappedComponent index={0} {...propertyRtProps} />)
+    it('true when addButtonHidden prop is true and isRepeatable is true', () => {
+      const wrapper = shallow(<PropertyResourceTemplate.WrappedComponent index={1} isRepeatable={'true'} {...propertyRtProps} />)
+      const actionButtons = wrapper.find(PropertyActionButtons)
+
+      expect(actionButtons.props().addButtonHidden).toBeTruthy()
+    })
+
+    it('true when addButtonHidden prop is false and isRepeatable is false', () => {
+      const wrapper = shallow(<PropertyResourceTemplate.WrappedComponent index={0} isRepeatable={'false'} {...propertyRtProps} />)
+      const actionButtons = wrapper.find(PropertyActionButtons)
+
+      expect(actionButtons.props().addButtonHidden).toBeTruthy()
+    })
+
+    it('false when addButtonHidden prop is false and isRepeatable is true', () => {
+      const wrapper = shallow(<PropertyResourceTemplate.WrappedComponent index={0} isRepeatable={'true'} {...propertyRtProps} />)
       const actionButtons = wrapper.find(PropertyActionButtons)
 
       expect(actionButtons.props().addButtonHidden).toBeFalsy()

--- a/__tests__/components/editor/property/PropertyTemplateOutline.test.js
+++ b/__tests__/components/editor/property/PropertyTemplateOutline.test.js
@@ -44,31 +44,31 @@ describe('<PropertyTemplateOutline />', () => {
       expect(wrapper.find('div Connect(ResourceProperty)').length).toEqual(1)
     })
 
-    it('creates a <ResourceProperty /> for the nested resourceTemplate with "Add" button disabled', () => {
+    it('creates a <ResourceProperty /> for the nested resourceTemplate with "Add" button not hidden', () => {
       const resourceProperty = wrapper.find(ResourceProperty)
 
       expect(resourceProperty.length).toEqual(1)
       expect(resourceProperty.props().propertyTemplate).toEqual(propertyRtProps.property)
-      expect(resourceProperty.props().addButtonDisabled).toEqual(false) // repeatable is true in outer propTemp
+      expect(resourceProperty.props().addButtonHidden).toEqual(false) // repeatable is true in outer propTemp
     })
 
-    it('"Add" button enabled for outer propertyTemplate with repeatable false', () => {
+    it('"Add" button hidden for outer propertyTemplate with repeatable false', () => {
       const resourceTypePropTemp = { ...propertyRtProps }
 
       resourceTypePropTemp.property.repeatable = 'false'
       const myWrapper = shallow(<PropertyTemplateOutline.WrappedComponent {...resourceTypePropTemp} />)
       const resourceProperty = myWrapper.find(ResourceProperty)
 
-      expect(resourceProperty.props().addButtonDisabled).toEqual(true)
+      expect(resourceProperty.props().addButtonHidden).toEqual(true)
     })
-    it('"Add" button enabled for outer propertyTemplate without repeatable indicated', () => {
+    it('"Add" button hidden for outer propertyTemplate without repeatable indicated (defaults to false)', () => {
       const resourceTypePropTemp = { ...propertyRtProps }
 
       delete resourceTypePropTemp.property.repeatable
       const myWrapper = shallow(<PropertyTemplateOutline.WrappedComponent {...resourceTypePropTemp} />)
       const resourceProperty = myWrapper.find(ResourceProperty)
 
-      expect(resourceProperty.props().addButtonDisabled).toEqual(true)
+      expect(resourceProperty.props().addButtonHidden).toEqual(true)
     })
 
     it('adds a PropertyComponent div for a row with the nested template', () => {

--- a/__tests__/components/editor/property/ResourceProperty.test.js
+++ b/__tests__/components/editor/property/ResourceProperty.test.js
@@ -52,7 +52,6 @@ describe('<ResourceProperty />', () => {
     const wrapper = shallow(<ResourceProperty.WrappedComponent
               propertyTemplate={property}
               reduxPath={[]}
-              addButtonDisabled={true}
               nestedResourceTemplates={nestedRTs}
               models={models} />)
 
@@ -76,11 +75,7 @@ describe('<ResourceProperty />', () => {
         expect(wrapper.find(PropertyActionButtons).props().reduxPath).toEqual(['http://id.loc.gov/ontologies/bibframe/note', 'abcd45', 'resourceTemplate:bf2:Note'])
       })
 
-      it('sets addButtonDisabled', () => {
-        expect(wrapper.find(PropertyActionButtons).props().addButtonDisabled).toEqual(true)
-      })
-
-      it('sets addButtonHidden', () => {
+      it('sets addButtonHidden to false by default', () => {
         expect(wrapper.find(PropertyActionButtons).props().addButtonHidden).toEqual(false)
       })
 

--- a/src/components/editor/property/PropertyActionButtons.jsx
+++ b/src/components/editor/property/PropertyActionButtons.jsx
@@ -21,8 +21,7 @@ const PropertyActionButtons = (props) => {
   return (<div className="btn-group" role="group" aria-label="...">
     { props.addButtonHidden
       || <button className="btn btn-default btn-sm btn-add-another"
-                 onClick={ handleAddClick }
-                 disabled={ props.addButtonDisabled }>Add another {props.resourceLabel}</button>
+                 onClick={ handleAddClick }>Add another {props.resourceLabel}</button>
     }
     { props.removeButtonHidden
       || <button className="btn btn-default btn-sm btn-remove-another"
@@ -33,7 +32,6 @@ const PropertyActionButtons = (props) => {
 }
 PropertyActionButtons.propTypes = {
   reduxPath: PropTypes.array,
-  addButtonDisabled: PropTypes.bool,
   removeButtonHidden: PropTypes.bool,
   addButtonHidden: PropTypes.bool,
   addResource: PropTypes.func,

--- a/src/components/editor/property/PropertyResourceTemplate.jsx
+++ b/src/components/editor/property/PropertyResourceTemplate.jsx
@@ -59,9 +59,9 @@ class PropertyResourceTemplate extends Component {
     if (!this.props.resourceTemplate) {
       return null
     }
-    // repeatable defaults to false, so isAddDisabled defaults to true
-    const isAddDisabled = this.props.isRepeatable ? !JSON.parse(this.props.isRepeatable) : true
-    const isAddHidden = this.props.index > 0
+    // repeatable defaults to false, so isNotRepeatable defaults to true
+    const isNotRepeatable = this.props.isRepeatable ? !JSON.parse(this.props.isRepeatable) : true
+    const isAddHidden = isNotRepeatable || this.props.index > 0
     const isRemoveHidden = this.props.siblingResourceCount === 1
     return (<div>
       <div className="row" key={shortid.generate()}>
@@ -71,7 +71,6 @@ class PropertyResourceTemplate extends Component {
         <section className="col-md-6">
           <PropertyActionButtons
             addButtonHidden={isAddHidden}
-            addButtonDisabled={isAddDisabled}
             removeButtonHidden={isRemoveHidden}
             reduxPath={this.props.reduxPath}
             key={shortid.generate()} />

--- a/src/components/editor/property/PropertyTemplateOutline.jsx
+++ b/src/components/editor/property/PropertyTemplateOutline.jsx
@@ -25,11 +25,11 @@ class PropertyTemplateOutline extends Component {
     }
 
     if (isResourceWithValueTemplateRef(this.props.property)) {
-      const isAddDisabled = !booleanPropertyFromTemplate(this.props.property, 'repeatable', false)
+      const isAddHidden = !booleanPropertyFromTemplate(this.props.property, 'repeatable', false)
       return (<ResourceProperty key={shortid.generate()}
                                 propertyTemplate={this.props.property}
                                 reduxPath={this.props.reduxPath}
-                                addButtonDisabled={isAddDisabled} />)
+                                addButtonHidden={isAddHidden} />)
     }
 
     return (<PropertyComponent key={shortid.generate()} propertyTemplate={this.props.property} reduxPath={this.props.reduxPath} />)

--- a/src/components/editor/property/ResourceProperty.jsx
+++ b/src/components/editor/property/ResourceProperty.jsx
@@ -29,7 +29,7 @@ export class ResourceProperty extends Component {
 
         const propertyReduxPath = _.first(resourceRow.properties)
         const resourceReduxPath = propertyReduxPath.slice(0, propertyReduxPath.length - 1)
-        const isAddHidden = index > 0
+        const isAddHidden = this.props.addButtonHidden || index > 0
         const isRemoveHidden = resourceRows.length === 1
         jsx.push(
           <div className="row" key={shortid.generate()}>
@@ -39,8 +39,7 @@ export class ResourceProperty extends Component {
             <section className="col-sm-6">
               <PropertyActionButtons reduxPath={resourceReduxPath}
                                      addButtonHidden={isAddHidden}
-                                     removeButtonHidden={isRemoveHidden}
-                                     addButtonDisabled={this.props.addButtonDisabled} />
+                                     removeButtonHidden={isRemoveHidden} />
             </section>
           </div>,
         )
@@ -66,7 +65,7 @@ export class ResourceProperty extends Component {
 }
 
 ResourceProperty.propTypes = {
-  addButtonDisabled: PropTypes.bool,
+  addButtonHidden: PropTypes.bool,
   propertyTemplate: PropTypes.object,
   reduxPath: PropTypes.array,
   models: PropTypes.object,


### PR DESCRIPTION
Fixes #1100 "A disabled button is confusing to a user, if the property is not repeatable, don't show the button rather than disabling it."

Please review carefully as I'm not awesomely confident in whether I did this properly.  Aside from the tests, I did empirically prove the code in my local instance.

## Before

![before issue 1100](https://user-images.githubusercontent.com/96775/62173209-0f485200-b2ea-11e9-9358-d69b33b7f7de.png)

## After

![after issue 1100](https://user-images.githubusercontent.com/96775/62173216-166f6000-b2ea-11e9-9566-725be58f5d19.png)


Note:  I saw a disabled add button in OutlineHeader component that I don't fully understand, and I'm assuming it's not relevant.  https://github.com/LD4P/sinopia_editor/blob/master/src/components/editor/property/OutlineHeader.jsx#L43

```
<button type="button" className="btn btn-sm btn-toggle" onClick={props.handleToggle} data-id={props.id} disabled={isAdd}>
  <FontAwesomeIcon icon={icon} />
</button>
```