### PR TITLE
Copy URI "button" improvements

### DIFF
--- a/__tests__/components/editor/ResourceURIMessage.test.js
+++ b/__tests__/components/editor/ResourceURIMessage.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { fireEvent } from '@testing-library/react'
+import { fireEvent, wait } from '@testing-library/react'
 import ResourceURIMessage from 'components/editor/ResourceURIMessage'
 /* eslint import/no-unresolved: 'off' */
 import { renderWithRedux, createReduxStore } from 'testUtils'
@@ -45,5 +45,9 @@ describe('ResourceURIMessage', () => {
     )
     fireEvent.click(getByText('Copy URI'))
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith('http://localhost:8080/repository/cornell/f6b80d28-cc1b-44ef-8aaf-618569a981cd')
+    expect(getByText('Copied URI to Clipboard'))
+    wait(() => {
+      expect(getByText('Copy URI'))
+    })
   })
 })

--- a/src/components/editor/ResourceURIMessage.jsx
+++ b/src/components/editor/ResourceURIMessage.jsx
@@ -1,21 +1,31 @@
 // Copyright 2019 Stanford University see LICENSE for license
 
-import React from 'react'
+import React, { useState } from 'react'
 import { useSelector } from 'react-redux'
 import { rootResourceId } from 'selectors/resourceSelectors'
 
 // Renders the resource URI message for saved resource
 const ResourceURIMessage = () => {
   const uri = useSelector(state => rootResourceId(state))
+  const [copyText, setCopyText] = useState('Copy URI')
 
   if (!uri) {
     return null
   }
 
+  const handleClick = (event) => {
+    navigator.clipboard.writeText(uri)
+    setCopyText(<em>Copied URI to Clipboard</em>)
+    setTimeout(() => setCopyText('Copy URI'), 3000)
+    event.preventDefault()
+  }
+
   return (
     <div>
       <h4>URI for this resource: &lt;{ uri }&gt;&nbsp;
-        <button type="button" className="btn btn-default btn-xs" onClick={() => { navigator.clipboard.writeText(uri) }}>Copy URI</button>
+        <button type="button"
+                className="btn btn-secondary btn-xs"
+                onClick={ handleClick }>{ copyText }</button>
       </h4>
     </div>
   )


### PR DESCRIPTION
Copy URI button now has `btn-secondary` css class so looks more like a button. When clicked, the text changes to _Copied URI  to Clipboard_ for 3 seconds before reverting back to *Copy URI* 

Fixes #1588 