### PR TITLE
Fixes typehead bug when hitting backspace key.

### DIFF
--- a/__tests__/integration/previewRDFHelper.js
+++ b/__tests__/integration/previewRDFHelper.js
@@ -13,7 +13,9 @@ export async function fillInRequredFieldsForBibframeInstance() {
 
   // Click on one of the property type rows to expand a nested resource
   await page.waitForSelector('div.rOutline-header button.btn-add[data-id=\'title\']')
-  await page.click('div.rOutline-header button.btn-add[data-id=\'title\']')
+  await page.evaluate(() => {
+    document.querySelector('div.rOutline-header button.btn-add[data-id=\'title\']').click()
+  })
 
   // Fill in required element
   await page.waitForSelector('button.btn-add[data-id=\'partName\']')

--- a/src/components/editor/property/InputListLOC.jsx
+++ b/src/components/editor/property/InputListLOC.jsx
@@ -25,6 +25,17 @@ class InputListLOC extends Component {
     }
   }
 
+  // From https://github.com/ericgio/react-bootstrap-typeahead/issues/389
+  onKeyDown = (e) => {
+    // 8 = backspace
+    if (e.keyCode === 8
+        && e.target.value === '') {
+      // Don't trigger a "back" in the browser on backspace
+      e.returnValue = false
+      e.preventDefault()
+    }
+  }
+
   selectionChanged(items) {
     const payload = {
       id: this.props.propertyTemplate.propertyURI,
@@ -99,6 +110,7 @@ class InputListLOC extends Component {
       isLoading: this.state.isLoading,
       options: this.state.options,
       selected: this.props.selected,
+      onKeyDown: this.onKeyDown,
     }
 
     let error

--- a/src/components/editor/property/InputLookupQA.jsx
+++ b/src/components/editor/property/InputLookupQA.jsx
@@ -33,6 +33,17 @@ class InputLookupQA extends Component {
     }
   }
 
+  // From https://github.com/ericgio/react-bootstrap-typeahead/issues/389
+  onKeyDown = (e) => {
+    // 8 = backspace
+    if (e.keyCode === 8
+        && e.target.value === '') {
+      // Don't trigger a "back" in the browser on backspace
+      e.returnValue = false
+      e.preventDefault()
+    }
+  }
+
   // Render token function to be used by typeahead
   renderTokenFunc = (option, props, idx) => {
     const optionLabel = getOptionLabel(option, props.labelKey)
@@ -226,6 +237,7 @@ class InputLookupQA extends Component {
       selected: this.props.selected,
       allowNew: true,
       delay: 300,
+      onKeyDown: this.onKeyDown,
     }
 
     let error

--- a/src/components/editor/property/InputLookupSinopia.jsx
+++ b/src/components/editor/property/InputLookupSinopia.jsx
@@ -52,6 +52,17 @@ const InputLookupSinopia = (props) => {
     props.handleSelectedChange(payload)
   }
 
+  // From https://github.com/ericgio/react-bootstrap-typeahead/issues/389
+  const onKeyDown = (e) => {
+    // 8 = backspace
+    if (e.keyCode === 8
+        && e.target.value === '') {
+      // Don't trigger a "back" in the browser on backspace
+      e.returnValue = false
+      e.preventDefault()
+    }
+  }
+
   let error
   let groupClasses = 'form-group'
 
@@ -64,6 +75,7 @@ const InputLookupSinopia = (props) => {
     <div className={groupClasses}>
       <AsyncTypeahead onSearch={search}
                       onChange={change}
+                      onKeyDown={onKeyDown}
                       options={options}
                       required={isMandatory}
                       multiple={isRepeatable}


### PR DESCRIPTION
closes #581

So this isn't perfect (you have to hit backspace twice to delete a value in a typeahead box), but better than the reported bug.