### PR TITLE
Fixed proptype for InputLookupQA.

### DIFF
--- a/src/components/editor/property/InputLookupQA.jsx
+++ b/src/components/editor/property/InputLookupQA.jsx
@@ -218,7 +218,7 @@ InputLookupQA.propTypes = {
   search: PropTypes.func,
   errors: PropTypes.array,
   isLoading: PropTypes.bool.isRequired,
-  options: PropTypes.object,
+  options: PropTypes.arrayOf(PropTypes.object),
 }
 
 const mapStateToProps = (state, ownProps) => {


### PR DESCRIPTION
To fix:
```
Warning: Failed prop type: Invalid prop `options` of type `array` supplied to `InputLookupQA`, expected `object`.
    in InputLookupQA (created by Context.Consumer)
    in Connect(InputLookupQA) (created by PropertyComponent)
    in Suspense (created by PropertyComponent)
    in PropertyComponent (created by ResourceTemplateForm)
    in div (created by PropertyPanel)
    in div (created by PropertyPanel)
    in PropertyPanel (created by Context.Consumer)
    in Connect(PropertyPanel) (created by ResourceTemplateForm)
    in div (created by ResourceTemplateForm)
    in form (created by ResourceTemplateForm)
    in div (created by ResourceTemplateForm)
    in ResourceTemplateForm (created by Context.Consumer)
    in Connect(ResourceTemplateForm) (created by ResourceTemplate)
    in div (created by ResourceTemplate)
    in div (created by ResourceTemplate)
    in ResourceTemplate (created by Context.Consumer)
    in Connect(ResourceTemplate) (created by Editor)
    in div (created by Editor)
    in Editor (created by Context.Consumer)
    in Connect(Editor) (created by Route)
    in Route (created by App)
    in Switch (created by App)
    in div (created by App)
    in App (created by Context.Consumer)
    in Connect(App) (created by Route)
    in Route (created by withRouter(Connect(App)))
    in withRouter(Connect(App)) (created by RootContainer)
    in Provider (created by RootContainer)
    in Router (created by BrowserRouter)
    in BrowserRouter (created by RootContainer)
    in div
    in OffCanvasBody (created by RootContainer)
    in div
    in OffCanvas (created by RootContainer)
    in div (created by RootContainer)
    in RootContainer (created by HotExportedRootContainer)
    in AppContainer (created by HotExportedRootContainer)
    in HotExportedRootContainer checkPropTypes.js:19:15
```