### PR TITLE
#1200 handle objects in context

### DIFF
--- a/__tests__/__fixtures__/MonographInstance.json
+++ b/__tests__/__fixtures__/MonographInstance.json
@@ -163,7 +163,8 @@
         "valueTemplateRefs": [],
         "useValuesFrom": [
           "urn:ld4p:qa:names:person",
-          "urn:ld4p:qa:subjects"
+          "urn:ld4p:qa:subjects",
+          "urn:ld4p:qa:genres"
         ],
         "valueDataType": {
           "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Agent"

--- a/__tests__/__fixtures__/MonographInstance.json
+++ b/__tests__/__fixtures__/MonographInstance.json
@@ -163,7 +163,7 @@
         "valueTemplateRefs": [],
         "useValuesFrom": [
           "urn:ld4p:qa:names:person",
-          "urn:ld4p:qa:subjects",
+          "urn:ld4p:qa:subjects"
         ],
         "valueDataType": {
           "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Agent"

--- a/__tests__/__fixtures__/MonographInstance.json
+++ b/__tests__/__fixtures__/MonographInstance.json
@@ -164,7 +164,6 @@
         "useValuesFrom": [
           "urn:ld4p:qa:names:person",
           "urn:ld4p:qa:subjects",
-          "urn:ld4p:qa:genres"
         ],
         "valueDataType": {
           "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Agent"

--- a/__tests__/components/editor/property/RenderLookupContext.test.js
+++ b/__tests__/components/editor/property/RenderLookupContext.test.js
@@ -80,6 +80,24 @@ const discogsResult = {
 
 }
 
+const genreResult = {
+  uri: 'http://id.loc.gov/authorities/genreForms/gf2011026181',
+  id: 'gf2011026181',
+  label: 'Cutout animation films',
+  context: [
+    {
+      property: 'Broader',
+      values: [
+        {
+          uri: 'http://id.loc.gov/authorities/genreForms/gf2011026049',
+          id: 'gf2011026049',
+          label: 'Animated films',
+        },
+      ],
+    },
+  ],
+}
+
 const plProps = {
   authURI: 'urn:ld4p:qa:names:person',
   authLabel: 'LOC person [names] (QA)',
@@ -98,6 +116,13 @@ const p3Props = {
   authURI: 'urn:discogs',
   authLabel: 'Discogs',
   innerResult: discogsResult,
+  colorClassName: 'context-result-bg',
+}
+
+const p4Props = {
+  authURI: 'urn:ld4p:qa:genres',
+  authLabel: 'LOC Genre Forms',
+  innerResult: genreResult,
   colorClassName: 'context-result-bg',
 }
 
@@ -137,5 +162,13 @@ describe('<RenderLookupContext />', () => {
     expect(discogsDetailsContainer.contains('Reprise Records')).toEqual(true)
     expect(discogsDetailsContainer.contains('Vinyl')).toEqual(true)
     expect(discogsDetailsContainer.find('.type-span').contains('Master')).toEqual(true)
+  })
+
+  const genreWrapper = shallow(<RenderLookupContext.WrappedComponent {...p4Props} />)
+  it('displays nested object label', () => {
+    const genreContainer = genreWrapper.find('.details-container')
+    const genreDetails = genreContainer.at(1)
+    expect(genreDetails.find('.context-field').contains('Broader')).toEqual(true)
+    expect(genreDetails.contains('Animated films')).toEqual(true)
   })
 })

--- a/src/components/editor/property/RenderLookupContext.jsx
+++ b/src/components/editor/property/RenderLookupContext.jsx
@@ -68,12 +68,8 @@ class RenderLookupContext extends Component {
      const property = contextResult.property
      // if property is one of the possible main label values don't show it
      if (mainLabelProperty.indexOf(property.toLowerCase()) < 0) {
-       const values = contextResult.values
-       // const values = [contextResult.value] //hack for wikidata, to be removed later
        const innerDivKey = `c${index}`
-       if (values.length) {
-         return (<div className="details-container" key={innerDivKey}> <span className="context-field">{property}</span>: {values.join(', ')} </div>)
-       }
+       return this.displayValues(contextResult.values, innerDivKey, property)
      }
    })
    return contextContent
@@ -85,14 +81,31 @@ class RenderLookupContext extends Component {
    const propertyOrder = authorityToContextOrderMap[authURI]
    const contextContent = propertyOrder.map((property, index) => {
      if (property in contextHash) {
-       const values = contextHash[property].values
        const innerDivKey = `c${index}`
-       if (values.length) {
-         return (<div className="details-container" key={innerDivKey}> <span className="context-field">{property}</span>: {values.join(', ')} </div>)
-       }
+       return this.displayValues(contextHash[property].values, innerDivKey, property)
      }
    })
    return contextContent
+ }
+
+ displayValues = (values, innerDivKey, property) => {
+   const valuesDisplay = this.generateValuesView(values)
+   if (valuesDisplay.length) {
+     return (<div className="details-container" key={innerDivKey}> <span className="context-field">{property}</span>: {valuesDisplay} </div>)
+   }
+ }
+
+ // Handle both string and object value
+ generateValuesView = (values) => {
+   const valuesDisplay = values.map((value) => {
+     if (typeof value === 'object') {
+       if ('label' in value) return value.label
+       if ('uri' in value) return value.uri
+       return JSON.stringify(value)
+     }
+     return value
+   })
+   return valuesDisplay.join(', ')
  }
 
  render() {


### PR DESCRIPTION
Updating context rendering component to handle objects that come back as values in context.
For example, broader concepts in genre form lookup come back as
values": [
    {
        "uri": "http://id.loc.gov/authorities/genreForms/gf2011026049",
        "id": "gf2011026049",
        "label": "Animated films"
    }
]

The code now looks for "label" in the value object and displays that.  If there is no label but there is a uri, it will display that instead, and if neither, then it will display a stringified version of the json object 