### PR TITLE
Allow user to upload rt or profile

### DIFF
--- a/__tests__/components/templates/ImportFileZone.test.js
+++ b/__tests__/components/templates/ImportFileZone.test.js
@@ -159,7 +159,7 @@ describe('<DropZone />', () => {
     wrapper.setState({ showDropZone: false })
     wrapper.find('button.btn').simulate('click')
     expect(wrapper.find('DropZone > section > p').last().text())
-      .toMatch('Drag and drop a resource template file in the box or click it to select a file to upload:')
+      .toMatch('Drag and drop a profile or resource template file in the box or click it to select a file to upload:')
   })
 
   it('hides the dropzone div when button is clicked again', () => {

--- a/__tests__/components/templates/ImportResourceTemplate.test.js
+++ b/__tests__/components/templates/ImportResourceTemplate.test.js
@@ -43,7 +43,7 @@ describe('<ImportResourceTemplate />', () => {
   })
 
   describe('setResourceTemplates()', () => {
-    const content = {
+    const profileContent = {
       Profile: {
         resourceTemplates: [
           {
@@ -56,15 +56,32 @@ describe('<ImportResourceTemplate />', () => {
       },
     }
 
-    it('resets messages, creates one resource per template, and then updates state', async () => {
+    const resourceTemplateContent = {
+      id: 'template1',
+    }
+
+    it('resets messages, creates one resource per template in profile, and then updates state', async () => {
       expect.assertions(3)
       const createResourceSpy = jest.spyOn(wrapper.instance(), 'createResource').mockImplementation(async () => {})
       const updateStateSpy = jest.spyOn(wrapper.instance(), 'updateStateFromServerResponses').mockReturnValue(null)
       const resetMessagesSpy = jest.spyOn(wrapper.instance(), 'resetMessages').mockReturnValue(null)
 
-      await wrapper.instance().setResourceTemplates(content, 'ld4p')
+      await wrapper.instance().setResourceTemplates(profileContent, 'ld4p')
 
       expect(createResourceSpy).toHaveBeenCalledTimes(2)
+      expect(updateStateSpy).toHaveBeenCalledTimes(1)
+      expect(resetMessagesSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('resets messages, creates one resource template, and then updates state', async () => {
+      expect.assertions(3)
+      const createResourceSpy = jest.spyOn(wrapper.instance(), 'createResource').mockImplementation(async () => {})
+      const updateStateSpy = jest.spyOn(wrapper.instance(), 'updateStateFromServerResponses').mockReturnValue(null)
+      const resetMessagesSpy = jest.spyOn(wrapper.instance(), 'resetMessages').mockReturnValue(null)
+
+      await wrapper.instance().setResourceTemplates(resourceTemplateContent, 'ld4p')
+
+      expect(createResourceSpy).toHaveBeenCalledTimes(1)
       expect(updateStateSpy).toHaveBeenCalledTimes(1)
       expect(resetMessagesSpy).toHaveBeenCalledTimes(1)
     })
@@ -302,7 +319,7 @@ describe('<ImportResourceTemplate />', () => {
 
       expect(updateResourceSpy).toHaveBeenCalledTimes(2)
       expect(updateStateSpy).toHaveBeenCalledTimes(1)
-      expect(mockFetchResourceTemplateSummaries).toHaveBeenCalledTimes(2)
+      expect(mockFetchResourceTemplateSummaries).toHaveBeenCalledTimes(3)
     })
   })
 })

--- a/__tests__/integration/schemaValidation.test.js
+++ b/__tests__/integration/schemaValidation.test.js
@@ -48,8 +48,7 @@ describe('Loading an invalid resource template', () => {
     // Upload the resource template
     fireEvent.click(getByText('Linked Data Editor'))
     fireEvent.click(getByText('Import a Profile containing New or Revised Resource Templates'))
-
-    expect(getByText(/Drag and drop a resource template file/)).toBeInTheDocument()
+    expect(getByText(/Drag and drop a profile or resource template file/)).toBeInTheDocument()
     expect(queryByText(/The profile you provided was not valid JSON/)).not.toBeInTheDocument()
 
     const file = new File(['(⌐□_□)'], 'bad_json.json', {

--- a/cypress/integration/end2end.spec.js
+++ b/cypress/integration/end2end.spec.js
@@ -37,7 +37,7 @@ describe('End-to-end test', () => {
     cy.get('#resource-template-list').then((resourceTemplateList) => {
       if (resourceTemplateList.text().includes('No resource template are available.')) {
         cy.contains('Import a Profile').click()
-        cy.contains('Drag and drop a resource template file')
+        cy.contains('Drag and drop a profile or resource template file')
         const fileName = 'LD4P_BIBFRAME_2.0_Title_Information.json'
         cy.fixture(fileName).then((fileJson) => {
           const fileContent = JSON.stringify(fileJson)

--- a/cypress/integration/end2end.spec.js
+++ b/cypress/integration/end2end.spec.js
@@ -29,7 +29,7 @@ describe('End-to-end test', () => {
     cy.url().should('include', '/templates')
   })
 
-  it('Uploads a resource template', () => {
+  it('Uploads a profile template', () => {
     // Need to determine if should upload a resource template.
     // Both the resource template list and the notification that there are no loaded resource templates
     // have the same id. Waiting for that element to be present allows this test to be deterministic,

--- a/src/components/templates/DropZone.jsx
+++ b/src/components/templates/DropZone.jsx
@@ -56,7 +56,7 @@ const DropZone = (props) => {
       <p style={{
         marginLeft: 'auto', marginRight: 'auto', paddingLeft: '1.5em', textIndent: '-1.5em', width: '300px',
       }}>
-        Drag and drop a resource template file in the box
+        Drag and drop a profile or resource template file in the box
           or click it to select a file to upload:
       </p>
 

--- a/src/components/templates/ImportFileZone.jsx
+++ b/src/components/templates/ImportFileZone.jsx
@@ -74,7 +74,7 @@ class ImportFileZone extends Component {
           await this.props.setResourceTemplateCallback(template, this.state.group)
         })
         .catch((err) => {
-          this.addMessage(`The profile you provided was not in an accepable format: ${err}`)
+          this.addMessage(`The profile you provided was not in an acceptable format: ${err}`)
         })
     } catch (err) {
       this.addMessage(`The profile you provided was not valid JSON: ${err}`)

--- a/src/components/templates/ImportResourceTemplate.jsx
+++ b/src/components/templates/ImportResourceTemplate.jsx
@@ -29,9 +29,16 @@ class ImportResourceTemplate extends Component {
     const responses = []
     // Prefer for ... of to forEach when loop body uses async/await
 
-    for (const rt of content.Profile.resourceTemplates) {
-      const response = await this.createResource(rt, group)
-
+    // if we have a profile with multiple resource templates, iterate and load all of them
+    if (content.Profile) {
+      for (const rt of content.Profile.resourceTemplates) {
+        const response = await this.createResource(rt, group)
+        responses.push(response)
+      }
+    }
+    else // if the uploaded content is a single resource template, just load that one
+    {
+      const response = await this.createResource(content, group)
       responses.push(response)
     }
     this.updateStateFromServerResponses(responses)


### PR DESCRIPTION
fixes #1602 

Allows a user to upload either a single resource template or a profile. Also, changed some labels to match the new reality.

Note: Some of the work was already done (validation code works fine in both scenarios).


To do:
- [x] test