### PR TITLE
Removes LOC orgs from Config

### DIFF
--- a/static/lookupConfig.json
+++ b/static/lookupConfig.json
@@ -962,10 +962,5 @@
     "label": "type of recording",
     "uri": "https://id.loc.gov/vocabulary/mrectype",
     "component": "list"
-  },
-  {
-    "label": "code list for cultural heritage organizations",
-    "uri": "https://id.loc.gov/vocabulary/organizations",
-    "component": "list"
   }
 ]


### PR DESCRIPTION
The  authority for https://id.loc.gov/vocabulary/organizations no longer returns the expected JSON list of codes expected by the `InputListLOC` component.

For #1208 