### PR TITLE
Discogs search should use the endpoint configured by authorityConfig.json

### DIFF
--- a/__tests__/actionCreators/search.test.js
+++ b/__tests__/actionCreators/search.test.js
@@ -25,7 +25,7 @@ describe('fetchSinopiaSearchResults', () => {
     expect(dispatch).toBeCalledWith({
       type: 'SET_SEARCH_RESULTS',
       payload: {
-        authority: 'sinopia',
+        uri: 'sinopia',
         query: '*',
         searchResults: mockSearchResults.results,
         totalResults: mockSearchResults.totalHits,
@@ -37,7 +37,7 @@ describe('fetchSinopiaSearchResults', () => {
 
 describe('fetchQASearchResults', () => {
   const query = '*'
-  const authority = 'sharevde_stanford_ld4l_cache'
+  const uri = 'urn:ld4p:qa:sharevde_stanford_ld4l_cache:all'
   it('dispatches action', async () => {
     const dispatch = jest.fn()
     const mockSearchResults = [
@@ -109,13 +109,13 @@ describe('fetchQASearchResults', () => {
     const client = { apis: { SearchQuery: { GET_searchAuthority: mockActionFunction } } }
     Swagger.mockResolvedValue(client)
 
-    await fetchQASearchResults(query, authority)(dispatch)
+    await fetchQASearchResults(query, uri)(dispatch)
 
     expect(dispatch).toHaveBeenCalledTimes(1)
     expect(dispatch).toBeCalledWith({
       type: 'SET_SEARCH_RESULTS',
       payload: {
-        authority,
+        uri,
         query,
         searchResults: mockSearchResults,
         totalResults: 2,
@@ -130,13 +130,13 @@ describe('fetchQASearchResults', () => {
     const client = { apis: { SearchQuery: { GET_searchAuthority: mockActionFunction } } }
     Swagger.mockResolvedValue(client)
 
-    await fetchQASearchResults(query, authority)(dispatch)
+    await fetchQASearchResults(query, uri)(dispatch)
 
     expect(dispatch).toHaveBeenCalledTimes(1)
     expect(dispatch).toBeCalledWith({
       type: 'SET_SEARCH_RESULTS',
       payload: {
-        authority,
+        uri,
         query,
         searchResults: [],
         totalResults: 0,

--- a/__tests__/components/search/Search.test.js
+++ b/__tests__/components/search/Search.test.js
@@ -88,7 +88,7 @@ describe('<Search />', () => {
     expect(getByDisplayValue('Sinopia')).toBeInTheDocument()
 
     // Select an authority
-    fireEvent.change(getByDisplayValue('Sinopia'), { target: { value: 'sharevde_stanford_ld4l_cache' } })
+    fireEvent.change(getByDisplayValue('Sinopia'), { target: { value: 'urn:ld4p:qa:sharevde_stanford_ld4l_cache:all' } })
     expect(getByDisplayValue('SHAREVDE STANFORD')).toBeInTheDocument()
 
     // Enter a query

--- a/__tests__/integration/copyQASearchResult.test.js
+++ b/__tests__/integration/copyQASearchResult.test.js
@@ -71,7 +71,7 @@ const createInitialState = () => {
         results: [],
         totalResults: 0,
         query: undefined,
-        authority: undefined,
+        uri: undefined,
       },
     },
   }
@@ -152,7 +152,7 @@ rdfs:label "These twain.";
     expect(getByLabelText('Search')).toBeInTheDocument()
 
     // Select an authority
-    fireEvent.change(getByDisplayValue('Sinopia'), { target: { value: 'sharevde_stanford_ld4l_cache' } })
+    fireEvent.change(getByDisplayValue('Sinopia'), { target: { value: 'urn:ld4p:qa:sharevde_stanford_ld4l_cache:all' } })
 
     // Enter a query
     fireEvent.change(getByLabelText('Query'), { target: { value: 'twain' } })

--- a/__tests__/utilities/qa.test.js
+++ b/__tests__/utilities/qa.test.js
@@ -42,7 +42,7 @@ describe('getTerm', () => {
   it('fetches N3 from QA', async () => {
     global.fetch = jest.fn().mockImplementation(() => Promise.resolve({ text: () => 'n3' }))
 
-    const term = await getTerm('http://share-vde.org/sharevde/rdfBibframe/Work/4840195', 'sharevde_chicago_ld4l_cache')
+    const term = await getTerm('http://share-vde.org/sharevde/rdfBibframe/Work/4840195', 'urn:ld4p:qa:sharevde_chicago_ld4l_cache:all')
     expect(term).toBe('n3')
 
     expect(global.fetch).toHaveBeenCalledTimes(1)

--- a/src/actionCreators/search.js
+++ b/src/actionCreators/search.js
@@ -2,20 +2,22 @@
 import { setSearchResults } from 'actions/index'
 import { getSearchResults } from 'sinopiaServer'
 import { createLookupPromises } from 'utilities/qa'
+import { findAuthorityConfig } from 'utilities/authorityConfig'
 
 export const fetchSinopiaSearchResults = (query, queryFrom = 0) => dispatch => getSearchResults(query, queryFrom).then((response) => {
   dispatch(setSearchResults('sinopia', response.results, response.totalHits, query, queryFrom, response.error))
 })
 
-export const fetchQASearchResults = (query, authority, queryFrom = 0) => (dispatch) => {
-  const searchPromise = createLookupPromises(query, [{ authority }])[0]
+export const fetchQASearchResults = (query, uri, queryFrom = 0) => (dispatch) => {
+  const result = findAuthorityConfig(uri)
+  const searchPromise = createLookupPromises(query, [result])[0]
 
   return searchPromise.then((response) => {
     if (response.isError) {
-      dispatch(setSearchResults(authority, [], 0, query, queryFrom, { message: response.errorObject.message }))
+      dispatch(setSearchResults(uri, [], 0, query, queryFrom, { message: response.errorObject.message }))
     } else {
       // Don't have total hits yet, so just using size of this response
-      dispatch(setSearchResults(authority, response.body, response.body.length, query, queryFrom))
+      dispatch(setSearchResults(uri, response.body, response.body.length, query, queryFrom))
     }
   })
 }

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -176,10 +176,10 @@ export const clearSearchResults = () => ({
   type: 'CLEAR_SEARCH_RESULTS',
 })
 
-export const setSearchResults = (authority, searchResults, totalResults, query, startOfRange, error) => ({
+export const setSearchResults = (uri, searchResults, totalResults, query, startOfRange, error) => ({
   type: 'SET_SEARCH_RESULTS',
   payload: {
-    authority,
+    uri,
     searchResults,
     totalResults,
     query,

--- a/src/components/search/QASearchResults.jsx
+++ b/src/components/search/QASearchResults.jsx
@@ -19,7 +19,7 @@ const QASearchResults = (props) => {
   const showResourceTemplateChooser = () => dispatch(showResourceTemplateChooserAction())
 
   const searchResults = useSelector(state => state.selectorReducer.search.results)
-  const authority = useSelector(state => state.selectorReducer.search.authority)
+  const searchUri = useSelector(state => state.selectorReducer.search.uri)
   const rootResource = useSelector(state => rootResourceSelector(state))
 
   const [error, setError] = useState(null)
@@ -41,13 +41,13 @@ const QASearchResults = (props) => {
 
   // Retrieve N3 from QA
   useEffect(() => {
-    if (!resourceURI || !authority) {
+    if (!resourceURI || !searchUri) {
       return
     }
-    getTerm(resourceURI, authority)
+    getTerm(resourceURI, searchUri)
       .then(resourceN3 => setResourceN3(resourceN3))
       .catch(err => setError(`Error retrieving resource: ${err.toString()}`))
-  }, [resourceURI, authority])
+  }, [resourceURI, searchUri])
 
   // Transform the results into the format to be displayed in the table.
   const tableData = useMemo(() => searchResults.map((result) => {

--- a/src/components/search/Search.jsx
+++ b/src/components/search/Search.jsx
@@ -19,15 +19,15 @@ import { clearSearchResults as clearSearchResultsAction } from 'actions/index'
 
 const Search = (props) => {
   const dispatch = useDispatch()
-  const fetchQASearchResults = (queryString, authority) => dispatch(fetchQASearchResultsCreator(queryString, authority))
+  const fetchQASearchResults = (queryString, uri) => dispatch(fetchQASearchResultsCreator(queryString, uri))
   const fetchSinopiaSearchResults = queryString => dispatch(fetchSinopiaSearchResultsCreator(queryString))
   const clearSearchResults = useCallback(() => dispatch(clearSearchResultsAction()), [dispatch])
 
   const error = useSelector(state => state.selectorReducer.search.error)
-  const resultAuthority = useSelector(state => state.selectorReducer.search.authority)
+  const searchUri = useSelector(state => state.selectorReducer.search.uri)
 
   const [queryString, setQueryString] = useState('')
-  const [authority, setAuthority] = useState('sinopia')
+  const [uri, setUri] = useState('sinopia')
 
   useEffect(() => {
     clearSearchResults()
@@ -49,17 +49,17 @@ const Search = (props) => {
     if (queryString === '') {
       return
     }
-    if (authority === 'sinopia') {
+    if (uri === 'sinopia') {
       fetchSinopiaSearchResults(queryString)
     } else {
-      fetchQASearchResults(queryString, authority)
+      fetchQASearchResults(queryString, uri)
     }
   }
 
-  const options = searchConfig.map(config => (<option key={config.authority} value={config.authority}>{config.label}</option>))
+  const options = searchConfig.map(config => (<option key={config.uri} value={config.uri}>{config.label}</option>))
 
   let results
-  if (resultAuthority === 'sinopia') {
+  if (searchUri === 'sinopia') {
     results = (
       <div>
         <SinopiaSearchResults {...props} key="search-results" />
@@ -67,7 +67,7 @@ const Search = (props) => {
         <SearchResultsMessage />
       </div>
     )
-  } else if (resultAuthority) {
+  } else if (searchUri) {
     results = (
       <QASearchResults history={props.history} key="search-results" />
     )
@@ -91,9 +91,9 @@ const Search = (props) => {
           <div className="form-group">
             <label htmlFor="searchType">Search</label>&nbsp;
             <select className="form-control" id="searchType"
-                    value={authority}
-                    onChange={ event => setAuthority(event.target.value) }
-                    onBlur={ event => setAuthority(event.target.value) }>
+                    value={uri}
+                    onChange={ event => setUri(event.target.value) }
+                    onBlur={ event => setUri(event.target.value) }>
               <option value="sinopia">Sinopia</option>
               {options}
             </select>

--- a/src/reducers/search.js
+++ b/src/reducers/search.js
@@ -9,7 +9,7 @@
 export const setSearchResults = (state, action) => {
   const newState = { ...state }
 
-  newState.search.authority = action.payload.authority
+  newState.search.uri = action.payload.uri
   newState.search.results = action.payload.searchResults
   newState.search.totalResults = action.payload.totalResults
   newState.search.query = action.payload.query
@@ -27,7 +27,7 @@ export const setSearchResults = (state, action) => {
 export const clearSearchResults = (state) => {
   const newState = { ...state }
 
-  newState.search.authority = undefined
+  newState.search.uri = undefined
   newState.search.results = []
   newState.search.totalResults = 0
   newState.search.query = undefined

--- a/src/utilities/authorityConfig.js
+++ b/src/utilities/authorityConfig.js
@@ -1,0 +1,7 @@
+// Copyright 2019 Stanford University see LICENSE for license
+
+import authorityConfig from '../../static/authorityConfig.json'
+
+export const findAuthorityConfig = searchUri => authorityConfig.find(configItem => configItem.uri === searchUri)
+
+export const findAuthorityConfigs = searchUris => authorityConfig.filter(configItem => searchUris.includes(configItem.uri))

--- a/src/utilities/propertyTemplates.js
+++ b/src/utilities/propertyTemplates.js
@@ -1,5 +1,6 @@
+// Copyright 2019 Stanford University see LICENSE for license
 
-import lookupConfig from '../../static/lookupConfig.json'
+import { findAuthorityConfigs } from 'utilities/authorityConfig'
 import shortid from 'shortid'
 import { defaultLanguageId } from 'Utilities'
 
@@ -83,7 +84,7 @@ export const getLookupConfigItems = (propertyTemplate) => {
 
   if (vocabUriList === undefined || vocabUriList.length === 0) return []
 
-  const result = lookupConfig.filter(configItem => vocabUriList.includes(configItem.uri))
+  const result = findAuthorityConfigs(vocabUriList)
   if (result.length === 0) {
     throw `Unable to find ${vocabUriList} in the lookup configuration`
   }

--- a/src/utilities/qa.js
+++ b/src/utilities/qa.js
@@ -5,6 +5,7 @@ import Swagger from 'swagger-client'
 import swaggerSpec from 'lib/apidoc.json'
 import { getLookupConfigItems } from 'utilities/propertyTemplates'
 import Config from 'Config'
+import { findAuthorityConfig } from 'utilities/authorityConfig'
 
 export const getSearchResults = (query, propertyTemplate) => {
   const lookupConfigs = getLookupConfigItems(propertyTemplate)
@@ -74,11 +75,12 @@ export const createLookupPromises = (query, lookupConfigs) => lookupConfigs.map(
 /**
  * Fetches a term (aka resource) from QA.
  * @param {string} uri of the resource
- * @param {string} authority from which to fetch
+ * @param {string} searchUri uri of the endpoint from which to fetch
  * @param {string} format supported by QA
   * @return {Promise<string>} the term as text
  */
-export const getTerm = (uri, authority, format = 'n3') => {
+export const getTerm = (uri, searchUri, format = 'n3') => {
+  const authority = findAuthorityConfig(searchUri).authority
   const url = `${Config.qaUrl}/authorities/fetch/linked_data/${authority.toLowerCase()}?format=${format}&uri=${uri}`
   return fetch(url)
     .then(resp => resp.text())

--- a/static/authorityConfig.json
+++ b/static/authorityConfig.json
@@ -974,6 +974,13 @@
     "component": "lookup"
   },
   {
+    "label": "SHAREVDE ALBERTA (QA)",
+    "uri": "urn:ld4p:qa:sharevde_alberta_ld4l_cache:all",
+    "authority": "sharevde_alberta_ld4l_cache",
+    "language": "en",
+    "component": "lookup"
+  },
+  {
     "label": "SHAREVDE ALBERTA work (QA)",
     "uri": "urn:ld4p:qa:sharevde_alberta_ld4l_cache:work",
     "authority": "sharevde_alberta_ld4l_cache",
@@ -994,6 +1001,13 @@
     "uri": "urn:ld4p:qa:sharevde_alberta_ld4l_cache:instance",
     "authority": "sharevde_alberta_ld4l_cache",
     "subauthority": "instance",
+    "language": "en",
+    "component": "lookup"
+  },
+  {
+    "label": "SHAREVDE CHICAGO (QA)",
+    "uri": "urn:ld4p:qa:sharevde_chicago_ld4l_cache:all",
+    "authority": "sharevde_chicago_ld4l_cache",
     "language": "en",
     "component": "lookup"
   },
@@ -1022,6 +1036,13 @@
     "component": "lookup"
   },
   {
+    "label": "SHAREVDE CORNELL (QA)",
+    "uri": "urn:ld4p:qa:sharevde_cornell_ld4l_cache:all",
+    "authority": "sharevde_cornell_ld4l_cache",
+    "language": "en",
+    "component": "lookup"
+  },
+  {
     "label": "SHAREVDE CORNELL work (QA)",
     "uri": "urn:ld4p:qa:sharevde_cornell_ld4l_cache:work",
     "authority": "sharevde_cornell_ld4l_cache",
@@ -1042,6 +1063,13 @@
     "uri": "urn:ld4p:qa:sharevde_cornell_ld4l_cache:instance",
     "authority": "sharevde_cornell_ld4l_cache",
     "subauthority": "instance",
+    "language": "en",
+    "component": "lookup"
+  },
+  {
+    "label": "SHAREVDE CU BOULDER (QA)",
+    "uri": "urn:ld4p:qa:sharevde_cuboulder_ld4l_cache:all",
+    "authority": "sharevde_cuboulder_ld4l_cache",
     "language": "en",
     "component": "lookup"
   },
@@ -1070,6 +1098,13 @@
     "component": "lookup"
   },
   {
+    "label": "SHAREVDE DUKE (QA)",
+    "uri": "urn:ld4p:qa:sharevde_duke_ld4l_cache:all",
+    "authority": "sharevde_duke_ld4l_cache",
+    "language": "en",
+    "component": "lookup"
+  },
+  {
     "label": "SHAREVDE DUKE work (QA)",
     "uri": "urn:ld4p:qa:sharevde_duke_ld4l_cache:work",
     "authority": "sharevde_duke_ld4l_cache",
@@ -1090,6 +1125,13 @@
     "uri": "urn:ld4p:qa:sharevde_duke_ld4l_cache:instance",
     "authority": "sharevde_duke_ld4l_cache",
     "subauthority": "instance",
+    "language": "en",
+    "component": "lookup"
+  },
+  {
+    "label": "SHAREVDE FRICK (QA)",
+    "uri": "urn:ld4p:qa:sharevde_frick_ld4l_cache:all",
+    "authority": "sharevde_frick_ld4l_cache",
     "language": "en",
     "component": "lookup"
   },
@@ -1118,6 +1160,13 @@
     "component": "lookup"
   },
   {
+    "label": "SHAREVDE HARRYRANSOM (QA)",
+    "uri": "urn:ld4p:qa:sharevde_harryransom_ld4l_cache:all",
+    "authority": "sharevde_harryransom_ld4l_cache",
+    "language": "en",
+    "component": "lookup"
+  },
+  {
     "label": "SHAREVDE HARRYRANSOM work (QA)",
     "uri": "urn:ld4p:qa:sharevde_harryransom_ld4l_cache:work",
     "authority": "sharevde_harryransom_ld4l_cache",
@@ -1138,6 +1187,13 @@
     "uri": "urn:ld4p:qa:sharevde_harryransom_ld4l_cache:instance",
     "authority": "sharevde_harryransom_ld4l_cache",
     "subauthority": "instance",
+    "language": "en",
+    "component": "lookup"
+  },
+  {
+    "label": "SHAREVDE HARVARD (QA)",
+    "uri": "urn:ld4p:qa:sharevde_harvard_ld4l_cache:all",
+    "authority": "sharevde_harvard_ld4l_cache",
     "language": "en",
     "component": "lookup"
   },
@@ -1166,6 +1222,13 @@
     "component": "lookup"
   },
   {
+    "label": "SHAREVDE MICHIGAN (QA)",
+    "uri": "urn:ld4p:qa:sharevde_michigan_ld4l_cache:all",
+    "authority": "sharevde_michigan_ld4l_cache",
+    "language": "en",
+    "component": "lookup"
+  },
+  {
     "label": "SHAREVDE MICHIGAN work (QA)",
     "uri": "urn:ld4p:qa:sharevde_michigan_ld4l_cache:work",
     "authority": "sharevde_michigan_ld4l_cache",
@@ -1186,6 +1249,13 @@
     "uri": "urn:ld4p:qa:sharevde_michigan_ld4l_cache:instance",
     "authority": "sharevde_michigan_ld4l_cache",
     "subauthority": "instance",
+    "language": "en",
+    "component": "lookup"
+  },
+  {
+    "label": "SHAREVDE MINNESOTA (QA)",
+    "uri": "urn:ld4p:qa:sharevde_minnesota_ld4l_cache:all",
+    "authority": "sharevde_minnesota_ld4l_cache",
     "language": "en",
     "component": "lookup"
   },
@@ -1214,6 +1284,13 @@
     "component": "lookup"
   },
   {
+    "label": "SHAREVDE NLM (QA)",
+    "uri": "urn:ld4p:qa:sharevde_nlm_ld4l_cache:all",
+    "authority": "sharevde_nlm_ld4l_cache",
+    "language": "en",
+    "component": "lookup"
+  },
+  {
     "label": "SHAREVDE NLM work (QA)",
     "uri": "urn:ld4p:qa:sharevde_nlm_ld4l_cache:work",
     "authority": "sharevde_nlm_ld4l_cache",
@@ -1234,6 +1311,13 @@
     "uri": "urn:ld4p:qa:sharevde_nlm_ld4l_cache:instance",
     "authority": "sharevde_nlm_ld4l_cache",
     "subauthority": "instance",
+    "language": "en",
+    "component": "lookup"
+  },
+  {
+    "label": "SHAREVDE NORTHWESTERN (QA)",
+    "uri": "urn:ld4p:qa:sharevde_northwestern_ld4l_cache:all",
+    "authority": "sharevde_northwestern_ld4l_cache",
     "language": "en",
     "component": "lookup"
   },
@@ -1262,6 +1346,13 @@
     "component": "lookup"
   },
   {
+    "label": "SHAREVDE PRINCETON (QA)",
+    "uri": "urn:ld4p:qa:sharevde_princeton_ld4l_cache:all",
+    "authority": "sharevde_princeton_ld4l_cache",
+    "language": "en",
+    "component": "lookup"
+  },
+  {
     "label": "SHAREVDE PRINCETON work (QA)",
     "uri": "urn:ld4p:qa:sharevde_princeton_ld4l_cache:work",
     "authority": "sharevde_princeton_ld4l_cache",
@@ -1286,6 +1377,13 @@
     "component": "lookup"
   },
   {
+    "label": "SHAREVDE STANFORD (QA)",
+    "uri": "urn:ld4p:qa:sharevde_stanford_ld4l_cache:all",
+    "authority": "sharevde_stanford_ld4l_cache",
+    "language": "en",
+    "component": "lookup"
+  },
+  {
     "label": "SHAREVDE STANFORD work (QA)",
     "uri": "urn:ld4p:qa:sharevde_stanford_ld4l_cache:work",
     "authority": "sharevde_stanford_ld4l_cache",
@@ -1306,6 +1404,13 @@
     "uri": "urn:ld4p:qa:sharevde_stanford_ld4l_cache:instance",
     "authority": "sharevde_stanford_ld4l_cache",
     "subauthority": "instance",
+    "language": "en",
+    "component": "lookup"
+  },
+  {
+    "label": "SHAREVDE TEXASAM (QA)",
+    "uri": "urn:ld4p:qa:sharevde_texasam_ld4l_cache:all",
+    "authority": "sharevde_texasam_ld4l_cache",
     "language": "en",
     "component": "lookup"
   },
@@ -1358,6 +1463,13 @@
     "component": "lookup"
   },
   {
+    "label": "SHAREVDE UCSD (QA)",
+    "uri": "urn:ld4p:qa:sharevde_ucsd_ld4l_cache:all",
+    "authority": "sharevde_ucsd_ld4l_cache",
+    "language": "en",
+    "component": "lookup"
+  },
+  {
     "label": "SHAREVDE UCSD work (QA)",
     "uri": "urn:ld4p:qa:sharevde_ucsd_ld4l_cache:work",
     "authority": "sharevde_ucsd_ld4l_cache",
@@ -1378,6 +1490,13 @@
     "uri": "urn:ld4p:qa:sharevde_ucsd_ld4l_cache:instance",
     "authority": "sharevde_ucsd_ld4l_cache",
     "subauthority": "instance",
+    "language": "en",
+    "component": "lookup"
+  },
+  {
+    "label": "SHAREVDE UPENN (QA)",
+    "uri": "urn:ld4p:qa:sharevde_upenn_ld4l_cache:all",
+    "authority": "sharevde_upenn_ld4l_cache",
     "language": "en",
     "component": "lookup"
   },
@@ -1406,6 +1525,13 @@
     "component": "lookup"
   },
   {
+    "label": "SHAREVDE UWASHINGTON (QA)",
+    "uri": "urn:ld4p:qa:sharevde_uwashington_ld4l_cache:all",
+    "authority": "sharevde_uwashington_ld4l_cache",
+    "language": "en",
+    "component": "lookup"
+  },
+  {
     "label": "SHAREVDE UWASHINGTON work (QA)",
     "uri": "urn:ld4p:qa:sharevde_uwashington_ld4l_cache:work",
     "authority": "sharevde_uwashington_ld4l_cache",
@@ -1426,6 +1552,13 @@
     "uri": "urn:ld4p:qa:sharevde_uwashington_ld4l_cache:instance",
     "authority": "sharevde_uwashington_ld4l_cache",
     "subauthority": "instance",
+    "language": "en",
+    "component": "lookup"
+  },
+  {
+    "label": "SHAREVDE YALE (QA)",
+    "uri": "urn:ld4p:qa:sharevde_yale_ld4l_cache:all",
+    "authority": "sharevde_yale_ld4l_cache",
     "language": "en",
     "component": "lookup"
   },

--- a/static/searchConfig.json
+++ b/static/searchConfig.json
@@ -1,86 +1,86 @@
 [
   {
     "label": "DISCOGS",
-    "authority": "discogs"
+    "uri": "urn:discogs"
   },
   {
     "label": "SHAREVDE ALBERTA",
-    "authority": "sharevde_alberta_ld4l_cache"
+    "uri": "urn:ld4p:qa:sharevde_alberta_ld4l_cache:all"
   },
   {
     "label": "SHAREVDE CHICAGO",
-    "authority": "sharevde_chicago_ld4l_cache"
+    "uri": "urn:ld4p:qa:sharevde_chicago_ld4l_cache:all"
   },
   {
     "label": "SHAREVDE CORNELL",
-    "authority": "sharevde_cornell_ld4l_cache"
+    "uri": "urn:ld4p:qa:sharevde_cornell_ld4l_cache:all"
   },
   {
     "label": "SHAREVDE CU BOULDER",
-    "authority": "sharevde_cuboulder_ld4l_cache"
+    "uri": "urn:ld4p:qa:sharevde_cuboulder_ld4l_cache:all"
   },
   {
     "label": "SHAREVDE DUKE",
-    "authority": "sharevde_duke_ld4l_cache"
+    "uri": "urn:ld4p:qa:sharevde_duke_ld4l_cache:all"
   },
   {
     "label": "SHAREVDE FRICK",
-    "authority": "sharevde_frick_ld4l_cache"
+    "uri": "urn:ld4p:qa:sharevde_frick_ld4l_cache:all"
   },
   {
     "label": "SHAREVDE HARRYRANSOM",
-    "authority": "sharevde_harryransom_ld4l_cache"
+    "uri": "urn:ld4p:qa:sharevde_harryransom_ld4l_cache:all"
   },
   {
     "label": "SHAREVDE HARVARD",
-    "authority": "sharevde_harvard_ld4l_cache"
+    "uri": "urn:ld4p:qa:sharevde_harvard_ld4l_cache:all"
   },
   {
     "label": "SHAREVDE MICHIGAN",
-    "authority": "sharevde_michigan_ld4l_cache"
+    "uri": "urn:ld4p:qa:sharevde_michigan_ld4l_cache:all"
   },
   {
     "label": "SHAREVDE MINNESOTA",
-    "authority": "sharevde_minnesota_ld4l_cache"
+    "uri": "urn:ld4p:qa:sharevde_minnesota_ld4l_cache:all"
   },
   {
     "label": "SHAREVDE NLM",
-    "authority": "sharevde_nlm_ld4l_cache"
+    "uri": "urn:ld4p:qa:sharevde_nlm_ld4l_cache:all"
   },
   {
     "label": "SHAREVDE NORTHWESTERN",
-    "authority": "sharevde_northwestern_ld4l_cache"
+    "uri": "urn:ld4p:qa:sharevde_northwestern_ld4l_cache:all"
   },
   {
     "label": "SHAREVDE PRINCETON",
-    "authority": "sharevde_princeton_ld4l_cache"
+    "uri": "urn:ld4p:qa:sharevde_princeton_ld4l_cache:all"
   },
   {
     "label": "SHAREVDE STANFORD",
-    "authority": "sharevde_stanford_ld4l_cache"
+    "uri": "urn:ld4p:qa:sharevde_stanford_ld4l_cache:all"
   },
   {
     "label": "SHAREVDE TEXASAM",
-    "authority": "sharevde_texasam_ld4l_cache"
+    "uri": "urn:ld4p:qa:sharevde_texasam_ld4l_cache:all"
   },
   {
     "label": "SHAREVDE UCDAVIS",
-    "authority": "sharevde_ucdavis_ld4l_cache"
+    "uri": "urn:ld4p:qa:sharevde_ucdavis_ld4l_cache:all"
   },
   {
     "label": "SHAREVDE UCSD",
-    "authority": "sharevde_ucsd_ld4l_cache"
+    "uri": "urn:ld4p:qa:sharevde_ucsd_ld4l_cache:all"
   },
   {
     "label": "SHAREVDE UPENN",
-    "authority": "sharevde_upenn_ld4l_cache"
+    "uri": "urn:ld4p:qa:sharevde_upenn_ld4l_cache:all"
   },
   {
     "label": "SHAREVDE UWASHINGTON",
-    "authority": "sharevde_uwashington_ld4l_cache"
+    "uri": "urn:ld4p:qa:sharevde_uwashington_ld4l_cache:all"
   },
   {
     "label": "SHAREVDE YALE",
-    "authority": "sharevde_yale_ld4l_cache"
+    "uri": "urn:ld4p:qa:sharevde_yale_ld4l_cache:all"
   }
 ]


### PR DESCRIPTION
Fixes #1420

This switches the store from using "authority" to using "uri" which is a unique reference in the `authorityConfig.json`.  Using this `authorityConfig.json` allows it to know that "discogs" is a non-LD source.