### PR TITLE
add basic wikidata lookup

### DIFF
--- a/__tests__/__fixtures__/WikidataLookup.json
+++ b/__tests__/__fixtures__/WikidataLookup.json
@@ -1,0 +1,25 @@
+{
+  "id": "test:resource:WikidataLookup",
+  "resourceLabel": "Testing wikidata lookup",
+  "remark": "This hits wikidata",
+  "resourceURI": "http://id.loc.gov/ontologies/bibframe/Instance",
+  "propertyTemplates": [
+    {
+      "propertyURI": "http://id.loc.gov/ontologies/bibframe/instanceOf",
+      "propertyLabel": "Instance of (lookup)",
+      "remark": "lookup",
+      "mandatory": "true",
+      "repeatable": "false",
+      "type": "lookup",
+      "resourceTemplates": [],
+      "valueConstraint": {
+        "valueTemplateRefs": [],
+        "useValuesFrom": [
+          "urn:wikidata"
+        ],
+        "valueDataType": {},
+        "defaults": []
+      }
+    }
+  ]
+}

--- a/__tests__/fixtureLoaderHelper.js
+++ b/__tests__/fixtureLoaderHelper.js
@@ -39,6 +39,7 @@ const rtFileNames = [
   'TitleNote.json',
   'TranscribedTitle.json',
   'VarTitle.json',
+  'WikidataLookup.json',
   'WorkTitle.json',
   'WorkVariantTitle.json',
   'defaultsAndRefs.json',

--- a/static/authorityConfig.json
+++ b/static/authorityConfig.json
@@ -1617,6 +1617,15 @@
     "component": "lookup"
   },
   {
+    "label": "Wikidata (QA)",
+    "uri": "urn:wikidata",
+    "authority": "wikidata",
+    "subauthority": "item",
+    "language": "en",
+    "component": "lookup",
+    "nonldLookup": true
+  },
+  {
     "label": "MARC relator terms",
     "uri": "https://id.loc.gov/vocabulary/relators",
     "component": "list"


### PR DESCRIPTION
This adds a basic wikidata lookup from QA.  It is a non-linked data lookup and provides results in a format consistent with the normalized linked data search results.

Example:

```
[
  {
    "id": "Q8495",
    "uri": "http://www.wikidata.org/entity/Q8495",
    "label": "milk",
    "context": [
      {
        "property": "label",
        "value": "milk"
      },
     {
        "property": "title",
        "value": "Q8495"
      },
      {
        "property": "description",
        "value": "white liquid produced by the mammary glands of mammals"
      }
    ]
  },
  ...
]
```
