### PR TITLE
override bootstrap CSS to ensure text is black against white background

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -340,6 +340,10 @@ input.rbt-input-main {
   padding-left: 8px;
 }
 
+.dropdown-item.active {
+  color: #000000;
+}
+
 th.search-header {
   background-color: #F8F6EF;
 }


### PR DESCRIPTION
fixes #1576 

when rendering drop-down menus in the LookupComponent, we should be sure the text is black (since the background is white), so we can read it