### PR TITLE
Cleans up resource validation state.

### DIFF
--- a/__tests__/components/App.test.js
+++ b/__tests__/components/App.test.js
@@ -35,6 +35,11 @@ const createInitialState = (options = {}) => {
       },
       editor: {
         copyToNewMessage: {},
+        resourceValidation: {
+          show: false,
+          errors: [],
+          errorsByPath: {},
+        }
       },
       appVersion: {
         version: undefined,

--- a/__tests__/components/editor/Editor.test.js
+++ b/__tests__/components/editor/Editor.test.js
@@ -61,7 +61,11 @@ const createInitialState = (options = {}) => {
           timestamp: Date.now(),
           oldUri: 'https://sinopia.io/pcc/1345',
         },
-        resourceValidationErrors: {},
+        resourceValidation: {
+          show: false,
+          errors: [],
+          errorsByPath: {},
+        },
         saveResourceError: 'Error 999',
         rdfPreview: {
           show: true,
@@ -69,7 +73,6 @@ const createInitialState = (options = {}) => {
         groupChoice: {
           show: false,
         },
-        errors: [],
       },
     },
   }

--- a/__tests__/components/editor/RDFModal.test.js
+++ b/__tests__/components/editor/RDFModal.test.js
@@ -12,6 +12,11 @@ describe('<RDFModal />', () => {
     selectorReducer: {
       editor: {
         modal: undefined,
+        resourceValidation: {
+          show: false,
+          errors: [],
+          errorsByPath: {},
+        },
       },
       resource: {},
     },

--- a/__tests__/components/editor/SaveAndPublishButton.test.js
+++ b/__tests__/components/editor/SaveAndPublishButton.test.js
@@ -6,10 +6,12 @@ import SaveAndPublishButton from 'components/editor/SaveAndPublishButton'
 const createInitialState = () => ({
   selectorReducer: {
     editor: {
-      displayValidations: false,
+      resourceValidation: {
+        show: false,
+        errors: [],
+        errorsByPath: {},
+      },
       lastSaveChecksum: '54527c024d0021784f666c2794856938',
-      errors: [],
-      resourceValidationErrors: {},
     },
     resource: {
       'resourceTemplate:bf2:Identifiers:Barcode': {
@@ -82,7 +84,7 @@ describe('<SaveAndPublishButton />', () => {
   })
   it('is enabled if resource has changed and no validation errors', () => {
     const initialState = createInitialState()
-    initialState.selectorReducer.editor.displayValidations = true
+    initialState.selectorReducer.editor.resourceValidation.show = true
     const store = createReduxStore(initialState)
     const { getByText } = renderWithRedux(
       <SaveAndPublishButton id="test" />, store,
@@ -101,8 +103,8 @@ describe('<SaveAndPublishButton />', () => {
   it('is disabled if resource has changed and has validation errors', () => {
     const initialState = createInitialState()
     // initialState.selectorReducer.editor.lastSaveChecksum = 'c5c8da42a2b460a740c33c72acb4d115'
-    initialState.selectorReducer.editor.displayValidations = true
-    initialState.selectorReducer.editor.errors = [
+    initialState.selectorReducer.editor.resourceValidation.show = true
+    initialState.selectorReducer.editor.resourceValidation.errors = [
       {
         message: 'Required',
         path: [

--- a/__tests__/components/editor/property/InputListLOC.test.js
+++ b/__tests__/components/editor/property/InputListLOC.test.js
@@ -41,15 +41,17 @@ const createInitialState = (options = {}) => {
         lookups: {},
       },
       editor: {
-        resourceValidationErrors: {},
+        resourceValidation: {
+          show: false,
+          errors: [],
+          errorsByPath: {},
+        },
         rdfPreview: {
           show: true,
         },
         groupChoice: {
           show: false,
         },
-        errors: [],
-        displayValidations: false,
       },
     },
   }

--- a/__tests__/components/editor/property/InputLiteral.test.js
+++ b/__tests__/components/editor/property/InputLiteral.test.js
@@ -56,14 +56,17 @@ const createInitialState = (options = {}) => {
         },
       },
       editor: {
-        resourceValidationErrors: {},
+        resourceValidation: {
+          show: false,
+          errors: [],
+          errorsByPath: {},
+        },
         rdfPreview: {
           show: true,
         },
         groupChoice: {
           show: false,
         },
-        errors: [],
       },
     },
   }

--- a/__tests__/components/editor/property/InputURI.test.js
+++ b/__tests__/components/editor/property/InputURI.test.js
@@ -48,7 +48,11 @@ const createInitialState = (options = {}) => {
         },
       },
       editor: {
-        resourceValidationErrors: {},
+        resourceValidation: {
+          show: false,
+          errors: [],
+          errorsByPath: {},
+        },
         rdfPreview: {
           show: true,
         },

--- a/__tests__/components/load/LoadByRDFForm.test.js
+++ b/__tests__/components/load/LoadByRDFForm.test.js
@@ -29,6 +29,11 @@ const createInitialState = () => {
       },
       editor: {
         expanded: {},
+        resourceValidation: {
+          show: false,
+          errors: [],
+          errorsByPath: {},
+        },
       },
     },
     authenticate: {

--- a/__tests__/components/templates/SinopiaResourceTemplates.test.js
+++ b/__tests__/components/templates/SinopiaResourceTemplates.test.js
@@ -42,6 +42,9 @@ const createInitialState = () => {
       },
       editor: {
         serverError: '',
+        resourceValidation: {
+          show: false,
+        },
       },
     },
 

--- a/__tests__/integration/copyQASearchResult.test.js
+++ b/__tests__/integration/copyQASearchResult.test.js
@@ -47,7 +47,11 @@ const createInitialState = () => {
         lookups: {},
       },
       editor: {
-        resourceValidationErrors: {},
+        resourceValidation: {
+          show: false,
+          errors: [],
+          errorsByPath: {},
+        },
         copyToNewMessage: {
           show: false,
         },

--- a/__tests__/integration/nestedResources.test.js
+++ b/__tests__/integration/nestedResources.test.js
@@ -41,8 +41,11 @@ const createInitialState = () => {
         lookups: {},
       },
       editor: {
-        resourceValidationErrors: {},
-        errors: [],
+        resourceValidation: {
+          show: false,
+          errors: [],
+          errorsByPath: {},
+        },
         copyToNewMessage: {},
         rdfPreview: {
           show: true,

--- a/__tests__/integration/previewSaveIncompleteResource.test.js
+++ b/__tests__/integration/previewSaveIncompleteResource.test.js
@@ -68,7 +68,11 @@ const createInitialState = () => {
         },
       },
       editor: {
-        resourceValidationErrors: {},
+        resourceValidation: {
+          show: false,
+          errors: [],
+          errorsByPath: {},
+        },
         copyToNewMessage: {},
         rdfPreview: {
           show: true,

--- a/__tests__/integration/previewSaveResource.test.js
+++ b/__tests__/integration/previewSaveResource.test.js
@@ -71,8 +71,11 @@ const createInitialState = () => {
         },
       },
       editor: {
-        resourceValidationErrors: {},
-        errors: [],
+        resourceValidation: {
+          show: false,
+          errors: [],
+          errorsByPath: {},
+        },
         copyToNewMessage: {},
         rdfPreview: {
           show: true,

--- a/__tests__/reducers/index.test.js
+++ b/__tests__/reducers/index.test.js
@@ -32,7 +32,11 @@ beforeEach(() => {
       resource: { // The state we're displaying in the editor
       },
       editor: {
-        displayValidations: false,
+        resourceValidation: {
+          show: false,
+          errors: [],
+          errorsByPath: {},
+        },
       },
     },
   }
@@ -302,8 +306,8 @@ describe('removeResource', () => {
       },
     })
     // Validation performed
-    expect(newState.editor.errors).toBeTruthy()
-    expect(newState.editor.resourceValidationErrors).toBeTruthy()
+    expect(newState.editor.resourceValidation.errors).toBeTruthy()
+    expect(newState.editor.resourceValidation.errorsByPath).toBeTruthy()
   })
 })
 
@@ -340,7 +344,7 @@ describe('setLastSaveChecksum', () => {
 describe('setResource', () => {
   it('updates state', () => {
     initialState.selectorReducer.entities.resourceTemplates['resourceTemplate:bf2:Work:Instance'] = 'anotherrt'
-    initialState.selectorReducer.editor.displayValidations = true
+    initialState.selectorReducer.editor.resourceValidation.show = true
     initialState.selectorReducer.editor.copyToNewMessage = { foo: 'bar' }
     const newState = appReducer(initialState, {
       type: 'RESOURCE_LOADED',
@@ -357,7 +361,7 @@ describe('setResource', () => {
       'resourceTemplate:bf2:Monograph:Instance': 'thert',
       'resourceTemplate:bf2:Work:Instance': 'anotherrt',
     })
-    expect(newState.selectorReducer.editor.displayValidations).toBe(false)
+    expect(newState.selectorReducer.editor.resourceValidation.show).toBe(false)
     expect(newState.selectorReducer.editor.copyToNewMessage).toEqual({})
   })
 })

--- a/__tests__/reducers/inputs.test.js
+++ b/__tests__/reducers/inputs.test.js
@@ -5,9 +5,7 @@ import {
   validate, showGroupChooser, showCopyNewMessage,
   showModal, hideModal,
 } from 'reducers/inputs'
-import {
-  findNode,
-} from 'selectors/resourceSelectors'
+import { findNode } from 'selectors/resourceSelectors'
 import Validator from 'ResourceValidator'
 
 let initialState
@@ -27,8 +25,11 @@ beforeAll(() => {
 beforeEach(() => {
   initialState = {
     editor: {
-      errors: [],
-      displayValidations: false,
+      resourceValidation: {
+        show: false,
+        errors: [],
+        errorsByPath: {},
+      },
       modal: undefined,
       copyToNewMessage: {},
       resourceURIMessage: {
@@ -446,6 +447,6 @@ describe('removeMyItem', () => {
 describe('validate', () => {
   it('returns a new state', () => {
     const result = validate(initialState)
-    expect(findNode({ selectorReducer: result }, ['resource', 'editor', 'displayValidations'])).toBeTruthy()
+    expect(findNode({ selectorReducer: result }, ['resource', 'editor', 'resourceValidation', 'show'])).toBeTruthy()
   })
 })

--- a/__tests__/selectors/resourceSelectors.test.js
+++ b/__tests__/selectors/resourceSelectors.test.js
@@ -2,7 +2,7 @@
 
 import {
   rootResourceId, isExpanded, itemsForProperty,
-  getDisplayValidations, getResourceTemplate, getPropertyTemplate,
+  getDisplayResourceValidations, getResourceTemplate, getPropertyTemplate,
   resourceHasChangesSinceLastSave,
 } from 'selectors/resourceSelectors'
 import { getFixtureResourceTemplate } from '../fixtureLoaderHelper'
@@ -37,21 +37,18 @@ describe('rootResourceId', () => {
   })
 })
 
-describe('getDisplayValidations()', () => {
-  it('returns false when missing', () => {
-    expect(getDisplayValidations(initialState)).toBeFalsy()
-  })
-
+describe('getDisplayResourceValidations()', () => {
   it('returns value when present', () => {
     const state = {
       selectorReducer: {
         editor: {
-          displayValidations: true,
+          resourceValidation: {
+            show: true,
+          },
         },
       },
     }
-
-    expect(getDisplayValidations(state)).toBeTruthy()
+    expect(getDisplayResourceValidations(state)).toBeTruthy()
   })
 })
 

--- a/src/components/editor/ErrorMessages.jsx
+++ b/src/components/editor/ErrorMessages.jsx
@@ -3,7 +3,7 @@
 import React from 'react'
 import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
-import { findNode } from 'selectors/resourceSelectors'
+import { getDisplayResourceValidations, findResourceValidationErrors } from 'selectors/resourceSelectors'
 import Alert from '../Alert'
 
 const ErrorMessages = (props) => {
@@ -25,8 +25,8 @@ ErrorMessages.propTypes = {
 }
 
 const mapStateToProps = state => ({
-  errors: findNode(state, ['editor']).errors,
-  displayValidations: state.selectorReducer.editor.displayValidations,
+  errors: findResourceValidationErrors(state),
+  displayValidations: getDisplayResourceValidations(state),
 })
 
 export default connect(mapStateToProps, {})(ErrorMessages)

--- a/src/components/editor/SaveAndPublishButton.jsx
+++ b/src/components/editor/SaveAndPublishButton.jsx
@@ -4,7 +4,10 @@ import React, { useState, useEffect } from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import PropTypes from 'prop-types'
 import { update as updateCreator } from 'actionCreators/resources'
-import { rootResourceId, resourceHasChangesSinceLastSave } from 'selectors/resourceSelectors'
+import {
+  rootResourceId, resourceHasChangesSinceLastSave, findResourceValidationErrors,
+  getDisplayResourceValidations,
+} from 'selectors/resourceSelectors'
 import { getCurrentUser } from 'authSelectors'
 import {
   showGroupChooser as showGroupChooserAction,
@@ -24,8 +27,8 @@ const SaveAndPublishButton = (props) => {
 
   const resourceHasChanged = useSelector(state => resourceHasChangesSinceLastSave(state))
   const isSaved = useSelector(state => !!rootResourceId(state))
-  const hasValidationErrors = useSelector(state => state.selectorReducer.editor.errors?.length > 0)
-  const validationErrorsAreShowing = useSelector(state => state.selectorReducer.editor.displayValidations)
+  const hasValidationErrors = useSelector(state => findResourceValidationErrors(state).length > 0)
+  const validationErrorsAreShowing = useSelector(state => getDisplayResourceValidations(state))
   const [isDisabled, setIsDisabled] = useState(true)
 
   useEffect(() => {

--- a/src/components/editor/property/InputListLOC.jsx
+++ b/src/components/editor/property/InputListLOC.jsx
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types'
 import { useDispatch, useSelector } from 'react-redux'
 import { changeSelections as changeSelectionsAction } from 'actions/index'
 import {
-  itemsForProperty, getDisplayValidations, getPropertyTemplate, findErrors,
+  itemsForProperty, getDisplayResourceValidations, getPropertyTemplate, findResourceValidationErrorsByPath,
 } from 'selectors/resourceSelectors'
 import { booleanPropertyFromTemplate, getLookupConfigItems } from 'utilities/propertyTemplates'
 import { renderMenuFunc, renderTokenFunc } from './renderTypeaheadFunctions'
@@ -91,8 +91,8 @@ const InputListLOC = (props) => {
     return defaultFilterBy(option, props)
   }
 
-  const displayValidations = useSelector(state => getDisplayValidations(state))
-  const validationErrors = useSelector(state => findErrors(state, props.reduxPath))
+  const displayValidations = useSelector(state => getDisplayResourceValidations(state))
+  const validationErrors = useSelector(state => findResourceValidationErrorsByPath(state, props.reduxPath))
 
   let error
   let groupClasses = 'form-group'

--- a/src/components/editor/property/InputLiteral.jsx
+++ b/src/components/editor/property/InputLiteral.jsx
@@ -8,7 +8,7 @@ import { connect } from 'react-redux'
 import shortid from 'shortid'
 import { itemsSelected } from 'actions/index'
 import {
-  findNode, getDisplayValidations, getPropertyTemplate, findErrors,
+  findNode, getDisplayResourceValidations, getPropertyTemplate, findResourceValidationErrorsByPath,
 } from 'selectors/resourceSelectors'
 import InputValue from './InputValue'
 import { defaultLanguageId } from 'Utilities'
@@ -106,9 +106,9 @@ const mapStateToProps = (state, ownProps) => {
   const reduxPath = ownProps.reduxPath
   const resourceTemplateId = reduxPath[reduxPath.length - 2]
   const propertyURI = reduxPath[reduxPath.length - 1]
-  const displayValidations = getDisplayValidations(state)
+  const displayValidations = getDisplayResourceValidations(state)
   const formData = findNode(state, reduxPath)
-  const errors = findErrors(state, reduxPath)
+  const errors = findResourceValidationErrorsByPath(state, reduxPath)
   // items has to be its own prop or rerendering won't occur when one is removed
   const items = formData.items || {}
   const propertyTemplate = getPropertyTemplate(state, resourceTemplateId, propertyURI)

--- a/src/components/editor/property/InputLookupQA.jsx
+++ b/src/components/editor/property/InputLookupQA.jsx
@@ -8,7 +8,7 @@ import shortid from 'shortid'
 import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
 import {
-  itemsForProperty, getDisplayValidations, getPropertyTemplate, findErrors,
+  itemsForProperty, getDisplayResourceValidations, getPropertyTemplate, findResourceValidationErrorsByPath,
 } from 'selectors/resourceSelectors'
 import { changeSelections } from 'actions/index'
 import { getSearchResults } from 'utilities/qa'
@@ -165,9 +165,9 @@ const mapStateToProps = (state, ownProps) => {
   const reduxPath = ownProps.reduxPath
   const resourceTemplateId = reduxPath[reduxPath.length - 2]
   const propertyURI = reduxPath[reduxPath.length - 1]
-  const displayValidations = getDisplayValidations(state)
+  const displayValidations = getDisplayResourceValidations(state)
   const propertyTemplate = getPropertyTemplate(state, resourceTemplateId, propertyURI)
-  const errors = findErrors(state, ownProps.reduxPath)
+  const errors = findResourceValidationErrorsByPath(state, ownProps.reduxPath)
   const selected = itemsForProperty(state, ownProps.reduxPath)
   const isLoading = state.selectorReducer.entities.qa.loading
 

--- a/src/components/editor/property/InputLookupSinopia.jsx
+++ b/src/components/editor/property/InputLookupSinopia.jsx
@@ -8,7 +8,8 @@ import SinopiaPropTypes from 'SinopiaPropTypes'
 import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
 import {
-  itemsForProperty, getDisplayValidations, getPropertyTemplate, findErrors,
+  itemsForProperty, getDisplayResourceValidations, getPropertyTemplate,
+  findResourceValidationErrorsByPath,
 } from 'selectors/resourceSelectors'
 import { changeSelections } from 'actions/index'
 import { booleanPropertyFromTemplate } from 'utilities/propertyTemplates'
@@ -105,9 +106,9 @@ const mapStateToProps = (state, ownProps) => {
   const reduxPath = ownProps.reduxPath
   const resourceTemplateId = reduxPath[reduxPath.length - 2]
   const propertyURI = reduxPath[reduxPath.length - 1]
-  const displayValidations = getDisplayValidations(state)
+  const displayValidations = getDisplayResourceValidations(state)
   const propertyTemplate = getPropertyTemplate(state, resourceTemplateId, propertyURI)
-  const errors = findErrors(state, ownProps.reduxPath)
+  const errors = findResourceValidationErrorsByPath(state, ownProps.reduxPath)
   const selected = itemsForProperty(state, ownProps.reduxPath)
 
   return {

--- a/src/components/editor/property/InputURI.jsx
+++ b/src/components/editor/property/InputURI.jsx
@@ -8,7 +8,7 @@ import { connect } from 'react-redux'
 import shortid from 'shortid'
 import { itemsSelected } from 'actions/index'
 import {
-  findNode, getDisplayValidations, getPropertyTemplate, findErrors,
+  findNode, getDisplayResourceValidations, getPropertyTemplate, findResourceValidationErrorsByPath,
 } from 'selectors/resourceSelectors'
 
 import InputValue from './InputValue'
@@ -126,11 +126,11 @@ const mapStateToProps = (state, props) => {
   const reduxPath = props.reduxPath
   const resourceTemplateId = reduxPath[reduxPath.length - 2]
   const propertyURI = reduxPath[reduxPath.length - 1]
-  const displayValidations = getDisplayValidations(state)
+  const displayValidations = getDisplayResourceValidations(state)
   // items has to be its own prop or rerendering won't occur when one is removed
   const items = findNode(state, reduxPath).items || {}
   const propertyTemplate = getPropertyTemplate(state, resourceTemplateId, propertyURI)
-  const errors = findErrors(state, reduxPath)
+  const errors = findResourceValidationErrorsByPath(state, reduxPath)
 
   return {
     items,

--- a/src/components/editor/property/OutlineHeader.jsx
+++ b/src/components/editor/property/OutlineHeader.jsx
@@ -8,7 +8,7 @@ import { faAngleRight, faAngleDown } from '@fortawesome/free-solid-svg-icons'
 import PropertyLabel from './PropertyLabel'
 import PropertyLabelInfo from './PropertyLabelInfo'
 import {
-  findNode, isExpanded, getPropertyTemplate, findErrors, getDisplayValidations,
+  findNode, isExpanded, getPropertyTemplate, findResourceValidationErrorsByPath, getDisplayResourceValidations,
 } from 'selectors/resourceSelectors'
 import { toggleCollapse, removeResource } from 'actions/index'
 import { expandResource } from 'actionCreators/resources'
@@ -74,8 +74,8 @@ const mapStateToProps = (state, ownProps) => {
   const resourceTemplateId = ownProps.reduxPath.slice(-2)[0]
   const property = getPropertyTemplate(state, resourceTemplateId, propertyURI)
   const resourceModel = findNode(state, ownProps.reduxPath)
-  const errors = findErrors(state, ownProps.reduxPath)
-  const displayValidations = getDisplayValidations(state)
+  const errors = findResourceValidationErrorsByPath(state, ownProps.reduxPath)
+  const displayValidations = getDisplayResourceValidations(state)
   return {
     resourceModel,
     property,

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -20,7 +20,7 @@ import _ from 'lodash'
 export const setResource = (state, action) => {
   // This should be a lodash cloneDeep.
   const newState = { ...state }
-  newState.editor.displayValidations = false
+  newState.editor.resourceValidation.show = false
   newState.editor.copyToNewMessage = {}
   newState.resource = action.payload.resource
   newState.entities.resourceTemplates = { ...newState.entities.resourceTemplates, ...action.payload.resourceTemplates }

--- a/src/reducers/inputs.js
+++ b/src/reducers/inputs.js
@@ -11,8 +11,8 @@ import { findObjectAtPath } from 'selectors/resourceSelectors'
 export const validate = (state) => {
   const newState = { ...state }
   const result = new Validator(newState).validate()
-  newState.editor.resourceValidationErrors = result[0]
-  newState.editor.errors = result[1]
+  newState.editor.resourceValidation.errorsByPath = result[0]
+  newState.editor.resourceValidation.errors = result[1]
   return newState
 }
 
@@ -24,13 +24,13 @@ export const validate = (state) => {
 export const showGroupChooser = (state) => {
   const newState = { ...state }
 
-  if (validate(state).editor.errors.length === 0) {
+  if (validate(state).editor.resourceValidation.errors.length === 0) {
     // Show the window to select a group
     newState.editor.modal = 'GroupChoiceModal'
   } else {
     newState.editor.modal = undefined
     // Show errors that prevent save
-    newState.editor.displayValidations = true
+    newState.editor.resourceValidation.show = true
   }
 
   return newState
@@ -45,7 +45,7 @@ export const showValidationErrors = (state) => {
   const newState = { ...state }
 
   newState.editor.modal = undefined
-  newState.editor.displayValidations = true
+  newState.editor.resourceValidation.show = true
 
   return newState
 }
@@ -58,7 +58,7 @@ export const showValidationErrors = (state) => {
 export const hideValidationErrors = (state) => {
   const newState = { ...state }
 
-  newState.editor.displayValidations = false
+  newState.editor.resourceValidation.show = false
 
   return newState
 }

--- a/src/selectors/resourceSelectors.js
+++ b/src/selectors/resourceSelectors.js
@@ -15,7 +15,22 @@ export const findObjectAtPath = (parent, path) => path.reduce((obj, key) => obj?
 export const isExpanded = (state, reduxPath) => [...reduxPath, 'expanded']
   .reduce((obj, key) => (typeof obj[key] !== 'undefined' ? obj[key] : false), state.selectorReducer.editor.expanded)
 
-export const findErrors = (state, reduxPath) => findObjectAtPath(state.selectorReducer.editor.resourceValidationErrors, reduxPath).errors || []
+const findResourceValidation = state => state.selectorReducer.editor.resourceValidation
+
+/**
+ * @returns {function} a function that returns all of the validation errors for the redux path
+ */
+export const findResourceValidationErrorsByPath = (state, reduxPath) => findObjectAtPath(findResourceValidation(state).errorsByPath, reduxPath).errors || []
+
+/**
+ * @returns {function} a function that returns all of the validation errors for the resource
+ */
+export const findResourceValidationErrors = state => findResourceValidation(state).errors
+
+/**
+ * @returns {function} a function that returns true if validations should be displayed
+ */
+export const getDisplayResourceValidations = state => findResourceValidation(state).show
 
 /**
  * Get a list of selections that have been made for the given reduxPath
@@ -27,11 +42,6 @@ export const itemsForProperty = (state, reduxPath) => {
   const result = findNode(state, reduxPath)
   return Object.values(result.items || {})
 }
-
-/**
- * @returns {function} a function that returns true if validations should be displayed
- */
-export const getDisplayValidations = state => findNode(state, ['editor']).displayValidations
 
 /**
  * @returns {function} a function that gets a resource template from state or undefined

--- a/src/store.js
+++ b/src/store.js
@@ -13,16 +13,17 @@ const initialState = {
       lastChecked: Date.now(),
     },
     editor: { // The state of the editor
-      displayValidations: false,
-      errors: [],
+      resourceValidation: {
+        show: false,
+        errors: [], // List of validation errors
+        errorsByPath: {}, // Errors from validating resource (redux path organized)
+      },
       modal: undefined, // Name of modal to show. Should only be one at a time.
       resourceURIMessage: {
         show: false,
       },
       copyToNewMessage: {},
       expanded: { // Should this node display as expanded in the editor (redux path organized)
-      },
-      resourceValidationErrors: { // Errors from validating resource (redux path organized)
       },
       retrieveResourceError: undefined,
       retrieveResourceTemplateError: undefined,


### PR DESCRIPTION
This re-organizes and renames resource validation state to make it consistent with other state conventions and to have clearer naming. This is in preparation for upcoming work on handling errors.