### PR TITLE
Refactor SinopiaResourceTemplates as functional component

### DIFF
--- a/__tests__/actionCreators/resourceTemplates.test.js
+++ b/__tests__/actionCreators/resourceTemplates.test.js
@@ -98,4 +98,20 @@ describe('fetchResourceTemplateSummaries', () => {
     expect(server.listResourcesInGroupContainer).toHaveBeenCalledWith('ld4p')
     expect(dispatch).toHaveBeenCalledTimes(0)
   })
+  it('handles a connection error', async () => {
+    const resourceTemplateId = 'list of resource templates'
+
+    server.listResourcesInGroupContainer = jest.fn().mockRejectedValue('Error: Request has been terminated..., etc.')
+    const dispatch = jest.fn()
+
+    await fetchResourceTemplateSummaries()(dispatch)
+
+    expect(dispatch).toBeCalledWith({
+      type: 'RETRIEVE_RESOURCE_TEMPLATE_ERROR',
+      payload: {
+        resourceTemplateId,
+        reason: 'Error: Request has been terminated..., etc.',
+      },
+    })
+  })
 })

--- a/__tests__/components/templates/SinopiaResourceTemplates.test.js
+++ b/__tests__/components/templates/SinopiaResourceTemplates.test.js
@@ -1,62 +1,95 @@
 // Copyright 2019 Stanford University see LICENSE for license
 
 import React from 'react'
-import { shallow } from 'enzyme'
 import SinopiaResourceTemplates from 'components/templates/SinopiaResourceTemplates'
+import * as sinopiaServer from 'sinopiaServer'
+import { fireEvent, wait } from '@testing-library/react'
+import { createMemoryHistory } from 'history'
+/* eslint import/no-unresolved: 'off' */
+import { renderWithReduxAndRouter, createReduxStore } from 'testUtils'
+import { getFixtureResourceTemplate } from '../../fixtureLoaderHelper'
+import { saveAs } from 'file-saver'
 
 jest.mock('sinopiaServer')
+// jest.mock('Download')
+jest.mock('file-saver')
 
-describe('<SinopiaResourceTemplates />', () => {
-  const messages = [
-    'Created http://localhost:8080/repository/ld4p/Note/sinopia:resourceTemplate:bf2:Note1',
-    'Created http://localhost:8080/repository/ld4p/Note/sinopia:resourceTemplate:bf2:Note2',
-  ]
+const createInitialState = () => {
+  const state = {
+    selectorReducer: {
+      resource: {
+        'resourceTemplate:bf2:Note': {
+          'http://id.loc.gov/ontologies/bibframe/note': {
+            items: {},
+          },
+        },
+      },
+      entities: {
+        resourceTemplateSummaries,
+        resourceTemplates: {
+          'resourceTemplate:bf2:Note': {
+            id: 'resourceTemplate:bf2:Note',
+            resourceURI: 'http://id.loc.gov/ontologies/bibframe/Note',
+            resourceLabel: 'Note',
+            propertyTemplates: [
+              {
+                propertyURI: 'http://www.w3.org/2000/01/rdf-schema#label',
+                propertyLabel: 'Note',
+                type: 'literal',
+              },
+            ],
+          },
+        },
+      },
+      editor: {
+        serverError: '',
+      },
+    },
 
-  const resourceTemplateSummary = {
-    name: 'Note',
-    key: 'ld4p:resourceTemplate:bf2:Note',
-    id: 'ld4p:resourceTemplate:bf2:Note',
-    author: 'wright.lee.renønd',
-    remark: 'very salient information',
-    group: 'stanford',
   }
+  return state
+}
 
-  const resourceTemplateSummaries = [resourceTemplateSummary]
+const resourceTemplateSummary = {
+  name: 'Note',
+  key: 'resourceTemplate:bf2:Note',
+  id: 'resourceTemplate:bf2:Note',
+  author: 'wright.lee.renønd',
+  remark: 'very salient information',
+  group: 'ld4p',
+}
 
-  const wrapper = shallow(<SinopiaResourceTemplates.WrappedComponent messages={messages} resourceTemplateSummaries={resourceTemplateSummaries} />)
+const resourceTemplateSummaries = [resourceTemplateSummary]
 
-  it('has a header for the area where the table of resource templates for the groups are displayed', () => {
-    expect(wrapper.find('div > h4').last().text()).toEqual('Available Resource Templates in Sinopia')
-  })
+describe('SinopiaResourceTemplates', () => {
+  it('displays a list of resource templates with links to load and to download the resources', async () => {
+    const store = createReduxStore(createInitialState())
+    const history = createMemoryHistory()
 
-  it('has a bootstrap table that displays the results from the calls to sinopia_server', () => {
-    expect(wrapper.find('BootstrapTableContainer').length).toEqual(1)
-  })
+    sinopiaServer.getResourceTemplate.mockImplementation(getFixtureResourceTemplate)
 
-  describe('display', () => {
-    const wrapper = shallow(<SinopiaResourceTemplates.WrappedComponent messages={[]} resourceTemplateSummaries={resourceTemplateSummaries} />)
+    const { container, getByText, getByTestId } = renderWithReduxAndRouter(
+      <SinopiaResourceTemplates messages={[]} history={history} />, store,
+    )
 
-    it('renders the table of resource templates with name, id, author, guiding statement, download columns', () => {
-      const tableHeaderCellText = wrapper.find('BootstrapTableContainer').props().columns.map(col => col.text)
-      expect(tableHeaderCellText).toEqual(['Template name', 'ID', 'Author', 'Guiding statement', 'Download'])
-    })
-  })
+    // There is a table with heading and header columns
+    expect(getByText('Available Resource Templates in Sinopia')).toBeInTheDocument()
+    expect(container.querySelector('table#resource-template-list')).toBeInTheDocument()
+    expect(getByText(/Template name/)).toBeInTheDocument()
+    expect(getByText(/ID/)).toBeInTheDocument()
+    expect(getByText(/Author/)).toBeInTheDocument()
+    expect(getByText(/Guiding statement/)).toBeInTheDocument()
+    expect(getByTestId('download-col-header')).toBeInTheDocument()
 
-  describe('linking back to the Editor component', () => {
-    it('renders a link to the Editor', () => {
-      expect.assertions(1)
-      const link = wrapper.instance().linkFormatter(resourceTemplateSummary.name, resourceTemplateSummary)
+    // There is a link from the resource label that loads the resource into the editor tab
+    expect(container.querySelector('a[href="/editor"]')).toBeInTheDocument()
+    fireEvent.click(getByText('Note'))
+    await wait(() => expect(history.location.pathname).toBe('/editor'))
 
-      expect(link.props.to.pathname).toEqual('/editor')
-    })
-  })
-  describe('linking to download the template', () => {
-    it('renders a link to download the template', () => {
-      expect.assertions(2)
-      const link = wrapper.instance().downloadLinkFormatter(resourceTemplateSummary.name, resourceTemplateSummary)
-
-      expect(link.props.resourceTemplateId).toEqual('ld4p:resourceTemplate:bf2:Note')
-      expect(link.props.groupName).toEqual('stanford')
-    })
+    // There is download link
+    saveAs.mockReturnValue('file saved')
+    expect(container.querySelector('button.btn-linky')).toBeInTheDocument()
+    fireEvent.click(getByTestId('download-link'))
+    expect(saveAs()).toMatch('file saved')
   })
 })

--- a/__tests__/test_utilities/testUtils.js
+++ b/__tests__/test_utilities/testUtils.js
@@ -6,10 +6,21 @@ import { render } from '@testing-library/react'
 import { createStore, applyMiddleware } from 'redux'
 import thunk from 'redux-thunk'
 import appReducer from 'reducers/index'
+import { MemoryRouter } from 'react-router-dom'
 
 export const renderWithRedux = (ui, store) => {
   return {
     ...render(<Provider store={store}>{ui}</Provider>),
+  }
+}
+
+export const renderWithReduxAndRouter = (ui, store) => {
+  return {
+    ...render(
+      <MemoryRouter>
+        <Provider store={store}>{ui}</Provider>
+      </MemoryRouter>,
+    ),
   }
 }
 

--- a/src/actionCreators/resourceTemplates.js
+++ b/src/actionCreators/resourceTemplates.js
@@ -41,6 +41,7 @@ export const fetchResourceTemplateSummaries = () => (dispatch) => {
     }
   }, (error) => {
     console.error('Error retrieving list of resource templates', error)
+    dispatch(setRetrieveResourceTemplateError('list of resource templates', error))
   })
 }
 

--- a/src/components/templates/Download.jsx
+++ b/src/components/templates/Download.jsx
@@ -14,7 +14,7 @@ const Download = (props) => {
   }
 
   return (
-    <button className="btn btn-link btn-linky" onClick={handleFileDownload}>Download</button>
+    <button className="btn btn-link btn-linky" data-testid="download-link" onClick={handleFileDownload}>Download</button>
   )
 }
 

--- a/src/components/templates/SinopiaResourceTemplates.jsx
+++ b/src/components/templates/SinopiaResourceTemplates.jsx
@@ -1,126 +1,116 @@
 // Copyright 2019 Stanford University see LICENSE for license
 
-import React, { Component } from 'react'
+import React, { useEffect, useState } from 'react'
+import { useSelector, useDispatch } from 'react-redux'
 import PropTypes from 'prop-types'
 import { Link } from 'react-router-dom'
 import 'react-bootstrap-table-next/dist/react-bootstrap-table2.min.css'
 import BootstrapTable from 'react-bootstrap-table-next'
 import Download from 'components/templates/Download'
-import { bindActionCreators } from 'redux'
-import { connect } from 'react-redux'
 import { newResource } from 'actionCreators/resources'
 import { rootResource } from 'selectors/resourceSelectors'
 
 /**
  * This is the list view of all the templates
  */
-class SinopiaResourceTemplates extends Component {
-  constructor(props) {
-    super(props)
-    this.state = { navigateEditor: false }
-  }
+const SinopiaResourceTemplates = (props) => {
+  const dispatch = useDispatch()
 
-  componentDidUpdate() {
+  const resourceTemplateSummaries = useSelector(state => Object.values(state.selectorReducer.entities.resourceTemplateSummaries))
+  const error = useSelector(state => state.selectorReducer.editor.retrieveResourceTemplateError)
+  const rtRoot = useSelector(state => rootResource(state))
+
+  const [navigateEditor, setNavigateEditor] = useState(false)
+
+  useEffect(() => {
     // Forces a wait until the root resource has been set in state
-    if (this.state.navigateEditor && this.props.rootResource && !this.props.error) {
-      this.props.history.push('/editor')
+    if (navigateEditor && rtRoot && !error) {
+      props.history.push('/editor')
     }
-  }
+  }, [navigateEditor, rtRoot, props.history, error])
 
-  handleClick = (resourceTemplateId, event) => {
+  const handleClick = (resourceTemplateId, event) => {
     event.preventDefault()
-    this.props.newResource(resourceTemplateId).then((result) => {
-      this.setState({ navigateEditor: result })
-    })
+    dispatch(newResource(resourceTemplateId)).then(result => setNavigateEditor(result))
   }
 
-  linkFormatter = (cell, row) => (
-    <Link to={{ pathname: '/editor', state: { } }} onClick={e => this.handleClick(row.id, e)}>{cell}</Link>
-  )
+  const linkFormatter = (cell, row) => (<Link to={{ pathname: '/editor', state: { } }} onClick={e => handleClick(row.id, e)}>{row.name}</Link>)
 
-  downloadLinkFormatter = (cell, row) => (<Download resourceTemplateId={ row.id } groupName={ row.group } />)
+  const downloadLinkFormatter = (cell, row) => (<Download resourceTemplateId={ row.id } groupName={ row.group } />)
 
-  render() {
-    if (this.props.resourceTemplateSummaries.length === 0) {
-      return (
-        <div className="alert alert-warning alert-dismissible">
-          <button className="close" data-dismiss="alert" aria-label="close">&times;</button>
-          No connection to the Sinopia Server is available, or there are no resources for any group.
-        </div>
-      )
-    }
-
-    const createResourceMessage = this.props.messages.length === 0
-      ? (<span />)
-      : (
-        <div className="alert alert-info">
-          { this.props.messages.join(', ') }
-        </div>
-      )
-
-    const errorMessage = this.props.error === undefined
-      ? (<span />)
-      : (<div className="alert alert-warning">{ this.props.error }</div>)
-
-    const defaultSorted = [{
-      dataField: 'name', // default sort column name
-      order: 'asc', // default sort order
-    }]
-
-    const columns = [
-      {
-        dataField: 'name',
-        text: 'Template name',
-        sort: true,
-        formatter: this.linkFormatter,
-        headerStyle: { backgroundColor: '#F8F6EF', width: '30%' },
-        style: { wordBreak: 'break-all' },
-      },
-      {
-        dataField: 'id',
-        text: 'ID',
-        sort: true,
-        headerStyle: { backgroundColor: '#F8F6EF', width: '30%' },
-        style: { wordBreak: 'break-all' },
-      },
-      {
-        dataField: 'author',
-        text: 'Author',
-        sort: true,
-        headerStyle: { backgroundColor: '#F8F6EF', width: '10%' },
-        style: { wordBreak: 'break-all' },
-      },
-      {
-        dataField: 'remark',
-        text: 'Guiding statement',
-        sort: false,
-        headerStyle: { backgroundColor: '#F8F6EF', width: '22%' },
-        style: { wordBreak: 'break-all' },
-      },
-      {
-        dataField: 'download',
-        text: 'Download',
-        sort: false,
-        formatter: this.downloadLinkFormatter,
-        headerStyle: { backgroundColor: '#F8F6EF', width: '8%' },
-        style: { wordBreak: 'break-all' },
-      },
-    ]
-
-    return (
-      <div>
-        { createResourceMessage }
-        { errorMessage }
-        <h4>Available Resource Templates in Sinopia</h4>
-        <BootstrapTable
-          id="resource-template-list"
-          keyField="key"
-          data={ this.props.resourceTemplateSummaries }
-          columns={ columns }
-          defaultSorted={ defaultSorted }/>
+  const createResourceMessage = props.messages.length === 0
+    ? (<span />)
+    : (
+      <div className="alert alert-info">
+        { props.messages.join(', ') }
       </div>
     )
-  }
+
+  const errorMessage = error === undefined
+    ? (<span />)
+    : (<div className="alert alert-warning">{ error }</div>)
+
+  const defaultSorted = [{
+    dataField: 'name', // default sort column name
+    order: 'asc', // default sort order
+  }]
+
+  const columns = [
+    {
+      dataField: 'name',
+      text: 'Template name',
+      sort: true,
+      formatter: linkFormatter,
+      headerStyle: { backgroundColor: '#F8F6EF', width: '30%' },
+      style: { wordBreak: 'break-all' },
+    },
+    {
+      dataField: 'id',
+      text: 'ID',
+      sort: true,
+      headerStyle: { backgroundColor: '#F8F6EF', width: '30%' },
+      style: { wordBreak: 'break-all' },
+    },
+    {
+      dataField: 'author',
+      text: 'Author',
+      sort: true,
+      headerStyle: { backgroundColor: '#F8F6EF', width: '10%' },
+      style: { wordBreak: 'break-all' },
+    },
+    {
+      dataField: 'remark',
+      text: 'Guiding statement',
+      sort: false,
+      headerStyle: { backgroundColor: '#F8F6EF', width: '22%' },
+      style: { wordBreak: 'break-all' },
+    },
+    {
+      dataField: 'download',
+      text: 'Download',
+      sort: false,
+      formatter: downloadLinkFormatter,
+      headerStyle: { backgroundColor: '#F8F6EF', width: '8%' },
+      style: { wordBreak: 'break-all' },
+      attrs: {
+        'data-testid': 'download-col-header',
+      },
+    },
+  ]
+
+  return (
+    <div>
+      { createResourceMessage }
+      { errorMessage }
+      <h4>Available Resource Templates in Sinopia</h4>
+      <BootstrapTable
+        id="resource-template-list"
+        keyField="key"
+        data={ resourceTemplateSummaries }
+        columns={ columns }
+        defaultSorted={ defaultSorted }/>
+    </div>
+  )
 }
 
 SinopiaResourceTemplates.propTypes = {
@@ -132,17 +122,4 @@ SinopiaResourceTemplates.propTypes = {
   rootResource: PropTypes.object,
 }
 
-const mapStateToProps = (state) => {
-  const resourceTemplateSummaries = Object.values(state.selectorReducer.entities.resourceTemplateSummaries)
-  const resource = rootResource(state)
-  const error = state.selectorReducer.editor.retrieveResourceTemplateError
-  return {
-    resourceTemplateSummaries,
-    error,
-    rootResource: resource,
-  }
-}
-
-const mapDispatchToProps = dispatch => bindActionCreators({ newResource }, dispatch)
-
-export default connect(mapStateToProps, mapDispatchToProps)(SinopiaResourceTemplates)
+export default SinopiaResourceTemplates


### PR DESCRIPTION
Clicking a Resource Template takes you to the Editor with the RT and default values loaded, and allows you to download the resource:

![SinopiaRTs 2019-10-11 12_19_14](https://user-images.githubusercontent.com/3093850/66678736-67bc9980-ec21-11e9-99c7-db0805fd825e.gif)

If the list of available resource templates cannot load, an error message is displayed (via redux not the component itself):

![SinopiaRTsError 2019-10-11 12_19_26](https://user-images.githubusercontent.com/3093850/66678747-71460180-ec21-11e9-9554-39003dd040bd.gif)


