### PR TITLE
Authorities in QA always request context

### DIFF
--- a/__tests__/utilities/qa.test.js
+++ b/__tests__/utilities/qa.test.js
@@ -1,17 +1,6 @@
 // Copyright 2019 Stanford University see LICENSE for license
 
-import getSearchResults, { isContext } from 'utilities/qa'
-
-describe('isContext()', () => {
-  // check context property is picked up and when property is not present, method returns false
-  it('detects context subproperty in resource template', () => {
-    expect(isContext({ subtype: 'context' })).toEqual(true)
-  })
-
-  it('detects absence of context subproperty in resource template', () => {
-    expect(isContext({})).toBeFalsy()
-  })
-})
+import getSearchResults from 'utilities/qa'
 
 describe('getSearchResults()', () => {
   const template = {

--- a/src/utilities/qa.js
+++ b/src/utilities/qa.js
@@ -11,7 +11,7 @@ const getSearchResults = (query, propertyTemplate) => Swagger({ spec: swaggerSpe
     const lookupConfigs = getLookupConfigItems(propertyTemplate)
 
     // Create array of promises based on the lookup config array that is sent in
-    const lookupPromises = createLookupPromises(client, query, lookupConfigs, isContext(propertyTemplate))
+    const lookupPromises = createLookupPromises(client, query, lookupConfigs)
 
     /*
      * If undefined, add info - note if error, error object returned in object
@@ -35,7 +35,7 @@ const getSearchResults = (query, propertyTemplate) => Swagger({ spec: swaggerSpe
 
 export const isContext = propertyTemplate => propertyTemplate?.subtype === 'context'
 
-export const createLookupPromises = (client, query, lookupConfigs, context) => lookupConfigs.map((lookupConfig) => {
+export const createLookupPromises = (client, query, lookupConfigs) => lookupConfigs.map((lookupConfig) => {
   const authority = lookupConfig.authority
   const subauthority = lookupConfig.subauthority
   const language = lookupConfig.language
@@ -74,7 +74,7 @@ export const createLookupPromises = (client, query, lookupConfigs, context) => l
       subauthority,
       maxRecords: Config.maxRecordsForQALookups,
       lang: language,
-      context,
+      context: true, // Always search to see if context is available
     })
     .catch((err) => {
       console.error('Error in executing lookup against source', err)


### PR DESCRIPTION
If the QA authority doesn't support context still returning expected results. The `InputLookupQA` component handles the presence of context property in the returned result.  Setting this parameter in the Swagger client to always true may have an impact performance but it also means we don't have to set a context property in each authority in `lookupConfig`. 

Closes #1338 