### PR TITLE
Reverts change to title field for searches

### DIFF
--- a/src/sinopiaServer.js
+++ b/src/sinopiaServer.js
@@ -190,7 +190,7 @@ export const getSearchResults = async (query, queryFrom = 0) => {
       totalHits: json.hits.total,
       results: json.hits.hits.map(row => ({
         uri: row._id,
-        title: row._source.label,
+        title: row._source.title,
       })),
     }))
     .catch(error => console.error(error))


### PR DESCRIPTION
fixes #1171 

This change from #1165 doesn't appear to have changed the results from a title & subtitle search, so `title` is still required.