### PR TITLE
rename search table columns to match sort option labels

### DIFF
--- a/__tests__/components/search/SinopiaSearchResults.test.js
+++ b/__tests__/components/search/SinopiaSearchResults.test.js
@@ -50,10 +50,10 @@ describe('<SinopiaSearchResults />', () => {
       expect(container.querySelector('table#search-results-list')).toBeInTheDocument()
 
       // Search table headers
-      expect(queryByText('Title')).toBeInTheDocument()
+      expect(queryByText('Label')).toBeInTheDocument()
       expect(queryByText('Type')).toBeInTheDocument()
       expect(queryByText('Institution')).toBeInTheDocument()
-      expect(getByText('Modified', 'th')).toBeInTheDocument()
+      expect(getByText('Modified Date', 'th')).toBeInTheDocument()
       // It has a sort button
       expect(getByText('Sort by')).toBeInTheDocument()
 

--- a/src/components/search/SinopiaSearchResults.jsx
+++ b/src/components/search/SinopiaSearchResults.jsx
@@ -99,7 +99,7 @@ const SinopiaSearchResults = (props) => {
             <thead>
               <tr>
                 <th className="search-header" style={{ width: '35%' }}>
-                  Title
+                  Label
                 </th>
                 <th className="search-header" style={{ width: '35%' }}>
                   Type
@@ -108,7 +108,7 @@ const SinopiaSearchResults = (props) => {
                   Institution
                 </th>
                 <th className="search-header" style={{ width: '5%' }}>
-                  Modified
+                  Modified Date
                 </th>
                 <th className="search-header">
                   <SinopiaSort />


### PR DESCRIPTION
As discussed during the demo yesterday, the search table 'Title' column should match the word 'Label' used in the sort menu.  Less important, but I also made the 'Modified' column match the language used in the sort drop-down as well.