### PR TITLE
Prevent an extra closing div tag

### DIFF
--- a/__tests__/components/templates/UpdateResourceModal.test.js
+++ b/__tests__/components/templates/UpdateResourceModal.test.js
@@ -33,7 +33,7 @@ describe('<UpdateResourceModal> with conflict message', () => {
   }]
 
   const mockUpdate = jest.fn()
-  const wrapper = shallow(<UpdateResourceModal show={true} messages={messages} update={mockUpdate} />)
+  const wrapper = shallow(<UpdateResourceModal messages={messages} update={mockUpdate} />)
 
   wrapper.update()
 
@@ -76,7 +76,7 @@ describe('message with no data (or id)', () => {
 
   const mockUpdate = jest.fn()
   const mockClose = jest.fn()
-  const wrapper = shallow(<UpdateResourceModal show={true} close={mockClose} messages={messages} update={mockUpdate} />)
+  const wrapper = shallow(<UpdateResourceModal close={mockClose} messages={messages} update={mockUpdate} />)
 
   wrapper.update()
 

--- a/src/components/templates/ImportResourceTemplate.jsx
+++ b/src/components/templates/ImportResourceTemplate.jsx
@@ -143,14 +143,11 @@ class ImportResourceTemplate extends Component {
   render() {
     return (
       <div id="importResourceTemplate">
-        <div>
-          { this.state.modalShow ? (
-            <UpdateResourceModal show={this.state.modalShow}
-                                 close={this.modalClose}
-                                 messages={this.state.modalMessages}
-                                 update={this.handleUpdateResource} />)
-            : (<div/>) }
-        </div>
+        { this.state.modalShow && (
+          <UpdateResourceModal close={this.modalClose}
+                               messages={this.state.modalMessages}
+                               update={this.handleUpdateResource} />)
+        }
         <Header triggerEditorMenu={this.props.triggerHandleOffsetMenu}/>
         <ImportFileZone setResourceTemplateCallback={this.setResourceTemplates} />
         <SinopiaResourceTemplates messages={this.state.flashMessages} history={this.props.history} key="sinopia-resource-templates" />

--- a/src/components/templates/UpdateResourceModal.jsx
+++ b/src/components/templates/UpdateResourceModal.jsx
@@ -43,7 +43,7 @@ class UpdateResourceModal extends Component {
   render() {
     return (
       <div>
-        <div className="modal fade" data-show={this.props.show} role="dialog">
+        <div className="modal fade" data-show={true} role="dialog">
           <div className="modal-dialog" role="document">
             <div className="modal-content">
               <div className="modal-header">
@@ -66,7 +66,6 @@ class UpdateResourceModal extends Component {
 
 UpdateResourceModal.propTypes = {
   close: PropTypes.func,
-  show: PropTypes.bool,
   messages: PropTypes.array,
   update: PropTypes.func,
 }


### PR DESCRIPTION
This can break the html.  Remove UpdateResourceModal show property because it's always true