### PR TITLE
Lookup sinopia literal

### DIFF
--- a/__tests__/components/editor/property/InputLookupQA.test.js
+++ b/__tests__/components/editor/property/InputLookupQA.test.js
@@ -2,7 +2,8 @@
 
 import React from 'react'
 import { shallow } from 'enzyme'
-import InputLookupQA, { renderMenuFunc, renderTokenFunc } from 'components/editor/property/InputLookupQA'
+import InputLookupQA from 'components/editor/property/InputLookupQA'
+import { renderMenuFunc, renderTokenFunc } from 'components/editor/property/renderTypeaheadFunctions'
 
 const plProps = {
   id: 'lookupComponent',

--- a/__tests__/components/editor/property/InputLookupSinopia.test.js
+++ b/__tests__/components/editor/property/InputLookupSinopia.test.js
@@ -4,6 +4,7 @@ import 'isomorphic-fetch'
 import React from 'react'
 import { shallow } from 'enzyme'
 import InputLookupSinopia from 'components/editor/property/InputLookupSinopia'
+import { renderMenuFunc, renderTokenFunc } from 'components/editor/property/renderTypeaheadFunctions'
 
 const plProps = {
   id: 'sinopia-lookup',
@@ -37,6 +38,21 @@ const plProps = {
     },
   ],
 }
+
+const multipleResults = [
+  { uri: 'https://sinopia.io/repository/test/abcdefg', label: 'Blue hat, green hat' },
+  { customOption: true, id: 'new-id-18', label: 'blue' },
+]
+
+const validNewURIResults = [{
+  customOption: true,
+  label: 'https://sinopia.io/repository/test/hijklmnop',
+}]
+
+const validNewLiteralResults = [{
+  customOption: true,
+  label: 'Some non URI string',
+}]
 
 describe('<InputLookupSinopia />', () => {
   const wrapper = shallow(<InputLookupSinopia.WrappedComponent {...plProps} />)
@@ -103,7 +119,67 @@ describe('<InputLookupSinopia />', () => {
       // Ideally we'd test that the sinopia-lookup props options are set, but I
       // don't know how to do this with enzyme and hooks.
     })
+
+    it('links the tokens when there is a URI', () => {
+      const option = {
+        uri: 'http://sinopia.example/abcdefg',
+        id: 'sinopia:uri',
+        label: 'example with uri',
+      }
+
+      const tokenWrapper = shallow(renderTokenFunc(option, { labelKey: 'label' }, 0))
+      expect(tokenWrapper.exists('a[href="http://sinopia.example/abcdefg"]')).toEqual(true)
+    })
+
+    it('does not link the tokens when there is no URI', () => {
+      const option = {
+        id: 'no1',
+        label: 'example no uri',
+      }
+
+      const tokenWrapper = shallow(renderTokenFunc(option, { labelKey: 'label' }, 0))
+      expect(tokenWrapper.exists('a')).toEqual(false)
+    })
+
+    it('shows menu headers with sinopia source label and literal value in the dropdown when provided results', () => {
+      const menuWrapper = shallow(renderMenuFunc(multipleResults, plProps))
+      const menuChildrenNumber = menuWrapper.children().length
+      // One top level menu component
+
+      expect(menuWrapper.find('ul').length).toEqual(1)
+      // Four children, with two headings and two items
+      expect(menuChildrenNumber).toEqual(4)
+      expect(menuWrapper.childAt(0).html()).toEqual('<li class="dropdown-header">Sinopia Entity</li>')
+      expect(menuWrapper.childAt(1).childAt(0).text()).toEqual('Blue hat, green hat')
+      expect(menuWrapper.childAt(2).html()).toEqual('<li class="dropdown-header">New Literal</li>')
+      expect(menuWrapper.childAt(3).childAt(0).text()).toEqual('blue')
+    })
+
+    it('shows a single new valid URI value with the correct header when no other matches are found', () => {
+      const menuWrapper = shallow(renderMenuFunc(validNewURIResults, plProps))
+      const menuChildrenNumber = menuWrapper.children().length
+      // One top level menu component
+
+      expect(menuWrapper.find('ul').length).toEqual(1)
+      // Two children, with one headings and one custom item
+      expect(menuChildrenNumber).toEqual(2)
+      expect(menuWrapper.childAt(0).html()).toEqual('<li class="dropdown-header">New URI</li>')
+      expect(menuWrapper.childAt(1).childAt(0).text()).toEqual('https://sinopia.io/repository/test/hijklmnop')
+    })
+
+    it('does show a single new literal value when no other matches are found', () => {
+      const menuWrapper = shallow(renderMenuFunc(validNewLiteralResults, plProps))
+      const menuChildrenNumber = menuWrapper.children().length
+      // One top level menu component
+
+      expect(menuWrapper.find('ul').length).toEqual(1)
+      // Nothing shown because the entered URI is not valid
+      expect(menuChildrenNumber).toEqual(2)
+      expect(menuWrapper.childAt(0).html()).toEqual('<li class="dropdown-header">New Literal</li>')
+      expect(menuWrapper.childAt(1).childAt(0).text()).toEqual('Some non URI string')
+    })
   })
+
   describe('Errors', () => {
     const errors = ['Required']
     const wrapper = shallow(<InputLookupSinopia.WrappedComponent displayValidations={true} errors={errors} {...plProps}/>)

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "jest-ci": "jest  --colors --silent --ci --runInBand --coverage --reporters=default --reporters=jest-junit && jest  --colors --silent --ci --runInBand --reporters=default --reporters=jest-junit --config integration-test.config.json && cat ./coverage/lcov.info | coveralls",
     "start": "npx babel-node server.js",
     "test": "jest --colors --silent --detectOpenHandles",
-    "integration": "jest --colors --silent--runInBand --detectOpenHandles --config integration-test.config.json",
+    "integration": "jest --colors --silent --runInBand --detectOpenHandles --config integration-test.config.json",
     "test-verbose": "jest --colors --runInBand",
     "integration-verbose": "jest --colors --runInBand --config integration-test.config.json"
   },

--- a/src/components/editor/property/InputLookupQA.jsx
+++ b/src/components/editor/property/InputLookupQA.jsx
@@ -1,10 +1,7 @@
 // Copyright 2019 Stanford University see LICENSE for license
 
 import React, { useState } from 'react'
-import {
-  Menu, MenuItem, Typeahead, asyncContainer, Token,
-} from 'react-bootstrap-typeahead'
-import { getOptionLabel } from 'react-bootstrap-typeahead/lib/utils'
+import { Typeahead, asyncContainer } from 'react-bootstrap-typeahead'
 import PropTypes from 'prop-types'
 import SinopiaPropTypes from 'SinopiaPropTypes'
 import shortid from 'shortid'
@@ -15,105 +12,11 @@ import {
 } from 'selectors/resourceSelectors'
 import { changeSelections } from 'actions/index'
 import getSearchResults from 'utilities/qa'
-import { isValidURI } from 'Utilities'
 import { booleanPropertyFromTemplate } from 'utilities/propertyTemplates'
 import _ from 'lodash'
-import RenderLookupContext from './RenderLookupContext'
+import { renderMenuFunc, renderTokenFunc } from './renderTypeaheadFunctions'
 
 const AsyncTypeahead = asyncContainer(Typeahead)
-
-
-export const renderMenuFunc = (results, menuProps) => {
-  const items = []
-  let authURI
-  let authLabel
-
-  /*
-   * Returning results
-   * If error is returned, it will be used to display for that source
-   */
-  results.forEach((result, i) => {
-    if (result.customOption) {
-      let headerLabel
-      let option
-      if (isValidURI(result.label)) {
-        headerLabel = 'New URI'
-        option = {
-          id: result.label,
-          label: result.label,
-          uri: result.label,
-        }
-      } else {
-        headerLabel = 'New Literal'
-        option = {
-          id: result.label,
-          label: result.label,
-          content: result.label,
-        }
-      }
-      items.push(<Menu.Header key="customOption-header">{headerLabel}</Menu.Header>)
-      items.push(
-        <MenuItem option={option} position={i} key={i}>
-          {result.label}
-        </MenuItem>,
-      )
-      return
-    }
-
-    if (result.isError) {
-      const errorMessage = result.label || 'An error occurred in retrieving results'
-
-      items.push(
-        <Menu.Header key={shortid.generate()}>
-          <span className="dropdown-error">{errorMessage}</span>
-        </Menu.Header>,
-      )
-
-      // Effectively a `continue`/`next` statement within the `forEach()` context, skipping to the next iteration
-      return
-    }
-    if ('authURI' in result) {
-      authLabel = result.authLabel
-      authURI = result.authURI
-      const labelKey = `${authLabel}-header`
-      items.push(<Menu.Header key={labelKey}>{authLabel}</Menu.Header>)
-      return
-    }
-    let bgClass = 'context-result-bg'
-    if (i % 2 === 0) {
-      bgClass = 'context-result-alt-bg'
-    }
-    items.push(
-      <MenuItem option={result} position={i} key={i}>
-        {result.context ? (
-          <RenderLookupContext innerResult={result} authLabel={authLabel} authURI={authURI} colorClassName={bgClass}></RenderLookupContext>
-        ) : result.label
-        }
-      </MenuItem>,
-    )
-  })
-
-  return (
-    <Menu {...menuProps} id={menuProps.id}>
-      {items}
-    </Menu>
-  )
-}
-
-// Render token function to be used by typeahead
-export const renderTokenFunc = (option, tokenProps, idx) => {
-  const optionLabel = getOptionLabel(option, tokenProps.labelKey)
-  const children = option.uri ? (<a href={option.uri} rel="noopener noreferrer" target="_blank">{optionLabel}</a>) : optionLabel
-  return (
-    <Token
-        disabled={tokenProps.disabled}
-        key={idx}
-        onRemove={tokenProps.onRemove}
-        tabIndex={tokenProps.tabIndex}>
-      { children }
-    </Token>
-  )
-}
 
 
 // propertyTemplate of type 'lookup' does live QA lookup via API

--- a/src/components/editor/property/InputLookupSinopia.jsx
+++ b/src/components/editor/property/InputLookupSinopia.jsx
@@ -1,3 +1,4 @@
+
 // Copyright 2019 Stanford University see LICENSE for license
 
 import React, { useState } from 'react'
@@ -12,6 +13,7 @@ import {
 } from 'selectors/resourceSelectors'
 import { changeSelections } from 'actions/index'
 import { booleanPropertyFromTemplate } from 'utilities/propertyTemplates'
+import { renderMenuFunc, renderTokenFunc } from './renderTypeaheadFunctions'
 import _ from 'lodash'
 
 const AsyncTypeahead = asyncContainer(Typeahead)
@@ -74,7 +76,9 @@ const InputLookupSinopia = (props) => {
 
   return (
     <div className={groupClasses}>
-      <AsyncTypeahead onSearch={search}
+      <AsyncTypeahead renderMenu={(results, menuProps) => renderMenuFunc(results, menuProps)}
+                      renderToken={(option, props, idx) => renderTokenFunc(option, props, idx)}
+                      onSearch={search}
                       onChange={change}
                       onKeyDown={onKeyDown}
                       options={options}
@@ -85,6 +89,7 @@ const InputLookupSinopia = (props) => {
                       placeholder={props.propertyTemplate.propertyLabel}
                       minLength={1}
                       filterBy={() => true }
+                      allowNew={() => true }
                       id="sinopia-lookup" />
 
       <span className="help-block">Use a * to wildcard your search.</span>

--- a/src/components/editor/property/renderTypeaheadFunctions.js
+++ b/src/components/editor/property/renderTypeaheadFunctions.js
@@ -1,0 +1,104 @@
+import React from 'react'
+import { Menu, MenuItem, Token } from 'react-bootstrap-typeahead'
+import { getOptionLabel } from 'react-bootstrap-typeahead/lib/utils'
+import { isValidURI } from '../../../Utilities'
+import RenderLookupContext from './RenderLookupContext'
+import shortid from 'shortid'
+
+export const renderMenuFunc = (results, menuProps) => {
+  const items = []
+  let authURI
+  let authLabel
+
+  /*
+   * Returning results
+   * If error is returned, it will be used to display for that source
+   */
+  results.forEach((result, i) => {
+    if (result.customOption) {
+      let headerLabel
+      let option
+
+      if (isValidURI(result.label)) {
+        headerLabel = 'New URI'
+        option = {
+          id: result.label,
+          label: result.label,
+          uri: result.label,
+        }
+      } else {
+        headerLabel = 'New Literal'
+        option = {
+          id: result.label,
+          label: result.label,
+          content: result.label,
+        }
+      }
+      items.push(<Menu.Header key="customOption-header">{headerLabel}</Menu.Header>)
+      items.push(
+        <MenuItem option={option} position={i} key={i}>
+          {result.label}
+        </MenuItem>,
+      )
+      return
+    }
+
+    if (result.isError) {
+      const errorMessage = result.label || 'An error occurred in retrieving results'
+
+      items.push(
+        <Menu.Header key={shortid.generate()}>
+          <span className="dropdown-error">{errorMessage}</span>
+        </Menu.Header>,
+      )
+
+      // Effectively a `continue`/`next` statement within the `forEach()` context, skipping to the next iteration
+      return
+    }
+    if ('authURI' in result) {
+      authLabel = result.authLabel
+      authURI = result.authURI
+      const labelKey = `${authLabel}-header`
+      items.push(<Menu.Header key={labelKey}>{authLabel}</Menu.Header>)
+      return
+    }
+    if (menuProps.id === 'sinopia-lookup') {
+      const labelKey = `${result.uri}-header`
+      items.push(<Menu.Header key={labelKey}>Sinopia Entity</Menu.Header>)
+    }
+
+    let bgClass = 'context-result-bg'
+    if (i % 2 === 0) {
+      bgClass = 'context-result-alt-bg'
+    }
+    items.push(
+      <MenuItem option={result} position={i} key={i}>
+        {result.context ? (
+          <RenderLookupContext innerResult={result} authLabel={authLabel} authURI={authURI} colorClassName={bgClass}></RenderLookupContext>
+        ) : result.label
+        }
+      </MenuItem>,
+    )
+  })
+
+  return (
+    <Menu {...menuProps} id={menuProps.id}>
+      {items}
+    </Menu>
+  )
+}
+
+// Render token function to be used by typeahead
+export const renderTokenFunc = (option, tokenProps, idx) => {
+  const optionLabel = getOptionLabel(option, tokenProps.labelKey)
+  const children = option.uri ? (<a href={option.uri} rel="noopener noreferrer" target="_blank">{optionLabel}</a>) : optionLabel
+  return (
+    <Token
+      disabled={tokenProps.disabled}
+      key={idx}
+      onRemove={tokenProps.onRemove}
+      tabIndex={tokenProps.tabIndex}>
+      { children }
+    </Token>
+  )
+}


### PR DESCRIPTION
Refactored so type-ahead functions are now exported from a separate file that each lookup component calls.

![SearchwithLiterals](https://user-images.githubusercontent.com/3093850/65918360-599f8b00-e38e-11e9-8b0c-8c5d8eeca327.gif)
