### PR TITLE
Use bindActionCreators whereever possible

### DIFF
--- a/__tests__/components/App.test.js
+++ b/__tests__/components/App.test.js
@@ -20,7 +20,7 @@ jest.mock('components/templates/ImportResourceTemplate')
 describe('<App />', () => {
   const mockStoreAppVersion = jest.fn()
   const mockFetchResourceTemplateSummaries = jest.fn()
-  const wrapper = shallow(<App.WrappedComponent storeAppVersion={mockStoreAppVersion}
+  const wrapper = shallow(<App.WrappedComponent saveAppVersion={mockStoreAppVersion}
                                                 fetchResourceTemplateSummaries={mockFetchResourceTemplateSummaries} />)
 
   it('is selectable by id "#app"', () => {
@@ -35,7 +35,7 @@ describe('<App />', () => {
     expect(wrapper.find(Footer).length).toBe(1)
   })
 
-  it('calls storeAppVersion on componentDidMount', () => {
+  it('calls saveAppVersion on componentDidMount', () => {
     expect(mockStoreAppVersion).toBeCalled()
   })
 

--- a/__tests__/components/editor/GroupChoiceModal.test.js
+++ b/__tests__/components/editor/GroupChoiceModal.test.js
@@ -17,10 +17,10 @@ describe('<GroupChoiceModal />', () => {
   const mockPublishMyResource = jest.fn()
   const wrapper = shallow(<GroupChoiceModal.WrappedComponent show={true}
                                                              rdf={rdfFunc}
-                                                             close={mockCloseGroupChooser}
-                                                             closeRdfPreview={mockCloseRdfPreview}
+                                                             closeGroupChooser={mockCloseGroupChooser}
+                                                             showRdfPreview={mockCloseRdfPreview}
                                                              currentUser={currentUser}
-                                                             publishMyResource={mockPublishMyResource} />)
+                                                             publishResource={mockPublishMyResource} />)
 
   it('renders the <GroupChoiceModal /> component as a Modal', () => {
     expect(wrapper.find(Modal).length).toBe(1)

--- a/__tests__/components/editor/SaveAndPublishButton.test.js
+++ b/__tests__/components/editor/SaveAndPublishButton.test.js
@@ -8,23 +8,23 @@ import Button from 'react-bootstrap/lib/Button'
 describe('<SaveAndPublishButton />', () => {
   const mockSave = jest.fn()
   describe('when disabled', () => {
-    const wrapper = shallow(<SaveAndPublishButton.WrappedComponent isDisabled={true} save={mockSave}/>)
+    const wrapper = shallow(<SaveAndPublishButton.WrappedComponent isDisabled={true} />)
     it('the button is disabled', () => {
       expect(wrapper.find(Button).prop('disabled')).toEqual(true)
     })
   })
   describe('when not disabled', () => {
-    const wrapper = shallow(<SaveAndPublishButton.WrappedComponent isDisabled={false} save={mockSave}/>)
+    const wrapper = shallow(<SaveAndPublishButton.WrappedComponent isDisabled={false} />)
     it('the button is not disabled', () => {
       expect(wrapper.find(Button).prop('disabled')).toEqual(false)
     })
   })
   describe('clicking the button', () => {
     const user = { name: 'Wilford Brimley' }
-    const wrapper = shallow(<SaveAndPublishButton.WrappedComponent isDisabled={false} save={mockSave} isSaved={false} currentUser={user} />)
-    it('calls save', () => {
+    const wrapper = shallow(<SaveAndPublishButton.WrappedComponent isDisabled={false} showGroupChooser={mockSave} isSaved={false} currentUser={user} />)
+    it('calls showGroupChooser', () => {
       wrapper.find(Button).simulate('click')
-      expect(mockSave).toHaveBeenCalledWith(false, user)
+      expect(mockSave).toHaveBeenCalledWith(true)
     })
   })
 })

--- a/__tests__/components/editor/property/InputListLOC.test.js
+++ b/__tests__/components/editor/property/InputListLOC.test.js
@@ -122,17 +122,17 @@ describe('<InputListLOC /> configuration', () => {
   })
 
   it('expects a single lookupConfig object', () => {
-    shallow(<InputListLOC.WrappedComponent {...propsOk} handleSelectedChange={mockFormDataFn} />)
+    shallow(<InputListLOC.WrappedComponent {...propsOk} changeSelections={mockFormDataFn} />)
     expect(global.alert.mock.calls.length).toEqual(0)
   })
 
   it('displays a browser alert if the lookupConfig is undefined', () => {
-    shallow(<InputListLOC.WrappedComponent {...propsUndefLookupURI} handleSelectedChange={mockFormDataFn} />)
+    shallow(<InputListLOC.WrappedComponent {...propsUndefLookupURI} changeSelections={mockFormDataFn} />)
     expect(global.alert.mock.calls.length).toEqual(1)
   })
 
   it('displays a browser alert if the lookupConfig is an array of objects and not a single object', () => {
-    shallow(<InputListLOC.WrappedComponent {...propsMultLookup} handleSelectedChange={mockFormDataFn} />)
+    shallow(<InputListLOC.WrappedComponent {...propsMultLookup} changeSelections={mockFormDataFn} />)
     expect(global.alert.mock.calls.length).toEqual(1)
   })
 })
@@ -140,7 +140,7 @@ describe('<InputListLOC /> configuration', () => {
 describe('<Typeahead /> component', () => {
   // Our mock formData function to replace the one provided by mapDispatchToProps
   const mockFormDataFn = jest.fn()
-  const wrapper = shallow(<InputListLOC.WrappedComponent {...propsOk} handleSelectedChange={mockFormDataFn} />)
+  const wrapper = shallow(<InputListLOC.WrappedComponent {...propsOk} changeSelections={mockFormDataFn} />)
 
   it('contains a placeholder with the value of propertyLabel', () => {
     expect(wrapper.find(Typeahead).props().placeholder).toMatch('Frequency (RDA 2.14)')

--- a/__tests__/components/editor/property/InputLiteral.test.js
+++ b/__tests__/components/editor/property/InputLiteral.test.js
@@ -70,7 +70,7 @@ describe('When the user enters input into field', () => {
     mockItemsChange = jest.fn()
 
     mockWrapper = shallow(<InputLiteral.WrappedComponent {...plProps}
-                                                         handleMyItemsChange={mockItemsChange} />)
+                                                         itemsSelected={mockItemsChange} />)
   })
 
   it('calls the change function when enter is pressed', () => {
@@ -156,7 +156,7 @@ describe('When the user enters input into field', () => {
       reduxPath: ['basePath'],
     }
     const wrapper = shallow(<InputLiteral.WrappedComponent {...plProps}
-                                                           handleMyItemsChange={mockItemsChange} />)
+                                                           itemsSelected={mockItemsChange} />)
 
     expect(wrapper.find('Connect(InputValue)').prop('reduxPath')).toEqual(['basePath', 'items', 'abc123'])
   })
@@ -181,7 +181,7 @@ describe('when there is a default literal value in the property template', () =>
     it('input has disabled attribute when there are items', () => {
       const nonrepeatWrapper = shallow(
         <InputLiteral.WrappedComponent {...nrProps}
-                                       handleMyItemsChange={mockMyItemsChange}
+                                       itemsSelected={mockMyItemsChange}
                                        items={{ 0: { content: 'fooby', lang: 'en' } }}/>,
       )
 
@@ -191,7 +191,7 @@ describe('when there is a default literal value in the property template', () =>
     it('input does not have disabled attribute when there are no items', () => {
       const nonrepeatWrapper = shallow(
         <InputLiteral.WrappedComponent {...nrProps}
-                                       handleMyItemsChange={mockMyItemsChange}
+                                       itemsSelected={mockMyItemsChange}
                                        items={{}}/>,
       )
       expect(nonrepeatWrapper.find('input').prop('disabled')).toBe(false)
@@ -217,7 +217,7 @@ describe('When a user enters non-roman text in a work title', () => {
 
   const workTitleWrapper = shallow(
     <InputLiteral.WrappedComponent {...workTitleProps}
-                                   handleMyItemsChange={mockDataFn} />,
+                                   itemsSelected={mockDataFn} />,
   )
 
   it('allows user to enter Chinese characters', () => {

--- a/__tests__/components/editor/property/InputLookupQA.test.js
+++ b/__tests__/components/editor/property/InputLookupQA.test.js
@@ -102,7 +102,7 @@ const validNewLiteralResults = [{
 
 describe('<InputLookupQA />', () => {
   const mockFormDataFn = jest.fn()
-  const wrapper = shallow(<InputLookupQA.WrappedComponent {...plProps} handleSelectedChange={mockFormDataFn} />)
+  const wrapper = shallow(<InputLookupQA.WrappedComponent {...plProps} changeSelections={mockFormDataFn} />)
 
   /*
    * Our mock formData function to replace the one provided by
@@ -181,7 +181,7 @@ describe('<InputLookupQA />', () => {
   })
 
   // Institute wrapper with multiple lookup options
-  const multipleWrapper = shallow(<InputLookupQA.WrappedComponent {...p2Props} handleSelectedChange={mockFormDataFn} />)
+  const multipleWrapper = shallow(<InputLookupQA.WrappedComponent {...p2Props} changeSelections={mockFormDataFn} />)
 
   it('passes multiple lookup results in state with search event', () => {
     const event = (wrap) => {

--- a/__tests__/components/editor/property/InputLookupSinopia.test.js
+++ b/__tests__/components/editor/property/InputLookupSinopia.test.js
@@ -65,7 +65,7 @@ describe('<InputLookupSinopia />', () => {
 
   describe('when changing what is selected', () => {
     const mockFormDataFn = jest.fn()
-    const wrapper2 = shallow(<InputLookupSinopia.WrappedComponent {...plProps} handleSelectedChange={mockFormDataFn} />)
+    const wrapper2 = shallow(<InputLookupSinopia.WrappedComponent {...plProps} changeSelections={mockFormDataFn} />)
     const items = [{ label: 'this', uri: 'http://example.com/one' }, { label: 'that', uri: 'http://example.com/two' }]
 
     it('call the onChange event with the selected option', () => {

--- a/__tests__/components/editor/property/InputURI.test.js
+++ b/__tests__/components/editor/property/InputURI.test.js
@@ -51,10 +51,10 @@ describe('When the user enters input into field', () => {
   beforeEach(() => {
     mockItemsChange = jest.fn()
     mockWrapper = shallow(<InputURI.WrappedComponent {...plProps}
-                                                     handleMyItemsChange={mockItemsChange} />)
+                                                     itemsSelected={mockItemsChange} />)
   })
 
-  it('calls handleMyItemsChange function', () => {
+  it('calls itemsSelected function', () => {
     mockWrapper.find('input').simulate('change', { target: { value: 'http://example.com/thing/1' } })
     mockWrapper.find('input').simulate('keypress', { key: 'Enter', preventDefault: () => {} })
     expect(mockItemsChange).toHaveBeenCalled()
@@ -149,7 +149,7 @@ describe('when there is a default literal value in the property template', () =>
     it('input has disabled attribute when there are items', () => {
       const nonrepeatWrapper = shallow(
         <InputURI.WrappedComponent {...nrProps}
-                                   handleMyItemsChange={mockMyItemsChange}
+                                   itemsSelected={mockMyItemsChange}
                                    items={{ 0: { uri: 'http://foo.by', id: 0 } }}/>,
       )
 
@@ -159,7 +159,7 @@ describe('when there is a default literal value in the property template', () =>
     it('input does not have disabled attribute when there are no items', () => {
       const nonrepeatWrapper = shallow(
         <InputURI.WrappedComponent {...nrProps}
-                                   handleMyItemsChange={mockMyItemsChange}
+                                   itemsSelected={mockMyItemsChange}
                                    items={{}}/>,
       )
       expect(nonrepeatWrapper.find('input').prop('disabled')).toBe(false)

--- a/__tests__/components/editor/property/LanguageButton.test.js
+++ b/__tests__/components/editor/property/LanguageButton.test.js
@@ -19,7 +19,7 @@ describe('<LanguageButton />', () => {
                                           'TM1qwVFkh',
                                         ]}
                                         language={'English'}
-                                        handleMyItemsLangChange={jest.fn()} />)
+                                        languageSelected={jest.fn()} />)
   })
 
   it('item appears when user inputs text into the field', () => {
@@ -39,7 +39,7 @@ describe('When the user enters input into language modal', () => {
                                               'TM1qwVFkh',
                                             ]}
                                             language={'English'}
-                                            handleMyItemsLangChange={mockMyItemsLangChange} />)
+                                            languageSelected={mockMyItemsLangChange} />)
 
   it('shows the <InputLang> modal when the <Button/> is clicked', () => {
     mockWrapper.find('Button').first().simulate('click')

--- a/__tests__/components/load/LoadByRDFForm.test.js
+++ b/__tests__/components/load/LoadByRDFForm.test.js
@@ -1,12 +1,22 @@
-// Copyright 2018 Stanford University see LICENSE for license
+// Copyright 2019 Stanford University see LICENSE for license
 
 import React from 'react'
 import { shallow } from 'enzyme'
 import LoadByRDFForm from 'components/load/LoadByRDFForm'
+/* eslint import/namespace: 'off' */
+import * as utils from 'Utilities'
+
+const mockState = { foo: 'bar' }
+jest.mock('ResourceStateBuilder', () => {
+  return jest.fn().mockImplementation(() => {
+    return { state: mockState }
+  })
+})
 
 describe('<LoadByRDFForm />', () => {
   const mockExistingResource = jest.fn()
   const n3 = 'not rdf'
+
   const wrapper = shallow(<LoadByRDFForm.WrappedComponent existingResource={mockExistingResource} />)
 
   it('renders an input (baseUri)', () => {
@@ -29,10 +39,11 @@ describe('<LoadByRDFForm />', () => {
   })
 
   describe('when n3 is provided', () => {
-    it('calls existingResource when submit is clicked', () => {
+    it('calls existingResource when submit is clicked', async () => {
+      utils.rdfDatasetFromN3 = jest.fn().mockResolvedValue([])
       wrapper.find('textarea').simulate('change', { target: { value: n3 }, preventDefault: jest.fn() })
-      wrapper.find('form').simulate('submit', { preventDefault: jest.fn() })
-      expect(mockExistingResource).toBeCalledWith(n3, '')
+      await wrapper.find('form').simulate('submit', { preventDefault: jest.fn() })
+      expect(mockExistingResource).toBeCalledWith(mockState)
     })
   })
 })

--- a/__tests__/components/load/LoadByURIForm.test.js
+++ b/__tests__/components/load/LoadByURIForm.test.js
@@ -1,4 +1,4 @@
-// Copyright 2018 Stanford University see LICENSE for license
+// Copyright 2019 Stanford University see LICENSE for license
 
 import React from 'react'
 import { shallow } from 'enzyme'
@@ -8,7 +8,7 @@ describe('<LoadByURIForm />', () => {
   const mockLoadResource = jest.fn()
   const user = { name: 'Ludwig Wittgenstein' }
   const uri = 'http://localhost:8080/repository/stanford/fe99a7d9'
-  const wrapper = shallow(<LoadByURIForm.WrappedComponent loadResource={mockLoadResource} currentUser={user} />)
+  const wrapper = shallow(<LoadByURIForm.WrappedComponent retrieveResource={mockLoadResource} currentUser={user} />)
 
   it('renders an input box', () => {
     expect(wrapper.find('input').length).toEqual(1)

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -16,9 +16,10 @@ import LoadResource from './load/LoadResource'
 import Search from './search/Search'
 import CanvasMenu from './menu/CanvasMenu'
 import { saveAppVersion } from 'actions/index'
+import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
 import { version } from '../../package.json'
-import { fetchResourceTemplateSummaries as fetchResourceTemplateSummariesCreator } from 'actionCreators/resourceTemplates'
+import { fetchResourceTemplateSummaries } from 'actionCreators/resourceTemplates'
 
 import _ from 'lodash'
 
@@ -34,7 +35,7 @@ class App extends Component {
   }
 
   componentDidMount() {
-    this.props.storeAppVersion(version)
+    this.props.saveAppVersion(version)
     this.props.fetchResourceTemplateSummaries()
   }
 
@@ -68,7 +69,7 @@ class App extends Component {
 }
 
 App.propTypes = {
-  storeAppVersion: PropTypes.func,
+  saveAppVersion: PropTypes.func,
   currentSession: PropTypes.object,
   handleOffsetMenu: PropTypes.func,
   hasResource: PropTypes.bool,
@@ -83,14 +84,7 @@ const mapStateToProps = (state) => {
   }
 }
 
-const mapDispatchToProps = dispatch => ({
-  storeAppVersion: (version) => {
-    dispatch(saveAppVersion(version))
-  },
-  fetchResourceTemplateSummaries: () => {
-    dispatch(fetchResourceTemplateSummariesCreator())
-  },
-})
+const mapDispatchToProps = dispatch => bindActionCreators({ saveAppVersion, fetchResourceTemplateSummaries }, dispatch)
 
 /*
  * 2019-05-07: note that withRouter must wrap connect

--- a/src/components/editor/Editor.jsx
+++ b/src/components/editor/Editor.jsx
@@ -1,6 +1,7 @@
 // Copyright 2019 Stanford University see LICENSE for license
 
 import React from 'react'
+import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
 import { showRdfPreview } from 'actions/index'
@@ -21,7 +22,7 @@ const Editor = props => (
     <AuthenticationMessage />
     <div className="row">
       <section className="col-md-3" style={{ float: 'right', width: '320px' }}>
-        <button type="button" className="btn btn-link btn-sm btn-editor" onClick={ props.openRdfPreview }>Preview RDF</button>
+        <button type="button" className="btn btn-link btn-sm btn-editor" onClick={ () => props.showRdfPreview(true) }>Preview RDF</button>
         <SaveAndPublishButton id="editor-save" />
       </section>
     </div>
@@ -36,7 +37,7 @@ const Editor = props => (
 Editor.propTypes = {
   triggerHandleOffsetMenu: PropTypes.func,
   userWantsToSave: PropTypes.func,
-  openRdfPreview: PropTypes.func,
+  showRdfPreview: PropTypes.func,
   isSaved: PropTypes.bool,
   location: PropTypes.object,
   history: PropTypes.object,
@@ -48,11 +49,6 @@ const mapStateToProps = state => ({
   resourceHasChanges: resourceHasChangesSinceLastSave(state),
 })
 
-
-const mapDispatchToProps = dispatch => ({
-  openRdfPreview: () => {
-    dispatch(showRdfPreview(true))
-  },
-})
+const mapDispatchToProps = dispatch => bindActionCreators({ showRdfPreview }, dispatch)
 
 export default connect(mapStateToProps, mapDispatchToProps)(Editor)

--- a/src/components/editor/GroupChoiceModal.jsx
+++ b/src/components/editor/GroupChoiceModal.jsx
@@ -1,6 +1,7 @@
 // Copyright 2019 Stanford University see LICENSE for license
 
 import React, { useState } from 'react'
+import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
 import Button from 'react-bootstrap/lib/Button'
 import Modal from 'react-bootstrap/lib/Modal'
@@ -24,14 +25,14 @@ const GroupChoiceModal = (props) => {
   }
 
   const saveAndClose = () => {
-    props.publishMyResource(props.currentUser, selectedValue)
-    props.closeRdfPreview()
-    props.close()
+    props.publishResource(props.currentUser, selectedValue)
+    props.showRdfPreview(false)
+    props.closeGroupChooser(false)
   }
 
   return (
     <div>
-      <Modal show={ props.show } onHide={ props.close } bsSize="lg">
+      <Modal show={ props.show } onHide={ () => props.closeGroupChooser(false) } bsSize="lg">
         <Modal.Header className="prop-heading" closeButton>
           <Modal.Title>
             Which group do you want to save to?
@@ -47,7 +48,7 @@ const GroupChoiceModal = (props) => {
                 { groups.map((group, index) => <option key={index} value={ group[0] }>{ group[1] }</option>) }
               </select>
               <div className="group-choose-buttons">
-                <Button bsStyle="link" style={{ paddingRight: '20px' }} onClick={ props.close }>
+                <Button bsStyle="link" style={{ paddingRight: '20px' }} onClick={ () => props.closeGroupChooser(false) }>
                   Cancel
                 </Button>
                 <Button bsStyle="primary" bsSize="small" onClick={ saveAndClose }>
@@ -63,13 +64,13 @@ const GroupChoiceModal = (props) => {
 }
 
 GroupChoiceModal.propTypes = {
-  close: PropTypes.func,
-  closeRdfPreview: PropTypes.func,
+  closeGroupChooser: PropTypes.func,
+  showRdfPreview: PropTypes.func,
   choose: PropTypes.func,
   show: PropTypes.bool,
   rdf: PropTypes.func,
   currentUser: PropTypes.object,
-  publishMyResource: PropTypes.func,
+  publishResource: PropTypes.func,
 }
 
 const mapStateToProps = state => ({
@@ -78,16 +79,6 @@ const mapStateToProps = state => ({
   currentUser: getCurrentUser(state),
 })
 
-const mapDispatchToProps = dispatch => ({
-  close() {
-    dispatch(closeGroupChooser(false))
-  },
-  closeRdfPreview() {
-    dispatch(showRdfPreview(false))
-  },
-  publishMyResource: (user, group) => {
-    dispatch(publishResource(user, group))
-  },
-})
+const mapDispatchToProps = dispatch => bindActionCreators({ closeGroupChooser, showRdfPreview, publishResource }, dispatch)
 
 export default connect(mapStateToProps, mapDispatchToProps)(GroupChoiceModal)

--- a/src/components/editor/RDFModal.jsx
+++ b/src/components/editor/RDFModal.jsx
@@ -1,6 +1,7 @@
 // Copyright 2019 Stanford University see LICENSE for license
 
 import React from 'react'
+import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
 import Modal from 'react-bootstrap/lib/Modal'
 import Row from 'react-bootstrap/lib/Row'
@@ -16,7 +17,7 @@ const RDFModal = (props) => {
   }
 
   return (<div>
-    <Modal show={true} bsSize="lg" onHide={props.close}>
+    <Modal show={true} bsSize="lg" onHide={() => props.showRdfPreview(false)}>
       <Modal.Header closeButton>
         <Modal.Title>
           RDF Preview
@@ -37,9 +38,7 @@ const RDFModal = (props) => {
 
 RDFModal.propTypes = {
   show: PropTypes.bool,
-  close: PropTypes.func,
-  save: PropTypes.func,
-  rtId: PropTypes.string,
+  showRdfPreview: PropTypes.func,
   rdf: PropTypes.func,
 }
 
@@ -48,9 +47,6 @@ const mapStateToProps = state => ({
   rdf: () => new GraphBuilder(state.selectorReducer).graph.toCanonical(),
 })
 
-const mapDispatchToProps = dispatch => ({
-  close() {
-    dispatch(showRdfPreview(false))
-  },
-})
+const mapDispatchToProps = dispatch => bindActionCreators({ showRdfPreview }, dispatch)
+
 export default connect(mapStateToProps, mapDispatchToProps)(RDFModal)

--- a/src/components/editor/SaveAndPublishButton.jsx
+++ b/src/components/editor/SaveAndPublishButton.jsx
@@ -1,6 +1,7 @@
 // Copyright 2019 Stanford University see LICENSE for license
 
 import React from 'react'
+import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
 import Button from 'react-bootstrap/lib/Button'
@@ -9,16 +10,27 @@ import { rootResourceId, resourceHasChangesSinceLastSave } from 'selectors/resou
 import { getCurrentUser } from 'authSelectors'
 import { showGroupChooser } from 'actions/index'
 
-const SaveAndPublishButton = props => (
-  <Button id={ props.id } bsStyle="primary" bsSize="small" onClick={ props.save(props.isSaved, props.currentUser) } disabled={ props.isDisabled }>
-        Save & Publish
-  </Button>
-)
+const SaveAndPublishButton = (props) => {
+  const save = () => {
+    if (props.isSaved) {
+      props.update(props.currentUser)
+    } else {
+      props.showGroupChooser(true)
+    }
+  }
+
+  return (
+    <Button id={ props.id } bsStyle="primary" bsSize="small" onClick={ save } disabled={ props.isDisabled }>
+      Save & Publish
+    </Button>
+  )
+}
 
 SaveAndPublishButton.propTypes = {
   id: PropTypes.string,
   isDisabled: PropTypes.bool,
-  save: PropTypes.func,
+  update: PropTypes.func,
+  showGroupChooser: PropTypes.func,
   isSaved: PropTypes.bool,
   currentUser: PropTypes.object,
 }
@@ -29,15 +41,6 @@ const mapStateToProps = state => ({
   isDisabled: !resourceHasChangesSinceLastSave(state),
 })
 
-const mapDispatchToProps = dispatch => ({
-  save: (isSaved, user) => () => {
-    if (isSaved) {
-      dispatch(update(user))
-    } else {
-      dispatch(showGroupChooser(true))
-    }
-  },
-})
-
+const mapDispatchToProps = dispatch => bindActionCreators({ update, showGroupChooser }, dispatch)
 
 export default connect(mapStateToProps, mapDispatchToProps)(SaveAndPublishButton)

--- a/src/components/editor/property/InputListLOC.jsx
+++ b/src/components/editor/property/InputListLOC.jsx
@@ -4,6 +4,7 @@ import React, { Component } from 'react'
 import { Typeahead } from 'react-bootstrap-typeahead'
 import PropTypes from 'prop-types'
 import SinopiaPropTypes from 'SinopiaPropTypes'
+import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
 import shortid from 'shortid'
 import { changeSelections } from 'actions/index'
@@ -43,7 +44,7 @@ class InputListLOC extends Component {
       reduxPath: this.props.reduxPath,
     }
 
-    this.props.handleSelectedChange(payload)
+    this.props.changeSelections(payload)
   }
 
   get isMandatory() {
@@ -139,7 +140,7 @@ class InputListLOC extends Component {
 InputListLOC.propTypes = {
   defaults: PropTypes.arrayOf(PropTypes.object),
   displayValidations: PropTypes.bool,
-  handleSelectedChange: PropTypes.func,
+  changeSelections: PropTypes.func,
   lookupConfig: PropTypes.arrayOf(PropTypes.object),
   propertyTemplate: SinopiaPropTypes.propertyTemplate,
   reduxPath: PropTypes.array,
@@ -166,10 +167,6 @@ const mapStateToProps = (state, ownProps) => {
   }
 }
 
-const mapDispatchToProps = dispatch => ({
-  handleSelectedChange(selected) {
-    dispatch(changeSelections(selected))
-  },
-})
+const mapDispatchToProps = dispatch => bindActionCreators({ changeSelections }, dispatch)
 
 export default connect(mapStateToProps, mapDispatchToProps)(InputListLOC)

--- a/src/components/editor/property/InputLiteral.jsx
+++ b/src/components/editor/property/InputLiteral.jsx
@@ -3,6 +3,7 @@
 import React, { useRef, useState } from 'react'
 import PropTypes from 'prop-types'
 import SinopiaPropTypes from 'SinopiaPropTypes'
+import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
 import shortid from 'shortid'
 import { itemsSelected } from 'actions/index'
@@ -38,7 +39,7 @@ const InputLiteral = (props) => {
         [shortid.generate()]: { content: currentcontent, lang },
       },
     }
-    props.handleMyItemsChange(userInput)
+    props.itemsSelected(userInput)
     setContent('')
     setLang(defaultLanguageId)
   }
@@ -95,7 +96,7 @@ InputLiteral.propTypes = {
   propertyTemplate: SinopiaPropTypes.propertyTemplate,
   errors: PropTypes.array,
   items: PropTypes.object,
-  handleMyItemsChange: PropTypes.func,
+  itemsSelected: PropTypes.func,
   reduxPath: PropTypes.array.isRequired,
   displayValidations: PropTypes.bool,
 }
@@ -119,10 +120,6 @@ const mapStateToProps = (state, ownProps) => {
   }
 }
 
-const mapDispatchToProps = dispatch => ({
-  handleMyItemsChange(userInput) {
-    dispatch(itemsSelected(userInput))
-  },
-})
+const mapDispatchToProps = dispatch => bindActionCreators({ itemsSelected }, dispatch)
 
 export default connect(mapStateToProps, mapDispatchToProps)(InputLiteral)

--- a/src/components/editor/property/InputLookupQA.jsx
+++ b/src/components/editor/property/InputLookupQA.jsx
@@ -10,6 +10,7 @@ import PropTypes from 'prop-types'
 import SinopiaPropTypes from 'SinopiaPropTypes'
 import Swagger from 'swagger-client'
 import swaggerSpec from 'lib/apidoc.json'
+import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
 import {
   itemsForProperty, getDisplayValidations, getPropertyTemplate, findErrors,
@@ -258,7 +259,7 @@ class InputLookupQA extends Component {
                             reduxPath: this.props.reduxPath,
                           }
 
-                          this.props.handleSelectedChange(payload)
+                          this.props.changeSelections(payload)
                         }}
                         renderToken={(option, props, idx) => this.renderTokenFunc(option, props, idx)}
                         {...typeaheadProps}
@@ -274,7 +275,7 @@ class InputLookupQA extends Component {
 
 InputLookupQA.propTypes = {
   displayValidations: PropTypes.bool,
-  handleSelectedChange: PropTypes.func,
+  changeSelections: PropTypes.func,
   lookupConfig: PropTypes.arrayOf(PropTypes.object).isRequired,
   propertyTemplate: SinopiaPropTypes.propertyTemplate,
   reduxPath: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
@@ -302,10 +303,6 @@ const mapStateToProps = (state, ownProps) => {
   }
 }
 
-const mapDispatchToProps = dispatch => ({
-  handleSelectedChange(selected) {
-    dispatch(changeSelections(selected))
-  },
-})
+const mapDispatchToProps = dispatch => bindActionCreators({ changeSelections }, dispatch)
 
 export default connect(mapStateToProps, mapDispatchToProps)(InputLookupQA)

--- a/src/components/editor/property/InputLookupSinopia.jsx
+++ b/src/components/editor/property/InputLookupSinopia.jsx
@@ -5,6 +5,7 @@ import { Typeahead, asyncContainer } from 'react-bootstrap-typeahead'
 import PropTypes from 'prop-types'
 import SinopiaPropTypes from 'SinopiaPropTypes'
 import Config from 'Config'
+import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
 import {
   itemsForProperty, getDisplayValidations, getPropertyTemplate, findErrors,
@@ -49,7 +50,7 @@ const InputLookupSinopia = (props) => {
       reduxPath: props.reduxPath,
     }
 
-    props.handleSelectedChange(payload)
+    props.changeSelections(payload)
   }
 
   // From https://github.com/ericgio/react-bootstrap-typeahead/issues/389
@@ -91,7 +92,7 @@ const InputLookupSinopia = (props) => {
 
 InputLookupSinopia.propTypes = {
   displayValidations: PropTypes.bool,
-  handleSelectedChange: PropTypes.func,
+  changeSelections: PropTypes.func,
   propertyTemplate: SinopiaPropTypes.propertyTemplate,
   reduxPath: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
   selected: PropTypes.arrayOf(PropTypes.object),
@@ -116,10 +117,6 @@ const mapStateToProps = (state, ownProps) => {
   }
 }
 
-const mapDispatchToProps = dispatch => ({
-  handleSelectedChange(selected) {
-    dispatch(changeSelections(selected))
-  },
-})
+const mapDispatchToProps = dispatch => bindActionCreators({ changeSelections }, dispatch)
 
 export default connect(mapStateToProps, mapDispatchToProps)(InputLookupSinopia)

--- a/src/components/editor/property/InputURI.jsx
+++ b/src/components/editor/property/InputURI.jsx
@@ -3,6 +3,7 @@
 import React, { useRef, useState } from 'react'
 import PropTypes from 'prop-types'
 import SinopiaPropTypes from 'SinopiaPropTypes'
+import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
 import shortid from 'shortid'
 import { itemsSelected } from 'actions/index'
@@ -42,7 +43,7 @@ const InputURI = (props) => {
       },
     }
 
-    props.handleMyItemsChange(userInput)
+    props.itemsSelected(userInput)
     setContent('')
   }
 
@@ -112,8 +113,7 @@ const InputURI = (props) => {
 InputURI.propTypes = {
   propertyTemplate: SinopiaPropTypes.propertyTemplate,
   items: PropTypes.object,
-  handleMyItemsChange: PropTypes.func,
-  handleRemoveItem: PropTypes.func,
+  itemsSelected: PropTypes.func,
   reduxPath: PropTypes.array.isRequired,
   displayValidations: PropTypes.bool,
   errors: PropTypes.array,
@@ -137,10 +137,6 @@ const mapStateToProps = (state, props) => {
   }
 }
 
-const mapDispatchToProps = dispatch => ({
-  handleMyItemsChange(userInput) {
-    dispatch(itemsSelected(userInput))
-  },
-})
+const mapDispatchToProps = dispatch => bindActionCreators({ itemsSelected }, dispatch)
 
 export default connect(mapStateToProps, mapDispatchToProps)(InputURI)

--- a/src/components/editor/property/LanguageButton.jsx
+++ b/src/components/editor/property/LanguageButton.jsx
@@ -2,6 +2,7 @@
 
 import React, { useState } from 'react'
 import PropTypes from 'prop-types'
+import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
 import Modal from 'react-bootstrap/lib/Modal'
 import Button from 'react-bootstrap/lib/Button'
@@ -19,7 +20,7 @@ const LanguageButton = (props) => {
   }
 
   const handleLangSubmit = () => {
-    props.handleMyItemsLangChange(langPayload)
+    props.languageSelected(langPayload)
     handleClose()
   }
 
@@ -54,7 +55,7 @@ const LanguageButton = (props) => {
 }
 
 LanguageButton.propTypes = {
-  handleMyItemsLangChange: PropTypes.func,
+  languageSelected: PropTypes.func,
   reduxPath: PropTypes.array.isRequired,
   language: PropTypes.string.isRequired,
 }
@@ -66,10 +67,6 @@ const mapStateToProps = (state, ourProps) => {
   }
 }
 
-const mapDispatchToProps = dispatch => ({
-  handleMyItemsLangChange(payload) {
-    dispatch(languageSelected(payload))
-  },
-})
+const mapDispatchToProps = dispatch => bindActionCreators({ languageSelected }, dispatch)
 
 export default connect(mapStateToProps, mapDispatchToProps)(LanguageButton)

--- a/src/components/editor/property/PropertyActionButtons.jsx
+++ b/src/components/editor/property/PropertyActionButtons.jsx
@@ -2,9 +2,10 @@
 
 import React from 'react'
 import PropTypes from 'prop-types'
+import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
-import { addResource as addResourceCreator } from 'actionCreators/resources'
-import { removeResource as removeResourceAction } from 'actions/index'
+import { addResource } from 'actionCreators/resources'
+import { removeResource } from 'actions/index'
 import { getResourceTemplate } from 'selectors/resourceSelectors'
 
 const PropertyActionButtons = (props) => {
@@ -15,7 +16,7 @@ const PropertyActionButtons = (props) => {
 
   const handleRemoveClick = (event) => {
     event.preventDefault()
-    props.removeResource(props.reduxPath)
+    props.removeResource(props.reduxPath.slice(0, props.reduxPath.length - 1))
   }
 
   return (<div className="btn-group" role="group" aria-label="...">
@@ -48,13 +49,6 @@ const mapStateToProps = (state, ownProps) => {
   }
 }
 
-const mapDispatchToProps = dispatch => ({
-  addResource(reduxPath) {
-    dispatch(addResourceCreator(reduxPath))
-  },
-  removeResource(reduxPath) {
-    dispatch(removeResourceAction(reduxPath.slice(0, reduxPath.length - 1)))
-  },
-})
+const mapDispatchToProps = dispatch => bindActionCreators({ addResource, removeResource }, dispatch)
 
 export default connect(mapStateToProps, mapDispatchToProps)(PropertyActionButtons)

--- a/src/components/editor/property/PropertyPanel.jsx
+++ b/src/components/editor/property/PropertyPanel.jsx
@@ -4,6 +4,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import PropertyLabel from './PropertyLabel'
 import PropertyLabelInfo from './PropertyLabelInfo'
+import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
 import { findNode, getPropertyTemplate } from 'selectors/resourceSelectors'
 import { removeResource } from 'actions/index'
@@ -21,12 +22,12 @@ const PropertyPanel = (props) => {
         <PropertyLabel propertyTemplate={ props.propertyTemplate } />
         <PropertyLabelInfo propertyTemplate={ props.propertyTemplate } />{nbsp}
         { isAdd && (
-          <button type="button" className="btn btn-sm btn-primary btn-add" onClick={props.handleAddButton} data-id={props.id}>
+          <button type="button" className="btn btn-sm btn-primary btn-add" onClick={() => props.expandResource(props.reduxPath)} data-id={props.id}>
             + Add
           </button>
         )}
         { !isAdd && !isMandatory && (
-          <button type="button" className="btn btn-sm btn-primary btn-remove" onClick={props.handleRemoveButton} data-id={props.id}>
+          <button type="button" className="btn btn-sm btn-primary btn-remove" onClick={() => props.removeResource(props.reduxPath)} data-id={props.id}>
             Remove
           </button>
         )}
@@ -47,8 +48,8 @@ PropertyPanel.propTypes = {
   resourceModel: PropTypes.object,
   propertyTemplate: PropTypes.object,
   id: PropTypes.string,
-  handleAddButton: PropTypes.func,
-  handleRemoveButton: PropTypes.func,
+  expandResource: PropTypes.func,
+  removeResource: PropTypes.func,
 }
 
 const mapStateToProps = (state, ourProps) => {
@@ -63,16 +64,6 @@ const mapStateToProps = (state, ourProps) => {
   }
 }
 
-const mapDispatchToProps = (dispatch, ownProps) => ({
-  handleAddButton: (event) => {
-    event.preventDefault()
-    dispatch(expandResource(ownProps.reduxPath))
-  },
-  handleRemoveButton: (event) => {
-    event.preventDefault()
-    dispatch(removeResource(ownProps.reduxPath))
-  },
-
-})
+const mapDispatchToProps = dispatch => bindActionCreators({ expandResource, removeResource }, dispatch)
 
 export default connect(mapStateToProps, mapDispatchToProps)(PropertyPanel)

--- a/src/components/load/LoadByRDFForm.jsx
+++ b/src/components/load/LoadByRDFForm.jsx
@@ -1,9 +1,10 @@
 // Copyright 2019 Stanford University see LICENSE for license
 
 import React, { useState, useEffect } from 'react'
+import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
-import { existingResource as existingResourceCreator } from 'actionCreators/resources'
+import { existingResource } from 'actionCreators/resources'
 import ResourceStateBuilder from 'ResourceStateBuilder'
 import { rdfDatasetFromN3 } from 'Utilities'
 import { getCurrentUser } from 'authSelectors'
@@ -24,9 +25,16 @@ const LoadByRDFForm = (props) => {
     }
   })
 
+  const existingResource = () => {
+    rdfDatasetFromN3(resourceN3).then((dataset) => {
+      const builder = new ResourceStateBuilder(dataset, baseUri)
+      props.existingResource(builder.state)
+    })
+  }
+
   const handleSubmit = (event) => {
     if (resourceN3 !== '') {
-      props.existingResource(resourceN3, baseUri)
+      existingResource()
       setNavigateEditor(true)
     }
     event.preventDefault()
@@ -56,20 +64,11 @@ LoadByRDFForm.propTypes = {
   rootResource: PropTypes.object,
 }
 
-const mapDispatchToProps = dispatch => ({
-  existingResource: (resourceN3, baseUri) => {
-    rdfDatasetFromN3(resourceN3).then((dataset) => {
-      const builder = new ResourceStateBuilder(dataset, baseUri)
-      const resource = builder.state
-      dispatch(existingResourceCreator(resource))
-    })
-  },
-})
-
 const mapStateToProps = state => ({
   currentUser: getCurrentUser(state),
   rootResource: rootResource(state),
 })
 
+const mapDispatchToProps = dispatch => bindActionCreators({ existingResource }, dispatch)
 
 export default connect(mapStateToProps, mapDispatchToProps)(LoadByRDFForm)

--- a/src/components/load/LoadByURIForm.jsx
+++ b/src/components/load/LoadByURIForm.jsx
@@ -1,6 +1,7 @@
 // Copyright 2019 Stanford University see LICENSE for license
 
 import React, { useState, useEffect } from 'react'
+import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
 import { retrieveResource } from 'actionCreators/resources'
@@ -22,7 +23,7 @@ const LoadByURIForm = (props) => {
 
   const handleSubmit = (event) => {
     if (uri !== '') {
-      props.loadResource(props.currentUser, uri)
+      props.retrieveResource(props.currentUser, uri)
       setNavigateEditor(true)
     }
     event.preventDefault()
@@ -44,22 +45,17 @@ const LoadByURIForm = (props) => {
 
 
 LoadByURIForm.propTypes = {
-  loadResource: PropTypes.func,
+  retrieveResource: PropTypes.func,
   history: PropTypes.object,
   currentUser: PropTypes.object,
   rootResource: PropTypes.object,
 }
-
-const mapDispatchToProps = dispatch => ({
-  loadResource: (user, uri) => {
-    dispatch(retrieveResource(user, uri))
-  },
-})
 
 const mapStateToProps = state => ({
   currentUser: getCurrentUser(state),
   rootResource: rootResource(state),
 })
 
+const mapDispatchToProps = dispatch => bindActionCreators({ retrieveResource }, dispatch)
 
 export default connect(mapStateToProps, mapDispatchToProps)(LoadByURIForm)

--- a/src/components/search/Search.jsx
+++ b/src/components/search/Search.jsx
@@ -1,6 +1,7 @@
 // Copyright 2019 Stanford University see LICENSE for license
 
 import React, { useState } from 'react'
+import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
 import Header from '../Header'
@@ -18,7 +19,7 @@ const Search = (props) => {
 
   const handleKeyPress = (event) => {
     if (event.key === 'Enter') {
-      props.retrieveSearchResults(queryString)
+      props.fetchSearchResults(queryString)
       event.preventDefault()
     }
   }
@@ -47,14 +48,10 @@ const Search = (props) => {
 
 Search.propTypes = {
   triggerHandleOffsetMenu: PropTypes.func,
-  retrieveSearchResults: PropTypes.func,
+  fetchSearchResults: PropTypes.func,
   currentUser: PropTypes.object,
 }
 
-const mapDispatchToProps = dispatch => ({
-  retrieveSearchResults: (queryString) => {
-    dispatch(fetchSearchResults(queryString))
-  },
-})
+const mapDispatchToProps = dispatch => bindActionCreators({ fetchSearchResults }, dispatch)
 
 export default connect(null, mapDispatchToProps)(Search)

--- a/src/components/search/SearchResults.jsx
+++ b/src/components/search/SearchResults.jsx
@@ -3,6 +3,7 @@
 /* eslint max-params: ["error", 4] */
 
 import React, { useState, useEffect } from 'react'
+import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
 import Config from 'Config'
@@ -18,7 +19,7 @@ const SearchResults = (props) => {
   const [navigateEditor, setNavigateEditor] = useState(false)
 
   const handleClick = (resourceURI) => {
-    props.loadResource(props.currentUser, resourceURI)
+    props.retrieveResource(props.currentUser, resourceURI)
     setNavigateEditor(true)
   }
 
@@ -71,7 +72,7 @@ const SearchResults = (props) => {
 
 SearchResults.propTypes = {
   searchResults: PropTypes.array,
-  loadResource: PropTypes.func,
+  retrieveResource: PropTypes.func,
   currentUser: PropTypes.object,
   history: PropTypes.object,
   rootResource: PropTypes.object,
@@ -83,10 +84,6 @@ const mapStateToProps = state => ({
   rootResource: rootResource(state),
 })
 
-const mapDispatchToProps = (dispatch, ourProps) => ({
-  loadResource: (user, uri) => {
-    dispatch(retrieveResource(user, uri))
-  },
-})
+const mapDispatchToProps = dispatch => bindActionCreators({ retrieveResource }, dispatch)
 
 export default connect(mapStateToProps, mapDispatchToProps)(SearchResults)

--- a/src/components/search/SearchResultsPaging.jsx
+++ b/src/components/search/SearchResultsPaging.jsx
@@ -1,6 +1,7 @@
 // Copyright 2019 Stanford University see LICENSE for license
 
 import React, { useState } from 'react'
+import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
 import Config from 'Config'
@@ -51,7 +52,7 @@ const SearchResultsPaging = (props) => {
     }
     queryFrom = (newCurrentPage - 1) * Config.searchResultsPerPage
     setCurrentPage(newCurrentPage)
-    props.retrieveSearchResults(props.queryString, queryFrom)
+    props.fetchSearchResults(props.queryString, queryFrom)
   }
 
   const lastPage = () => props.totalResults / Config.searchResultsPerPage
@@ -81,7 +82,7 @@ const SearchResultsPaging = (props) => {
 SearchResultsPaging.propTypes = {
   totalResults: PropTypes.number,
   queryString: PropTypes.string,
-  retrieveSearchResults: PropTypes.func,
+  fetchSearchResults: PropTypes.func,
 }
 
 const mapStateToProps = state => ({
@@ -89,10 +90,6 @@ const mapStateToProps = state => ({
   queryString: state.selectorReducer.search.query,
 })
 
-const mapDispatchToProps = dispatch => ({
-  retrieveSearchResults: (queryString, queryFrom) => {
-    dispatch(fetchSearchResults(queryString, queryFrom))
-  },
-})
+const mapDispatchToProps = dispatch => bindActionCreators({ fetchSearchResults }, dispatch)
 
 export default connect(mapStateToProps, mapDispatchToProps)(SearchResultsPaging)

--- a/src/components/templates/ImportResourceTemplate.jsx
+++ b/src/components/templates/ImportResourceTemplate.jsx
@@ -1,8 +1,8 @@
-
 // Copyright 2019 Stanford University see LICENSE for license
 
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
+import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
 import Header from '../Header'
 import ImportFileZone from './ImportFileZone'
@@ -10,7 +10,7 @@ import SinopiaResourceTemplates from './SinopiaResourceTemplates'
 import UpdateResourceModal from './UpdateResourceModal'
 import { createResourceTemplate, updateResourceTemplate } from 'sinopiaServer'
 import { getCurrentUser } from 'authSelectors'
-import { fetchResourceTemplateSummaries as fetchResourceTemplateSummariesCreator } from 'actionCreators/resourceTemplates'
+import { fetchResourceTemplateSummaries } from 'actionCreators/resourceTemplates'
 
 class ImportResourceTemplate extends Component {
   constructor(props) {
@@ -171,9 +171,6 @@ const mapStateToProps = state => ({
   currentUser: getCurrentUser(state),
 })
 
-const mapDispatchToProps = dispatch => ({
-  fetchResourceTemplateSummaries: () => {
-    dispatch(fetchResourceTemplateSummariesCreator())
-  },
-})
+const mapDispatchToProps = dispatch => bindActionCreators({ fetchResourceTemplateSummaries }, dispatch)
+
 export default connect(mapStateToProps, mapDispatchToProps)(ImportResourceTemplate)

--- a/src/components/templates/SinopiaResourceTemplates.jsx
+++ b/src/components/templates/SinopiaResourceTemplates.jsx
@@ -6,8 +6,9 @@ import { Link } from 'react-router-dom'
 import 'react-bootstrap-table-next/dist/react-bootstrap-table2.min.css'
 import BootstrapTable from 'react-bootstrap-table-next'
 import Download from 'components/templates/Download'
+import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
-import { newResource as newResourceCreator } from 'actionCreators/resources'
+import { newResource } from 'actionCreators/resources'
 import { rootResource } from 'selectors/resourceSelectors'
 
 /**
@@ -141,10 +142,6 @@ const mapStateToProps = (state) => {
   }
 }
 
-const mapDispatchToProps = dispatch => ({
-  newResource: (resourceTemplateId) => {
-    dispatch(newResourceCreator(resourceTemplateId))
-  },
-})
+const mapDispatchToProps = dispatch => bindActionCreators({ newResource }, dispatch)
 
 export default connect(mapStateToProps, mapDispatchToProps)(SinopiaResourceTemplates)


### PR DESCRIPTION
This reduces the amount of indirection around function names and makes it easer to follow the logic