### PR TITLE
fix getty tgn and ulan pointing to aat

### DIFF
--- a/static/lookupConfig.json
+++ b/static/lookupConfig.json
@@ -376,7 +376,7 @@
   {
     "label": "GETTY_TGN (QA)",
     "uri": "urn:ld4p:qa:gettytgn",
-    "authority": "getty_aat_ld4l_cache",
+    "authority": "getty_tgn_ld4l_cache",
     "subauthority": "",
     "language": "en",
     "component": "lookup"
@@ -392,7 +392,7 @@
   {
     "label": "GETTY_ULAN person (QA)",
     "uri": "urn:ld4p:qa:gettyulan:person",
-    "authority": "getty_aat_ld4l_cache",
+    "authority": "getty_ulan_ld4l_cache",
     "subauthority": "person",
     "language": "en",
     "component": "lookup"
@@ -400,7 +400,7 @@
   {
     "label": "GETTY_ULAN organization (QA)",
     "uri": "urn:ld4p:qa:gettyulan:organization",
-    "authority": "getty_aat_ld4l_cache",
+    "authority": "getty_ulan_ld4l_cache",
     "subauthority": "organization",
     "language": "en",
     "component": "lookup"


### PR DESCRIPTION
Fix several configs for getty that were pointing to aat when they should point to tgn or ulan.

Identified in https://github.com/LD4P/qa_server/issues/121