### PR TITLE
Always set multiple prop to true and use function to set disabled prop

### DIFF
--- a/__tests__/components/editor/property/InputLookupQA.test.js
+++ b/__tests__/components/editor/property/InputLookupQA.test.js
@@ -1,92 +1,277 @@
 // Copyright 2019 Stanford University see LICENSE for license
 
 import React from 'react'
-import { shallow } from 'enzyme'
 import InputLookupQA from 'components/editor/property/InputLookupQA'
+import { fireEvent, wait, waitForElement } from '@testing-library/react'
+import { showValidationErrors, validateResource } from 'actions/index'
+import {
+  renderWithRedux, assertRDF, createReduxStore, setupModal,
+} from 'testUtils'
 
-const plProps = {
-  id: 'lookupComponent',
-  propertyTemplate: {
-    mandatory: 'false',
-    repeatable: 'false',
-    type: 'lookup',
-    resourceTemplates: [],
-    valueConstraint: {
-      valueTemplateRefs: [],
-      useValuesFrom: [
-        'lookupQaLocNames',
-      ],
-      valueDataType: {
-        dataTypeURI: 'http://id.loc.gov/ontologies/bibframe/Agent',
+const createInitialState = (options = {}) => {
+  const state = {
+    selectorReducer: {
+      entities: {
+        resourceTemplates: {
+          'ld4p:RT:bf2:Agent:bfPerson': {
+            propertyTemplates: [
+              {
+                repeatable: 'false',
+                mandatory: 'true',
+                type: 'lookup',
+                valueConstraint: {
+                  useValuesFrom: [
+                    'urn:ld4p:qa:names',
+                  ],
+                },
+                propertyLabel: 'Search LCNAF',
+                propertyURI: 'http://id.loc.gov/ontologies/bibframe/Person',
+                editable: 'true',
+              },
+            ],
+            id: 'ld4p:RT:bf2:Agent:bfPerson',
+            resourceURI: 'http://id.loc.gov/ontologies/bibframe/Person',
+            resourceLabel: 'Bibframe Person',
+            author: 'LD4P',
+            date: '2019-08-19',
+            schema: 'https://ld4p.github.io/sinopia/schemas/0.2.0/resource-template.json',
+          },
+        },
+        qa: {
+          loading: false,
+          options: [],
+        },
+      },
+      resource: {
+        'ld4p:RT:bf2:Agent:bfPerson': {
+          'http://id.loc.gov/ontologies/bibframe/Person': {
+            items: {},
+          },
+          'http://www.w3.org/2000/01/rdf-schema#label': {},
+        },
+      },
+      editor: {
+        resourceValidation: {
+          show: false,
+          errors: [],
+          errorsByPath: {},
+        },
+        rdfPreview: {
+          show: true,
+        },
+        groupChoice: {
+          show: false,
+        },
+        errors: [],
       },
     },
-    propertyURI: 'http://id.loc.gov/ontologies/bflc/target',
-    propertyLabel: 'Name Lookup',
-  },
-  lookupConfig: [
-    {
-      label: 'LOC person [names] (QA)',
-      uri: 'urn:ld4p:qa:names:person',
-      authority: 'locnames_ld4l_cache',
-      subauthority: 'person',
-      language: 'en',
-      component: 'lookup',
-    },
-  ],
-  isLoading: false,
-  search: jest.fn(),
+  }
+  if (options.hasInitialValue) {
+    const items = [
+      {
+        id: 'foo',
+        label: 'foo',
+        content: 'foo',
+      },
+    ]
+    state.selectorReducer.resource['ld4p:RT:bf2:Agent:bfPerson']['http://id.loc.gov/ontologies/bibframe/Person'].items = items
+  }
+  if (options.repeatable) {
+    state.selectorReducer.entities.resourceTemplates['ld4p:RT:bf2:Agent:bfPerson'].propertyTemplates[0].repeatable = 'true'
+  }
+  return state
 }
 
-describe('<InputLookupQA />', () => {
-  const mockFormDataFn = jest.fn()
-  const wrapper = shallow(<InputLookupQA.WrappedComponent {...plProps} changeSelections={mockFormDataFn} />)
+setupModal()
 
-  /*
-   * Our mock formData function to replace the one provided by
-   * mapDispatchToProps
-   */
+const reduxPath = [
+  'resource',
+  'ld4p:RT:bf2:Agent:bfPerson',
+  'http://id.loc.gov/ontologies/bibframe/Person',
+]
 
-  it('uses the propertyLabel from the template as the form control label', () => {
-    expect(wrapper.find('#lookupComponent').props().placeholder).toMatch('Name Lookup')
+describe('InputLookupQA', () => {
+  it('renders when no value', () => {
+    const store = createReduxStore(createInitialState())
+    const { container, getByPlaceholderText } = renderWithRedux(
+      <InputLookupQA reduxPath={reduxPath} />, store,
+    )
+    // The input box is present.
+    expect(getByPlaceholderText('Search LCNAF')).toBeInTheDocument()
+    // There is no initial value present
+    expect(container.querySelector('.rbt-token')).not.toBeInTheDocument()
+    // The typeahead's multiple attribute is always set to 'true' in order to always allow the tokenization
+    expect(container.querySelector('.rbt-input-multi')).toBeInTheDocument()
   })
 
-  it('sets the typeahead component required attribute according to the mandatory property from the template', () => {
-    expect(wrapper.find('#lookupComponent').props().required).toBeFalsy()
+  it('renders existing value', () => {
+    const store = createReduxStore(createInitialState({ hasInitialValue: true }))
+    const { getByText } = renderWithRedux(
+      <InputLookupQA reduxPath={reduxPath} />, store,
+    )
+
+    // The subject is displayed
+    expect(getByText('foo')).toBeInTheDocument()
   })
 
-  describe('when mandatory is true', () => {
-    const template = { ...plProps.propertyTemplate, mandatory: 'true' }
-    const wrapper2 = shallow(<InputLookupQA.WrappedComponent {...plProps} propertyTemplate={template} />)
+  it('handles entering non-repeatable value', async () => {
+    const store = createReduxStore(createInitialState())
+    const {
+      container, getByPlaceholderText, getByText, getAllByText, getByTestId,
+    } = renderWithRedux(
+      <InputLookupQA reduxPath={reduxPath} />, store,
+    )
 
-    it('passes the "required" property to Typeahead', () => {
-      expect(wrapper2.find('#lookupComponent').props().required).toBeTruthy()
-    })
+    // Add a value
+    fireEvent.change(getByPlaceholderText('Search LCNAF'), { target: { value: 'foo' } })
+    expect(getAllByText('foo')).toHaveLength(2)
 
-    it('displays RequiredSuperscript if mandatory from template is true', () => {
-      expect(wrapper2.find('label > RequiredSuperscript')).toBeTruthy()
-    })
+    await waitForElement(() => getByTestId('customOption-link'))
+    fireEvent.click(container.querySelector('li[data-testid="customOption-link"] a.dropdown-item'))
+
+    // Verify the value
+    expect(getByText('×')).toBeInTheDocument()
+
+    // Input is disabled for multiple values
+    expect(container.querySelector('input.rbt-input-main[disabled]')).toBeInTheDocument()
   })
 
-  it('sets the typeahead component multiple attribute according to the repeatable property from the template', () => {
-    expect(wrapper.find('#lookupComponent').props().multiple).toBeFalsy()
+  it('handles entering non-Roman value', async () => {
+    const store = createReduxStore(createInitialState())
+    const {
+      container, getByPlaceholderText, getByText, getAllByText,
+    } = renderWithRedux(
+      <InputLookupQA reduxPath={reduxPath} />, store,
+    )
+    const artOfWar = '战争的艺术' // Chinese characters for Sun Tzu's Art of War
+
+    // Add a value
+    fireEvent.change(getByPlaceholderText('Search LCNAF'), { target: { value: artOfWar } })
+    expect(getAllByText(artOfWar)).toHaveLength(2)
+
+    await waitForElement(() => container.querySelector('a.dropdown-item'))
+    await fireEvent.click(container.querySelector('a.dropdown-item'))
+
+    // Verify the value
+    expect(getByText('×')).toBeInTheDocument()
   })
 
-  it('the change event fires the changeSelections callback', () => {
-    wrapper.find('#lookupComponent').simulate('change')
+  it('handles entering repeatable values', async () => {
+    const store = createReduxStore(createInitialState({ repeatable: true }))
+    const {
+      container, getByPlaceholderText, getByText, getAllByText, getByTestId,
+    } = renderWithRedux(
+      <InputLookupQA reduxPath={reduxPath} />, store,
+    )
 
-    expect(mockFormDataFn).toHaveBeenCalled()
+    // Add values
+    fireEvent.change(getByPlaceholderText('Search LCNAF'), { target: { value: 'foo' } })
+    expect(getAllByText('foo')).toHaveLength(2)
+
+    await waitForElement(() => getByTestId('customOption-link'))
+    fireEvent.click(container.querySelector('li[data-testid="customOption-link"] a.dropdown-item'))
+
+    // Verify the value
+    expect(getByText('foo')).toBeInTheDocument()
+
+    // Input is disabled for multiple values
+    expect(container.querySelector('input.rbt-input-main[disabled]')).not.toBeInTheDocument()
+
+    fireEvent.change(container.querySelector('input.rbt-input-main'), { target: { value: 'bar' } })
+    expect(getAllByText('bar')).toHaveLength(2)
+
+    await waitForElement(() => getByTestId('customOption-link'))
+    fireEvent.click(container.querySelector('li[data-testid="customOption-link"] a.dropdown-item'))
+
+    // Verify the value
+    expect(getByText('bar')).toBeInTheDocument()
+    expect(getAllByText('×')).toHaveLength(2)
   })
 
-  describe('Errors', () => {
-    const errors = ['Required']
-    const wrapper = shallow(<InputLookupQA.WrappedComponent displayValidations={true} errors={errors} {...plProps}/>)
+  it('allows deleting a value', async () => {
+    const store = createReduxStore(createInitialState({ hasInitialValue: true }))
+    const { getByText, queryByText } = renderWithRedux(
+      <InputLookupQA reduxPath={reduxPath} />, store,
+    )
+    expect(getByText('foo')).toBeInTheDocument()
 
-    it('displays the errors', () => {
-      expect(wrapper.find('span.help-block').text()).toEqual('Required')
-    })
+    // Delete the value
+    fireEvent.click(getByText('×'))
 
-    it('sets the has-error class', () => {
-      expect(wrapper.exists('div.has-error')).toEqual(true)
-    })
+    // Verify the value is removed
+    await wait(() => expect(queryByText('foo')).not.toBeInTheDocument())
+  })
+
+  it('validates when mandatory', async () => {
+    const store = createReduxStore(createInitialState())
+    const { getByText } = renderWithRedux(
+      <InputLookupQA reduxPath={reduxPath} />, store,
+    )
+
+    // Trigger validation
+    store.dispatch(validateResource())
+    store.dispatch(showValidationErrors())
+
+    await waitForElement(() => getByText('Required'))
+  })
+
+  // Testing the RDF is in the spirit of testing what the user expects from interacting with this component.
+  it('produces expected triples for a single value', async () => {
+    const store = createReduxStore(createInitialState())
+    const {
+      container, getByPlaceholderText, getByText, getAllByText, getByTestId,
+    } = renderWithRedux(
+      <InputLookupQA reduxPath={reduxPath} />, store,
+    )
+
+    // Add a value
+    fireEvent.change(getByPlaceholderText('Search LCNAF'), { target: { value: 'foo' } })
+    expect(getAllByText('foo')).toHaveLength(2)
+
+    await waitForElement(() => getByTestId('customOption-link'))
+    fireEvent.click(container.querySelector('li[data-testid="customOption-link"] a.dropdown-item'))
+
+    // Verify the value
+    await waitForElement(() => getByText('foo'))
+
+    // Render an RDFModal
+    await assertRDF(store, [
+      '<> <http://id.loc.gov/ontologies/bibframe/Person> "foo"',
+      '<> <http://sinopia.io/vocabulary/hasResourceTemplate> "ld4p:RT:bf2:Agent:bfPerson" .',
+      '<> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Person> .',
+    ])
+  })
+
+  it('produces expected triples for repeated values', async () => {
+    const store = createReduxStore(createInitialState())
+    const {
+      container, getByPlaceholderText, getByText, getByTestId,
+    } = renderWithRedux(
+      <InputLookupQA reduxPath={reduxPath} />, store,
+    )
+
+    // Add a value
+    fireEvent.change(getByPlaceholderText('Search LCNAF'), { target: { value: 'foo' } })
+    await waitForElement(() => getByTestId('customOption-link'))
+    fireEvent.click(container.querySelector('li[data-testid="customOption-link"] a.dropdown-item'))
+
+    // Verify the value
+    await waitForElement(() => getByText('foo'))
+
+    // Add another value
+    fireEvent.change(container.querySelector('input.rbt-input-main'), { target: { value: 'bar' } })
+    await waitForElement(() => getByTestId('customOption-link'))
+    fireEvent.click(container.querySelector('li[data-testid="customOption-link"] a.dropdown-item'))
+
+    // Verify the value
+    await waitForElement(() => getByText('bar'))
+
+    // Render an RDFModal
+    await assertRDF(store, [
+      '<> <http://id.loc.gov/ontologies/bibframe/Person> "foo"',
+      '<> <http://id.loc.gov/ontologies/bibframe/Person> "bar"',
+      '<> <http://sinopia.io/vocabulary/hasResourceTemplate> "ld4p:RT:bf2:Agent:bfPerson" .',
+      '<> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Person> .',
+    ])
   })
 })

--- a/src/components/editor/property/InputLookupQA.jsx
+++ b/src/components/editor/property/InputLookupQA.jsx
@@ -30,6 +30,8 @@ const InputLookupQA = (props) => {
   // search, but causes result to be ignored.
   const tokens = useRef([])
 
+  const myInput = useRef([])
+
   const search = (query) => {
     // Clear the results.
     // No re-render, so change not visible to user.
@@ -100,14 +102,19 @@ const InputLookupQA = (props) => {
     }
   }
 
-  const isMandatory = booleanPropertyFromTemplate(props.propertyTemplate, 'mandatory', false)
-
+  const isMandatory = booleanPropertyFromTemplate(props.propertyTemplate, 'mandatory', true)
   const isRepeatable = booleanPropertyFromTemplate(props.propertyTemplate, 'repeatable', true)
+
+  const setDisabled = () => {
+    if (props.selected?.length > 0 && !isRepeatable) {
+      myInput.current._instance?.blur()
+      return true
+    }
+  }
 
   const typeaheadProps = {
     id: 'lookupComponent',
-    required: isMandatory,
-    multiple: isRepeatable,
+    multiple: true,
     placeholder: props.propertyTemplate.propertyLabel,
     useCache: true,
     selectHintOnEnter: true,
@@ -128,6 +135,9 @@ const InputLookupQA = (props) => {
   return (
     <div className={groupClasses}>
       <AsyncTypeahead renderMenu={(results, menuProps) => renderMenuFunc(results, menuProps, props.propertyTemplate)}
+                      ref={myInput}
+                      required={isMandatory}
+                      disabled={setDisabled()}
                       onChange={(selected) => {
                         const payload = {
                           uri: props.propertyTemplate.propertyURI,
@@ -140,10 +150,7 @@ const InputLookupQA = (props) => {
                       onSearch={search}
                       renderToken={(option, props, idx) => renderTokenFunc(option, props, idx)}
                       {...typeaheadProps}
-
-                      filterBy={() => true
-                      }
-
+                      filterBy={() => true}
       />
       {error && <span className="help-block help-block-error">{error}</span>}
     </div>

--- a/src/components/editor/property/renderTypeaheadFunctions.js
+++ b/src/components/editor/property/renderTypeaheadFunctions.js
@@ -80,7 +80,7 @@ export const renderMenuFunc = (results, menuProps, propertyTemplate) => {
       content: result.label,
     }
     items.push(<Menu.Header key="customOption-header">{headerLabel}</Menu.Header>)
-    items.push(<MenuItem key={result.label} option={option}>{result.label}</MenuItem>)
+    items.push(<MenuItem key={result.label} option={option} data-testid="customOption-link">{result.label}</MenuItem>)
   })
 
 
@@ -101,7 +101,6 @@ export const renderTokenFunc = (option, tokenProps, idx) => {
   const children = option.uri ? (<a href={option.uri} rel="noopener noreferrer" target="_blank">{optionLabel}</a>) : optionLabel
   return (
     <Token
-      disabled={tokenProps.disabled}
       key={idx}
       onRemove={tokenProps.onRemove}
       tabIndex={tokenProps.tabIndex}>


### PR DESCRIPTION
One way to leverage the Typeahead component to do what we want here is to use the component's multiple prop in a different way: it should always be set to true, and we can use the component's disabled prop to prevent subsequent multiple entries by passing it the boolean result of an expression that checks both the resource template's repeatable prop along with the length of the selections.

- Removing the disabled prop of the `<Token/>` component allows items to always be removed.
- Use a component ref to force a blur of the input.

![intuitive](https://user-images.githubusercontent.com/3093850/67907993-06f4f280-fb37-11e9-97d5-5ffb790aaff4.gif)

