### PR TITLE
Search Results now use propertyTemplate valueConstraint ordering

### DIFF
--- a/__tests__/components/editor/property/InputListLOC.test.js
+++ b/__tests__/components/editor/property/InputListLOC.test.js
@@ -361,7 +361,7 @@ describe('InputListLOC', () => {
     // Start typing a new literal
     fireEvent.change(input, { target: { value: 'foo' } })
 
-    expect(await findByText('foo', '.dropdown-item')).toBeInTheDocument()
+    expect(await findByText('foo', 'a.dropdown-item')).toBeInTheDocument()
 
     fireEvent.click(getByText('foo', '.dropdown-item'))
 

--- a/__tests__/components/editor/property/renderTypeaheadFunctions.test.js
+++ b/__tests__/components/editor/property/renderTypeaheadFunctions.test.js
@@ -1,3 +1,5 @@
+// Copyright 2019 Stanford University see LICENSE for licenseimport React from 'react'
+
 import { shallow } from 'enzyme'
 import { renderMenuFunc, renderTokenFunc } from 'components/editor/property/renderTypeaheadFunctions'
 
@@ -9,6 +11,14 @@ describe('Rendering Typeahead Menu', () => {
   }]
 
   describe('Sinopia lookups', () => {
+    const propertyTemplate = {
+      valueConstraint: {
+        useValuesFrom: [
+          'urn:ld4p:sinopia',
+        ],
+      },
+    }
+
     const plProps = {
       id: 'sinopia-lookup',
     }
@@ -24,14 +34,14 @@ describe('Rendering Typeahead Menu', () => {
     ]
 
     it('shows menu headers with sinopia source label and literal value in the dropdown when provided results', () => {
-      const menuWrapper = shallow(renderMenuFunc(multipleResults, plProps))
+      const menuWrapper = shallow(renderMenuFunc(multipleResults, plProps, propertyTemplate))
       const menuChildrenNumber = menuWrapper.children().length
       // One top level menu component
 
       expect(menuWrapper.find('ul').length).toEqual(1)
       // Four children, with two headings and two items
       expect(menuChildrenNumber).toEqual(4)
-      expect(menuWrapper.childAt(0).html()).toEqual('<li class="dropdown-header">Sinopia Entity</li>')
+      expect(menuWrapper.childAt(0).html()).toEqual('<li class="dropdown-header">Sinopia (local)</li>')
       expect(menuWrapper.childAt(1).childAt(0).text()).toEqual('Blue hat, green hat')
       expect(menuWrapper.childAt(2).html()).toEqual('<li class="dropdown-header">New Literal</li>')
       expect(menuWrapper.childAt(3).childAt(0).text()).toEqual('blue')
@@ -67,10 +77,19 @@ describe('Rendering Typeahead Menu', () => {
       id: 'lookupComponent',
     }
 
+    const propertyTemplate = {
+      valueConstraint: {
+        useValuesFrom: [
+          'urn:ld4p:qa:gettyulan:person',
+          'urn:ld4p:qa:subjects',
+        ],
+      },
+    }
+
     const multipleResults = [
-      { authLabel: 'Person', authURI: 'PersonURI' },
+      { authLabel: 'GETTY_ULAN person (QA)', authURI: 'urn:ld4p:qa:gettyulan:person' },
       { uri: 'http://id.loc.gov/authorities/names/n860600181234', label: 'Names, Someone' },
-      { authLabel: 'Subject', authURI: 'SubjectURI' },
+      { authLabel: 'LOC all subjects (QA)', authURI: 'urn:ld4p:qa:subjects' },
       { uri: 'http://id.loc.gov/authorities/subjects/sh00001861123', label: 'A Specific Place' },
     ]
 
@@ -80,16 +99,16 @@ describe('Rendering Typeahead Menu', () => {
     }]
 
     it('shows menu headers for both lookups and new valid URI value with the correct headers when matches are found', () => {
-      const menuWrapper = shallow(renderMenuFunc(multipleResults.concat(validNewURIResults), p2Props))
+      const menuWrapper = shallow(renderMenuFunc(multipleResults.concat(validNewURIResults), p2Props, propertyTemplate))
       const menuChildrenNumber = menuWrapper.children().length
-      // One top level menu component
 
+      // One top level menu component
       expect(menuWrapper.find('ul').length).toEqual(1)
       // Five children, with three headings and three items
       expect(menuChildrenNumber).toEqual(6)
-      expect(menuWrapper.childAt(0).html()).toEqual('<li class="dropdown-header">Person</li>')
+      expect(menuWrapper.childAt(0).html()).toEqual('<li class="dropdown-header">GETTY_ULAN person (QA)</li>')
       expect(menuWrapper.childAt(1).childAt(0).text()).toEqual('Names, Someone')
-      expect(menuWrapper.childAt(2).html()).toEqual('<li class="dropdown-header">Subject</li>')
+      expect(menuWrapper.childAt(2).html()).toEqual('<li class="dropdown-header">LOC all subjects (QA)</li>')
       expect(menuWrapper.childAt(3).childAt(0).text()).toEqual('A Specific Place')
       expect(menuWrapper.childAt(4).html()).toEqual('<li class="dropdown-header">New URI</li>')
       expect(menuWrapper.childAt(5).childAt(0).text()).toEqual('http://id.loc.gov/authorities/subjects/123456789')

--- a/__tests__/test_utilities/testUtils.js
+++ b/__tests__/test_utilities/testUtils.js
@@ -1,3 +1,5 @@
+// Copyright 2019 Stanford University see LICENSE for licenseimport React from 'react'
+
 import React from 'react'
 import { Provider } from 'react-redux'
 // Will use for testing generated RDF.

--- a/src/components/editor/property/InputListLOC.jsx
+++ b/src/components/editor/property/InputListLOC.jsx
@@ -45,7 +45,9 @@ const InputListLOC = (props) => {
 
   const lookups = useSelector((state) => {
     const newLookups = {}
-    lookupConfigs.forEach(lookupConfig => newLookups[lookupConfig.uri] = findLookup(state, lookupConfig.uri) || [])
+    lookupConfigs.forEach((lookupConfig) => {
+      newLookups[lookupConfig.uri] = findLookup(state, lookupConfig.uri) || []
+    })
     return newLookups
   })
 
@@ -108,7 +110,7 @@ const InputListLOC = (props) => {
   return (
     <div className={groupClasses}>
       <Typeahead
-        renderMenu={(results, menuProps) => renderMenuFunc(results, menuProps)}
+        renderMenu={(results, menuProps) => renderMenuFunc(results, menuProps, propertyTemplate)}
         renderToken={(option, props, idx) => renderTokenFunc(option, props, idx)}
         allowNew={() => true }
         onChange={selected => selectionChanged(selected)}

--- a/src/components/editor/property/InputLookupQA.jsx
+++ b/src/components/editor/property/InputLookupQA.jsx
@@ -127,7 +127,7 @@ const InputLookupQA = (props) => {
   }
   return (
     <div className={groupClasses}>
-      <AsyncTypeahead renderMenu={(results, menuProps) => renderMenuFunc(results, menuProps)}
+      <AsyncTypeahead renderMenu={(results, menuProps) => renderMenuFunc(results, menuProps, props.propertyTemplate)}
                       onChange={(selected) => {
                         const payload = {
                           uri: props.propertyTemplate.propertyURI,
@@ -143,6 +143,7 @@ const InputLookupQA = (props) => {
 
                       filterBy={() => true
                       }
+
       />
       {error && <span className="help-block help-block-error">{error}</span>}
     </div>

--- a/src/components/editor/property/InputLookupSinopia.jsx
+++ b/src/components/editor/property/InputLookupSinopia.jsx
@@ -71,7 +71,7 @@ const InputLookupSinopia = (props) => {
 
   return (
     <div className={groupClasses}>
-      <AsyncTypeahead renderMenu={(results, menuProps) => renderMenuFunc(results, menuProps)}
+      <AsyncTypeahead renderMenu={(results, menuProps) => renderMenuFunc(results, menuProps, props.propertyTemplate)}
                       renderToken={(option, props, idx) => renderTokenFunc(option, props, idx)}
                       onSearch={search}
                       onChange={change}


### PR DESCRIPTION
For the `InputListLOC` and `InputLookupQA` components, the ordering of the sources is respected when displaying the drop-down menu.
```  "propertyTemplates": [
    {
      "mandatory": "false",
      "repeatable": "true",
      "type": "lookup",
      "resourceTemplates": [],
      "valueConstraint": {
        "valueTemplateRefs": [],
        "useValuesFrom": [
          "urn:ld4p:qa:sharevde_nlm_ld4l_cache:work",
          "urn:ld4p:qa:sharevde_alberta_ld4l_cache:work",
          "urn:ld4p:qa:sharevde_cuboulder_ld4l_cache:work"
        ],
        "defaults": [],
        "valueDataType": {}
      },
      "propertyLabel": "nlm, alberta, then colorado",
      "propertyURI": "http://www.cnn.com"
    },
```


This `propertyTemplate` creates this display in the UI:

![sorted-search](https://user-images.githubusercontent.com/71847/67974788-9bfbf800-fbd8-11e9-9018-ebc0b5df75cb.png)

Fixes #1638

