### PR TITLE
Bootstrap styles don't allow for labels that wrap the input

### DIFF
--- a/src/components/editor/property/InputURI.jsx
+++ b/src/components/editor/property/InputURI.jsx
@@ -116,21 +116,21 @@ const InputURI = (props) => {
     groupClasses += ' has-error'
     error = errors.join(', ')
   }
+  const id = shortid.generate()
 
   return (
     <div className={groupClasses}>
-      <label>Enter a URI
-        <input
-              required={required}
-              className="form-control"
-              placeholder={props.propertyTemplate.propertyLabel}
-              onChange={event => setContent(event.target.value)}
-              onKeyPress={handleKeypress}
-              value={content}
-              disabled={disabled}
-              ref={inputLiteralRef}
-        />
-      </label>
+      <label htmlFor={id}>Enter a URI</label>
+      <input id={id}
+             required={required}
+             className="form-control"
+             placeholder={props.propertyTemplate.propertyLabel}
+             onChange={event => setContent(event.target.value)}
+             onKeyPress={handleKeypress}
+             value={content}
+             disabled={disabled}
+             ref={inputLiteralRef}
+      />
       {error && <span className="help-block">{error}</span>}
       {addedList}
     </div>


### PR DESCRIPTION
Before:
<img width="706" alt="Screen Shot 2019-08-01 at 2 23 05 PM" src="https://user-images.githubusercontent.com/92044/62321451-47759f00-b468-11e9-885f-2012010e5beb.png">

After:
<img width="677" alt="Screen Shot 2019-08-01 at 2 24 40 PM" src="https://user-images.githubusercontent.com/92044/62321454-48a6cc00-b468-11e9-8ebb-eca77bd219d3.png">
