### PR TITLE
Add search paging

### DIFF
--- a/__tests__/actionCreators/search.test.js
+++ b/__tests__/actionCreators/search.test.js
@@ -1,0 +1,25 @@
+// Copyright 2019 Stanford University see LICENSE for license
+
+import fetchSearchResults from 'actionCreators/search'
+/* eslint import/namespace: 'off' */
+import * as server from 'sinopiaServer'
+
+describe('fetchSearchResults', () => {
+  const query = '*'
+  const mockSearchResults = {
+    totalHits: 1,
+    results: {
+      uri: 'http://sinopia.io/repository/stanford/123',
+      title: 'A lonely title',
+    },
+  }
+
+  it('dispatches actions', async () => {
+    server.getSearchResults = jest.fn().mockResolvedValue(mockSearchResults)
+    const dispatch = jest.fn()
+    await fetchSearchResults(query)(dispatch)
+    expect(dispatch).toHaveBeenCalledTimes(2)
+    expect(dispatch).toBeCalledWith({ type: 'GET_SEARCH_RESULTS_STARTED', payload: { query: '*', queryFrom: undefined } })
+    expect(dispatch).toBeCalledWith({ type: 'SET_SEARCH_RESULTS', payload: { query: '*', searchResults: mockSearchResults.results, totalResults: mockSearchResults.totalHits } })
+  })
+})

--- a/__tests__/components/search/SearchResultsPaging.test.jsx
+++ b/__tests__/components/search/SearchResultsPaging.test.jsx
@@ -1,0 +1,38 @@
+// Copyright 2019 Stanford University see LICENSE for license
+
+import React from 'react'
+import { shallow } from 'enzyme'
+import SearchResultsPaging from 'components/search/SearchResultsPaging'
+
+describe('<SearchResultsPaging />', () => {
+  describe('when there are no search results', () => {
+    const props = {
+      totalResults: 0,
+    }
+
+    const wrapper = shallow(<SearchResultsPaging.WrappedComponent {...props} />)
+
+    it('does not contain the paging div', () => {
+      expect(wrapper.find('div#search-results-pages').length).toBe(0)
+    })
+  })
+
+
+  describe('when there are search results', () => {
+    const props = {
+      totalResults: 100,
+    }
+
+    const wrapper = shallow(<SearchResultsPaging.WrappedComponent {...props} />)
+
+    it('it contains the main paging div', () => {
+      expect(wrapper.find('div#search-results-pages').length).toBe(1)
+      expect(wrapper.find('Pagination').length).toBe(1)
+      expect(wrapper.find('First').length).toBe(1)
+      expect(wrapper.find('Prev').length).toBe(1)
+      expect(wrapper.find('PaginationItem').length).toBe(10)
+      expect(wrapper.find('Next').length).toBe(1)
+      expect(wrapper.find('Last').length).toBe(1)
+    })
+  })
+})

--- a/src/Config.js
+++ b/src/Config.js
@@ -56,7 +56,7 @@ class Config {
   }
 
   static get searchResultsPerPage() {
-    return process.env.SEARCH_RESULTS_PER_PAGE || 10
+    return process.env.SEARCH_RESULTS_PER_PAGE || 1
   }
 
   /*

--- a/src/Config.js
+++ b/src/Config.js
@@ -56,7 +56,7 @@ class Config {
   }
 
   static get searchResultsPerPage() {
-    return process.env.SEARCH_RESULTS_PER_PAGE || 1
+    return process.env.SEARCH_RESULTS_PER_PAGE || 10
   }
 
   /*

--- a/src/Config.js
+++ b/src/Config.js
@@ -55,6 +55,9 @@ class Config {
     return process.env.SEARCH_HOST || ''
   }
 
+  static get searchResultsPerPage() {
+    return process.env.SEARCH_RESULTS_PER_PAGE || 1 // an intentionally small number during development
+  }
   /*
    * This is the public endpont for the sinopia search.
    */

--- a/src/Config.js
+++ b/src/Config.js
@@ -58,6 +58,7 @@ class Config {
   static get searchResultsPerPage() {
     return process.env.SEARCH_RESULTS_PER_PAGE || 1 // an intentionally small number during development
   }
+
   /*
    * This is the public endpont for the sinopia search.
    */

--- a/src/Config.js
+++ b/src/Config.js
@@ -56,7 +56,7 @@ class Config {
   }
 
   static get searchResultsPerPage() {
-    return process.env.SEARCH_RESULTS_PER_PAGE || 1 // an intentionally small number during development
+    return process.env.SEARCH_RESULTS_PER_PAGE || 10
   }
 
   /*

--- a/src/actionCreators/resources.js
+++ b/src/actionCreators/resources.js
@@ -42,7 +42,7 @@ export const retrieveResource = (currentUser, uri) => (dispatch) => {
       return rdfDatasetFromN3(data).then((dataset) => {
         const builder = new ResourceStateBuilder(dataset, null)
         dispatch(existingResource(builder.state, uri))
-        dispatch(setLastSaveChecksum(generateMD5(dataset.toCanonical())))
+        // dispatch(setLastSaveChecksum(generateMD5(dataset.toCanonical())))
       })
     })
 }
@@ -105,6 +105,7 @@ const stubResource = useDefaults => (dispatch, getState) => {
   stubResourceProperties(rootResourceTemplateId, resourceTemplate, rootResource, ['resource'], useDefaults, false, false, dispatch).then((resourceProperties) => {
     newResource[rootResourceTemplateId] = resourceProperties
     dispatch(setResource(newResource))
+    setLastSaveChecksum(generateMD5(dataset.toCanonical()))
   })
 }
 

--- a/src/actionCreators/resources.js
+++ b/src/actionCreators/resources.js
@@ -42,7 +42,7 @@ export const retrieveResource = (currentUser, uri) => (dispatch) => {
       return rdfDatasetFromN3(data).then((dataset) => {
         const builder = new ResourceStateBuilder(dataset, null)
         dispatch(existingResource(builder.state, uri))
-        // dispatch(setLastSaveChecksum(generateMD5(dataset.toCanonical())))
+        dispatch(setLastSaveChecksum(generateMD5(dataset.toCanonical())))
       })
     })
 }
@@ -105,7 +105,6 @@ const stubResource = useDefaults => (dispatch, getState) => {
   stubResourceProperties(rootResourceTemplateId, resourceTemplate, rootResource, ['resource'], useDefaults, false, false, dispatch).then((resourceProperties) => {
     newResource[rootResourceTemplateId] = resourceProperties
     dispatch(setResource(newResource))
-    setLastSaveChecksum(generateMD5(dataset.toCanonical()))
   })
 }
 

--- a/src/actionCreators/search.js
+++ b/src/actionCreators/search.js
@@ -1,14 +1,13 @@
 // Copyright 2019 Stanford University see LICENSE for license
-import {
-  getSearchResultsStarted, setSearchResults,
-} from 'actions/index'
+import { getSearchResultsStarted, setSearchResults } from 'actions/index'
 import { getSearchResults } from 'sinopiaServer'
-import _ from 'lodash'
 
-export const fetchSearchResults = (query, queryFrom) => (dispatch) => {
+const fetchSearchResults = (query, queryFrom) => (dispatch) => {
   dispatch(getSearchResultsStarted(query, queryFrom))
 
   return getSearchResults(query, queryFrom).then((response) => {
     dispatch(setSearchResults(response.results, response.totalHits, query))
   })
 }
+
+export default fetchSearchResults

--- a/src/actionCreators/search.js
+++ b/src/actionCreators/search.js
@@ -1,0 +1,14 @@
+// Copyright 2019 Stanford University see LICENSE for license
+import {
+  getSearchResultsStarted, setSearchResults,
+} from 'actions/index'
+import { getSearchResults } from 'sinopiaServer'
+import _ from 'lodash'
+
+export const fetchSearchResults = (query, queryFrom) => (dispatch) => {
+  dispatch(getSearchResultsStarted(query, queryFrom))
+
+  return getSearchResults(query, queryFrom).then((response) => {
+    dispatch(setSearchResults(response.results, response.totalHits, query))
+  })
+}

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -148,8 +148,13 @@ export const clearResourceTemplates = () => ({
   type: 'CLEAR_RESOURCE_TEMPLATES',
 })
 
-export const showSearchResults = (searchResults, totalResults, query) => ({
-  type: 'SHOW_SEARCH_RESULTS',
+export const getSearchResultsStarted = (query, queryFrom) => ({
+  type: 'GET_SEARCH_RESULTS_STARTED',
+  payload: { query, queryFrom },
+})
+
+export const setSearchResults = (searchResults, totalResults, query) => ({
+  type: 'SET_SEARCH_RESULTS',
   payload: { searchResults, totalResults, query },
 })
 

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -150,7 +150,7 @@ export const clearResourceTemplates = () => ({
 
 export const showSearchResults = (searchResults, totalResults, query) => ({
   type: 'SHOW_SEARCH_RESULTS',
-  payload: { searchResults, totalResults, query }
+  payload: { searchResults, totalResults, query },
 })
 
 export const setLastSaveChecksum = checksum => ({

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -148,9 +148,9 @@ export const clearResourceTemplates = () => ({
   type: 'CLEAR_RESOURCE_TEMPLATES',
 })
 
-export const showSearchResults = (searchResults, totalResults) => ({
+export const showSearchResults = (searchResults, totalResults, query) => ({
   type: 'SHOW_SEARCH_RESULTS',
-  payload: { searchResults, totalResults }
+  payload: { searchResults, totalResults, query }
 })
 
 export const setLastSaveChecksum = checksum => ({

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -148,9 +148,9 @@ export const clearResourceTemplates = () => ({
   type: 'CLEAR_RESOURCE_TEMPLATES',
 })
 
-export const showSearchResults = searchResults => ({
+export const showSearchResults = (searchResults, totalResults) => ({
   type: 'SHOW_SEARCH_RESULTS',
-  payload: searchResults,
+  payload: { searchResults, totalResults }
 })
 
 export const setLastSaveChecksum = checksum => ({

--- a/src/components/search/Search.jsx
+++ b/src/components/search/Search.jsx
@@ -18,7 +18,7 @@ const Search = (props) => {
 
   const handleKeyPress = (event) => {
     if (event.key === 'Enter') {
-      props.retrieveSearchResults(queryString, 0)
+      props.retrieveSearchResults(queryString)
       event.preventDefault()
     }
   }
@@ -52,8 +52,8 @@ Search.propTypes = {
 }
 
 const mapDispatchToProps = dispatch => ({
-  retrieveSearchResults: (queryString, queryFrom) => {
-    dispatch(fetchSearchResults(queryString, queryFrom))
+  retrieveSearchResults: (queryString) => {
+    dispatch(fetchSearchResults(queryString))
   },
 })
 

--- a/src/components/search/Search.jsx
+++ b/src/components/search/Search.jsx
@@ -24,9 +24,13 @@ const Search = (props) => {
     }
   }
 
-  const responseToSearchResults = json => {
-    return { totalHits: json.hits.total, results: json.hits.hits.map(row => ({ uri: row._id, title: row._source.title })) }
-  }
+  const responseToSearchResults = json => ({
+    totalHits: json.hits.total,
+    results: json.hits.hits.map(row => ({
+      uri: row._id,
+      title: row._source.title,
+    })),
+  })
 
   const search = (query) => {
     const uri = `${Config.searchHost}${Config.searchPath}?q=title:${query}%20OR%20subtitle:${query}&from=0&size=${Config.searchResultsPerPage}`

--- a/src/components/search/Search.jsx
+++ b/src/components/search/Search.jsx
@@ -11,6 +11,7 @@ import Row from 'react-bootstrap/lib/Row'
 import Form from 'react-bootstrap/lib/Form'
 import { showSearchResults } from 'actions/index'
 import SearchResults from './SearchResults'
+import SearchResultsPaging from './SearchResultsPaging'
 import Config from 'Config'
 
 const Search = (props) => {
@@ -23,17 +24,18 @@ const Search = (props) => {
     }
   }
 
-  const responseToSearchResults = json => json
-    .hits.hits.map(row => ({ uri: row._id, title: row._source.title }))
+  const responseToSearchResults = json => {
+    return { totalHits: json.hits.total, results: json.hits.hits.map(row => ({ uri: row._id, title: row._source.title })) }
+  }
 
   const search = (query) => {
-    const uri = `${Config.searchHost}${Config.searchPath}?q=title:${query}%20OR%20subtitle:${query}`
+    const uri = `${Config.searchHost}${Config.searchPath}?q=title:${query}%20OR%20subtitle:${query}&from=0&size=1`
 
     fetch(uri)
       .then(resp => resp.json())
       .then(json => responseToSearchResults(json))
       .then((results) => {
-        props.displaySearchResults(results)
+        props.displaySearchResults(results.results, results.totalHits)
       })
   }
 
@@ -53,6 +55,7 @@ const Search = (props) => {
           </Form>
         </Row>
         <SearchResults {...props} />
+        <SearchResultsPaging {...props} pageSize="1"/>
       </Grid>
     </div>
   )
@@ -65,8 +68,8 @@ Search.propTypes = {
 }
 
 const mapDispatchToProps = dispatch => ({
-  displaySearchResults: (searchResults) => {
-    dispatch(showSearchResults(searchResults))
+  displaySearchResults: (searchResults, totalResults) => {
+    dispatch(showSearchResults(searchResults, totalResults))
   },
 })
 

--- a/src/components/search/Search.jsx
+++ b/src/components/search/Search.jsx
@@ -29,13 +29,13 @@ const Search = (props) => {
   }
 
   const search = (query) => {
-    const uri = `${Config.searchHost}${Config.searchPath}?q=title:${query}%20OR%20subtitle:${query}&from=0&size=1`
+    const uri = `${Config.searchHost}${Config.searchPath}?q=title:${query}%20OR%20subtitle:${query}&from=0&size=${Config.searchResultsPerPage}`
 
     fetch(uri)
       .then(resp => resp.json())
       .then(json => responseToSearchResults(json))
       .then((results) => {
-        props.displaySearchResults(results.results, results.totalHits)
+        props.displaySearchResults(results.results, results.totalHits, query)
       })
   }
 
@@ -68,8 +68,8 @@ Search.propTypes = {
 }
 
 const mapDispatchToProps = dispatch => ({
-  displaySearchResults: (searchResults, totalResults) => {
-    dispatch(showSearchResults(searchResults, totalResults))
+  displaySearchResults: (searchResults, totalResults, queryString) => {
+    dispatch(showSearchResults(searchResults, totalResults, queryString))
   },
 })
 

--- a/src/components/search/Search.jsx
+++ b/src/components/search/Search.jsx
@@ -9,7 +9,7 @@ import FormControl from 'react-bootstrap/lib/FormControl'
 import Grid from 'react-bootstrap/lib/Grid'
 import Row from 'react-bootstrap/lib/Row'
 import Form from 'react-bootstrap/lib/Form'
-import { fetchSearchResults } from 'actionCreators/search'
+import fetchSearchResults from 'actionCreators/search'
 import SearchResults from './SearchResults'
 import SearchResultsPaging from './SearchResultsPaging'
 
@@ -18,7 +18,7 @@ const Search = (props) => {
 
   const handleKeyPress = (event) => {
     if (event.key === 'Enter') {
-      props.retrieveSearchResults(queryString,0)
+      props.retrieveSearchResults(queryString, 0)
       event.preventDefault()
     }
   }

--- a/src/components/search/Search.jsx
+++ b/src/components/search/Search.jsx
@@ -9,38 +9,18 @@ import FormControl from 'react-bootstrap/lib/FormControl'
 import Grid from 'react-bootstrap/lib/Grid'
 import Row from 'react-bootstrap/lib/Row'
 import Form from 'react-bootstrap/lib/Form'
-import { showSearchResults } from 'actions/index'
+import { fetchSearchResults } from 'actionCreators/search'
 import SearchResults from './SearchResults'
 import SearchResultsPaging from './SearchResultsPaging'
-import Config from 'Config'
 
 const Search = (props) => {
   const [queryString, setQueryString] = useState('')
 
   const handleKeyPress = (event) => {
     if (event.key === 'Enter') {
-      search(queryString)
+      props.retrieveSearchResults(queryString,0)
       event.preventDefault()
     }
-  }
-
-  const responseToSearchResults = json => ({
-    totalHits: json.hits.total,
-    results: json.hits.hits.map(row => ({
-      uri: row._id,
-      title: row._source.title,
-    })),
-  })
-
-  const search = (query) => {
-    const uri = `${Config.searchHost}${Config.searchPath}?q=title:${query}%20OR%20subtitle:${query}&from=0&size=${Config.searchResultsPerPage}`
-
-    fetch(uri)
-      .then(resp => resp.json())
-      .then(json => responseToSearchResults(json))
-      .then((results) => {
-        props.displaySearchResults(results.results, results.totalHits, query)
-      })
   }
 
   return (
@@ -67,13 +47,13 @@ const Search = (props) => {
 
 Search.propTypes = {
   triggerHandleOffsetMenu: PropTypes.func,
-  displaySearchResults: PropTypes.func,
+  retrieveSearchResults: PropTypes.func,
   currentUser: PropTypes.object,
 }
 
 const mapDispatchToProps = dispatch => ({
-  displaySearchResults: (searchResults, totalResults, queryString) => {
-    dispatch(showSearchResults(searchResults, totalResults, queryString))
+  retrieveSearchResults: (queryString, queryFrom) => {
+    dispatch(fetchSearchResults(queryString, queryFrom))
   },
 })
 

--- a/src/components/search/SearchResultsPaging.jsx
+++ b/src/components/search/SearchResultsPaging.jsx
@@ -5,11 +5,8 @@ import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
 import Config from 'Config'
 import 'react-bootstrap-table-next/dist/react-bootstrap-table2.min.css'
-import { getCurrentUser } from 'authSelectors'
-import Button from 'react-bootstrap/lib/Button'
 import Pagination from 'react-bootstrap/lib/Pagination'
 import { showSearchResults } from 'actions/index'
-
 
 const SearchResultsPaging = (props) => {
   const [currentPage, setCurrentPage] = useState(1) // initialize currentPage to 1
@@ -36,30 +33,35 @@ const SearchResultsPaging = (props) => {
     let newCurrentPage = 1
     switch (event.target.text) {
       case '«':
-          break
+        break
       case '‹':
-          newCurrentPage = currentPage - 1
-          break
+        newCurrentPage = currentPage - 1
+        break
       case '›':
-          newCurrentPage = currentPage + 1
-          break
+        newCurrentPage = currentPage + 1
+        break
       case '»':
         newCurrentPage = props.totalResults / Config.searchResultsPerPage
         break
       case undefined: // this is required to capture clicks on disabled buttons
-        return;
+        return
       default:
         newCurrentPage = Number(event.target.text)
         break
     }
-    queryFrom = (newCurrentPage-1)*Config.searchResultsPerPage
+    queryFrom = (newCurrentPage - 1) * Config.searchResultsPerPage
     setCurrentPage(newCurrentPage)
     search(props.queryString, queryFrom)
   }
 
-  const responseToSearchResults = json => {
-    return { totalHits: json.hits.total, results: json.hits.hits.map(row => ({ uri: row._id, title: row._source.title })) }
-  }
+  const responseToSearchResults = json => ({
+    totalHits: json.hits.total,
+    results: json.hits.hits.map(row => ({
+      uri: row._id,
+      title: row._source.title,
+    })),
+  })
+
 
   const search = (query, queryFrom) => {
     const uri = `${Config.searchHost}${Config.searchPath}?q=title:${query}%20OR%20subtitle:${query}&from=${queryFrom}&size=${Config.searchResultsPerPage}`
@@ -74,8 +76,8 @@ const SearchResultsPaging = (props) => {
   const lastPage = () => props.totalResults / Config.searchResultsPerPage
   const firstItemOnPage = () => Config.searchResultsPerPage * currentPage
   const lastItemOnPage = () => firstItemOnPage() + Config.searchResultsPerPage - 1
-  const pageButton = (key, active) => <Pagination.Item key={key} active={active}>{key}</Pagination.Item>
-  const pageButtons = () => Array.from({length: lastPage()}, (_, index) => pageButton(index+1,index+1 === currentPage))
+  const pageButton = (key, active) => <Pagination.Item key={ key } active={ active }>{key}</Pagination.Item>
+  const pageButtons = () => Array.from({ length: lastPage() }, (_, index) => pageButton(index + 1, index + 1 === currentPage))
 
   return (
     <div id="search-results-pages" className="row">

--- a/src/components/search/SearchResultsPaging.jsx
+++ b/src/components/search/SearchResultsPaging.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types'
 import Config from 'Config'
 import 'react-bootstrap-table-next/dist/react-bootstrap-table2.min.css'
 import Pagination from 'react-bootstrap/lib/Pagination'
-import { showSearchResults } from 'actions/index'
+import { fetchSearchResults } from 'actionCreators/search'
 
 const SearchResultsPaging = (props) => {
   const [currentPage, setCurrentPage] = useState(1) // initialize currentPage to 1
@@ -51,26 +51,7 @@ const SearchResultsPaging = (props) => {
     }
     queryFrom = (newCurrentPage - 1) * Config.searchResultsPerPage
     setCurrentPage(newCurrentPage)
-    search(props.queryString, queryFrom)
-  }
-
-  const responseToSearchResults = json => ({
-    totalHits: json.hits.total,
-    results: json.hits.hits.map(row => ({
-      uri: row._id,
-      title: row._source.title,
-    })),
-  })
-
-
-  const search = (query, queryFrom) => {
-    const uri = `${Config.searchHost}${Config.searchPath}?q=title:${query}%20OR%20subtitle:${query}&from=${queryFrom}&size=${Config.searchResultsPerPage}`
-    fetch(uri)
-      .then(resp => resp.json())
-      .then(json => responseToSearchResults(json))
-      .then((results) => {
-        props.displaySearchResults(results.results, results.totalHits, query)
-      })
+    props.retrieveSearchResults(props.queryString, queryFrom)
   }
 
   const lastPage = () => props.totalResults / Config.searchResultsPerPage
@@ -100,7 +81,7 @@ const SearchResultsPaging = (props) => {
 SearchResultsPaging.propTypes = {
   totalResults: PropTypes.number,
   queryString: PropTypes.string,
-  displaySearchResults: PropTypes.func,
+  retrieveSearchResults: PropTypes.func,
 }
 
 const mapStateToProps = state => ({
@@ -109,8 +90,8 @@ const mapStateToProps = state => ({
 })
 
 const mapDispatchToProps = dispatch => ({
-  displaySearchResults: (searchResults, totalResults, queryString) => {
-    dispatch(showSearchResults(searchResults, totalResults, queryString))
+  retrieveSearchResults: (queryString, queryFrom) => {
+    dispatch(fetchSearchResults(queryString, queryFrom))
   },
 })
 

--- a/src/components/search/SearchResultsPaging.jsx
+++ b/src/components/search/SearchResultsPaging.jsx
@@ -1,8 +1,6 @@
 // Copyright 2019 Stanford University see LICENSE for license
-/* eslint no-unused-vars: 0 */ // --> OFF
-/* eslint max-params: ["error", 4] */
 
-import React from 'react'
+import React, { useState } from 'react'
 import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
 import Config from 'Config'
@@ -10,23 +8,73 @@ import 'react-bootstrap-table-next/dist/react-bootstrap-table2.min.css'
 import { getCurrentUser } from 'authSelectors'
 import Button from 'react-bootstrap/lib/Button'
 import Pagination from 'react-bootstrap/lib/Pagination'
+import { showSearchResults } from 'actions/index'
 
 
 const SearchResultsPaging = (props) => {
+  const [currentPage, setCurrentPage] = useState('')
   /* Event.target.text is the page number clicked on
    * or:
-   *   << - first
-   *    < - previous
-   *    > - next
-   *   >> - last
+   *   « - first
+   *    ‹ - previous
+   *    › - next
+   *   » - last
    */
-  const handleClick = (event) => alert(event.target.text) 
+  const handleClick = (event) => {
+    switch (event.target.text) {
+      case '«':
+          search(props.queryString, 0) // Start from the beginning of the search results
+          return
+      case '‹':
+          const prevPage = currentPage - 1 // decrease the current page by 1
+          setCurrentPage(prevPage)
+          search(props.queryString, (prevPage-1)*Config.searchResultsPerPage)
+          return
+      case '›':
+          const nextPage = Number(currentPage) + 1 // increase the current page by 1
+          setCurrentPage(nextPage)
+          search(props.queryString, (currentPage)*Config.searchResultsPerPage)
+          return
+      case '»':
+        const lastPage = props.totalResults / Config.searchResultsPerPage
+        setCurrentPage(lastPage)
+        search(props.queryString, (Number(lastPage)-1)*Config.searchResultsPerPage)
+        return
+      default:
+        setCurrentPage(Number(event.target.text))
+        search(props.queryString, (Number(event.target.text)-1)*Config.searchResultsPerPage)
+        return
+    }
+  }
 
   if (props.totalResults === 0) {
     return null
   }
 
+  if (props.totalResults <= Config.searchResultsPerPage) {
+    return null
+  }
+
+  const responseToSearchResults = json => {
+    return { totalHits: json.hits.total, results: json.hits.hits.map(row => ({ uri: row._id, title: row._source.title })) }
+  }
+
+  const search = (query, queryFrom) => {
+    const uri = `${Config.searchHost}${Config.searchPath}?q=title:${query}%20OR%20subtitle:${query}&from=${queryFrom}&size=${Config.searchResultsPerPage}`
+    fetch(uri)
+      .then(resp => resp.json())
+      .then(json => responseToSearchResults(json))
+      .then((results) => {
+        props.displaySearchResults(results.results, results.totalHits, query)
+      })
+  }
+
   let items = []
+  items.push(
+    <Pagination.First />,
+    <Pagination.Prev />
+  )
+
   for (let number = 1; number <= props.totalResults / Config.searchResultsPerPage; number++) {
     items.push(
       <Pagination.Item key={number}>
@@ -34,6 +82,11 @@ const SearchResultsPaging = (props) => {
       </Pagination.Item>,
     );
   }
+
+  items.push(
+    <Pagination.Next />,
+    <Pagination.Last />
+  )
   
   return (
     <div id="search-results-pages" className="row">
@@ -47,11 +100,21 @@ const SearchResultsPaging = (props) => {
 }
 
 SearchResultsPaging.propTypes = {
-  totalResults: PropTypes.array,
+  totalResults: PropTypes.number,
+  queryString: PropTypes.string,
+  displaySearchResults: PropTypes.func,
+
 }
 
 const mapStateToProps = state => ({
   totalResults: state.selectorReducer.search.totalResults,
+  queryString: state.selectorReducer.search.query,
 })
 
-export default connect(mapStateToProps, null)(SearchResultsPaging)
+const mapDispatchToProps = dispatch => ({
+  displaySearchResults: (searchResults, totalResults, queryString) => {
+    dispatch(showSearchResults(searchResults, totalResults, queryString))
+  },
+})
+
+export default connect(mapStateToProps, mapDispatchToProps)(SearchResultsPaging)

--- a/src/components/search/SearchResultsPaging.jsx
+++ b/src/components/search/SearchResultsPaging.jsx
@@ -26,35 +26,20 @@ const SearchResultsPaging = (props) => {
     return null
   }
 
-  // for (let number = 1; number <= 5; number++) {
-  //   items.push(
-  //     <Pagination.Item key={number} active={number === active}>
-  //       {number}
-  //     </Pagination.Item>,
-  //   );
-  // }
+  let items = []
+  for (let number = 1; number <= props.totalResults / Config.searchResultsPerPage; number++) {
+    items.push(
+      <Pagination.Item key={number}>
+        {number}
+      </Pagination.Item>,
+    );
+  }
   
   return (
     <div id="search-results-pages" className="row">
       <div className="col-sm-2"></div>
       <div className="col-sm-8 text-center">
-        <Pagination size="lg" onClick={handleClick}>
-          <Pagination.First />
-          <Pagination.Prev />
-          <Pagination.Item>{1}</Pagination.Item>
-          <Pagination.Ellipsis />
-
-          <Pagination.Item>{10}</Pagination.Item>
-          <Pagination.Item>{11}</Pagination.Item>
-          <Pagination.Item>{12}</Pagination.Item>
-          <Pagination.Item>{13}</Pagination.Item>
-          <Pagination.Item>{14}</Pagination.Item>
-
-          <Pagination.Ellipsis />
-          <Pagination.Item>{20}</Pagination.Item>
-          <Pagination.Next />
-          <Pagination.Last />
-        </Pagination>
+        <Pagination size="lg" onClick={handleClick}>{items}</Pagination>
       </div>
       <div className="col-sm-2"></div>
     </div>

--- a/src/components/search/SearchResultsPaging.jsx
+++ b/src/components/search/SearchResultsPaging.jsx
@@ -1,0 +1,72 @@
+// Copyright 2019 Stanford University see LICENSE for license
+/* eslint no-unused-vars: 0 */ // --> OFF
+/* eslint max-params: ["error", 4] */
+
+import React from 'react'
+import { connect } from 'react-redux'
+import PropTypes from 'prop-types'
+import Config from 'Config'
+import 'react-bootstrap-table-next/dist/react-bootstrap-table2.min.css'
+import { getCurrentUser } from 'authSelectors'
+import Button from 'react-bootstrap/lib/Button'
+import Pagination from 'react-bootstrap/lib/Pagination'
+
+
+const SearchResultsPaging = (props) => {
+  /* Event.target.text is the page number clicked on
+   * or:
+   *   << - first
+   *    < - previous
+   *    > - next
+   *   >> - last
+   */
+  const handleClick = (event) => alert(event.target.text) 
+
+  if (props.totalResults === 0) {
+    return null
+  }
+
+  // for (let number = 1; number <= 5; number++) {
+  //   items.push(
+  //     <Pagination.Item key={number} active={number === active}>
+  //       {number}
+  //     </Pagination.Item>,
+  //   );
+  // }
+  
+  return (
+    <div id="search-results-pages" className="row">
+      <div className="col-sm-2"></div>
+      <div className="col-sm-8 text-center">
+        <Pagination size="lg" onClick={handleClick}>
+          <Pagination.First />
+          <Pagination.Prev />
+          <Pagination.Item>{1}</Pagination.Item>
+          <Pagination.Ellipsis />
+
+          <Pagination.Item>{10}</Pagination.Item>
+          <Pagination.Item>{11}</Pagination.Item>
+          <Pagination.Item>{12}</Pagination.Item>
+          <Pagination.Item>{13}</Pagination.Item>
+          <Pagination.Item>{14}</Pagination.Item>
+
+          <Pagination.Ellipsis />
+          <Pagination.Item>{20}</Pagination.Item>
+          <Pagination.Next />
+          <Pagination.Last />
+        </Pagination>
+      </div>
+      <div className="col-sm-2"></div>
+    </div>
+  )
+}
+
+SearchResultsPaging.propTypes = {
+  totalResults: PropTypes.array,
+}
+
+const mapStateToProps = state => ({
+  totalResults: state.selectorReducer.search.totalResults,
+})
+
+export default connect(mapStateToProps, null)(SearchResultsPaging)

--- a/src/components/search/SearchResultsPaging.jsx
+++ b/src/components/search/SearchResultsPaging.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types'
 import Config from 'Config'
 import 'react-bootstrap-table-next/dist/react-bootstrap-table2.min.css'
 import Pagination from 'react-bootstrap/lib/Pagination'
-import { fetchSearchResults } from 'actionCreators/search'
+import fetchSearchResults from 'actionCreators/search'
 
 const SearchResultsPaging = (props) => {
   const [currentPage, setCurrentPage] = useState(1) // initialize currentPage to 1

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -10,7 +10,7 @@ import {
   setResourceTemplate, clearResourceTemplates, setResourceTemplateSummary,
   loadingLanguages, languagesReceived,
 } from './entities'
-import showSearchResults from './search'
+import setSearchResults from './search'
 import { findNode } from 'selectors/resourceSelectors'
 import _ from 'lodash'
 
@@ -127,7 +127,7 @@ const handlers = {
   SET_BASE_URL: setBaseURL,
   SHOW_RESOURCE_URI_MESSAGE: showResourceURIMessage,
   CLEAR_RESOURCE_URI_MESSAGE: clearResourceURIMessage,
-  SHOW_SEARCH_RESULTS: showSearchResults,
+  SET_SEARCH_RESULTS: setSearchResults,
   SHOW_GROUP_CHOOSER: showGroupChooser,
   CLOSE_GROUP_CHOOSER: closeGroupChooser,
   LANGUAGE_SELECTED: setMyItemsLang,

--- a/src/reducers/search.js
+++ b/src/reducers/search.js
@@ -10,6 +10,7 @@ const showSearchResults = (state, action) => {
 
   newState.search.results = action.payload.searchResults
   newState.search.totalResults = action.payload.totalResults
+  newState.search.query = action.payload.query
 
   return newState
 }

--- a/src/reducers/search.js
+++ b/src/reducers/search.js
@@ -5,14 +5,15 @@
  * @param {Object} action the payload of the action is the this of search results
  * @return {Object} the next redux state
  */
-const showSearchResults = (state, action) => {
+const setSearchResults = (state, action) => {
   const newState = { ...state }
 
   newState.search.results = action.payload.searchResults
   newState.search.totalResults = action.payload.totalResults
   newState.search.query = action.payload.query
 
+  console.log("NEW STATE: ", newState)
   return newState
 }
 
-export default showSearchResults
+export default setSearchResults

--- a/src/reducers/search.js
+++ b/src/reducers/search.js
@@ -8,7 +8,9 @@
 const showSearchResults = (state, action) => {
   const newState = { ...state }
 
-  newState.search.results = action.payload
+  newState.search.results = action.payload.searchResults
+  newState.search.totalResults = action.payload.totalResults
+
   return newState
 }
 

--- a/src/reducers/search.js
+++ b/src/reducers/search.js
@@ -12,7 +12,6 @@ const setSearchResults = (state, action) => {
   newState.search.totalResults = action.payload.totalResults
   newState.search.query = action.payload.query
 
-  console.log("NEW STATE: ", newState)
   return newState
 }
 

--- a/src/sinopiaServer.js
+++ b/src/sinopiaServer.js
@@ -190,6 +190,6 @@ export const getSearchResults = async (query, queryFrom) => {
       results: json.hits.hits.map(row => ({
         uri: row._id,
         title: row._source.title,
-      })),  
+      })),
     }))
 }

--- a/src/sinopiaServer.js
+++ b/src/sinopiaServer.js
@@ -180,7 +180,7 @@ export const loadRDFResource = async (currentUser, uri) => {
   return await instance.getResourceWithHttpInfo(id.group, id.identifier, returningNtriples)
 }
 
-export const getSearchResults = async (query, queryFrom) => {
+export const getSearchResults = async (query, queryFrom = 0) => {
   const uri = `${Config.searchHost}${Config.searchPath}?q=title:${query}%20OR%20subtitle:${query}&from=${queryFrom}&size=${Config.searchResultsPerPage}`
 
   return await fetch(uri)

--- a/src/sinopiaServer.js
+++ b/src/sinopiaServer.js
@@ -181,18 +181,15 @@ export const loadRDFResource = async (currentUser, uri) => {
 }
 
 export const getSearchResults = async (query, queryFrom) => {
-
-  const responseToSearchResults = json => ({
-    totalHits: json.hits.total,
-    results: json.hits.hits.map(row => ({
-      uri: row._id,
-      title: row._source.title,
-    })),
-  })
-
   const uri = `${Config.searchHost}${Config.searchPath}?q=title:${query}%20OR%20subtitle:${query}&from=${queryFrom}&size=${Config.searchResultsPerPage}`
 
   return await fetch(uri)
     .then(resp => resp.json())
-    .then(json => responseToSearchResults(json))
+    .then(json => ({
+      totalHits: json.hits.total,
+      results: json.hits.hits.map(row => ({
+        uri: row._id,
+        title: row._source.title,
+      })),  
+    }))
 }

--- a/src/sinopiaServer.js
+++ b/src/sinopiaServer.js
@@ -183,7 +183,7 @@ export const loadRDFResource = async (currentUser, uri) => {
 export const getSearchResults = async (query, queryFrom = 0) => {
   const uri = `${Config.searchHost}${Config.searchPath}?q=title:${query}%20OR%20subtitle:${query}&from=${queryFrom}&size=${Config.searchResultsPerPage}`
 
-  return await fetch(uri)
+  return fetch(uri)
     .then(resp => resp.json())
     .then(json => ({
       totalHits: json.hits.total,
@@ -192,4 +192,5 @@ export const getSearchResults = async (query, queryFrom = 0) => {
         title: row._source.title,
       })),
     }))
+    .catch(error => console.log(error))
 }

--- a/src/sinopiaServer.js
+++ b/src/sinopiaServer.js
@@ -179,3 +179,20 @@ export const loadRDFResource = async (currentUser, uri) => {
   const id = identifiersForUri(uri)
   return await instance.getResourceWithHttpInfo(id.group, id.identifier, returningNtriples)
 }
+
+export const getSearchResults = async (query, queryFrom) => {
+
+  const responseToSearchResults = json => ({
+    totalHits: json.hits.total,
+    results: json.hits.hits.map(row => ({
+      uri: row._id,
+      title: row._source.title,
+    })),
+  })
+
+  const uri = `${Config.searchHost}${Config.searchPath}?q=title:${query}%20OR%20subtitle:${query}&from=${queryFrom}&size=${Config.searchResultsPerPage}`
+
+  return await fetch(uri)
+    .then(resp => resp.json())
+    .then(json => responseToSearchResults(json))
+}

--- a/src/sinopiaServer.js
+++ b/src/sinopiaServer.js
@@ -192,5 +192,5 @@ export const getSearchResults = async (query, queryFrom = 0) => {
         title: row._source.title,
       })),
     }))
-    .catch(error => console.log(error))
+    .catch(error => console.error(error))
 }

--- a/src/store.js
+++ b/src/store.js
@@ -35,6 +35,7 @@ const initialState = {
     resource: {}, // The state we're displaying in the editor
     search: {
       results: [],
+      totalResults: 0,
     },
   },
 }


### PR DESCRIPTION
Fixes #1082 

Note: Integration testing of search will come in a follow up PR addressing #1089 

![Screen Shot 2019-07-31 at 2 13 16 PM](https://user-images.githubusercontent.com/2294288/62250744-9b1db500-b3a2-11e9-9dbc-1be78e1279b4.png)

UI Notes:
- Paging includes a first page, previous page, next page, and last page button.
- First, previous, next, and last buttons are disabled as necessary
- Current page is shown as active
- Total result count and current result span are displayed.
