### PR TITLE
[WIP] dismiss popovers when user clicks elsewhere

### DIFF
--- a/__tests__/components/editor/property/PropertyLabelInfoTooltip.test.js
+++ b/__tests__/components/editor/property/PropertyLabelInfoTooltip.test.js
@@ -16,7 +16,7 @@ describe('<PropertyLabelInfoTooltip />', () => {
   const wrapper = shallow(<PropertyLabelInfoTooltip {...props} />)
 
   it('displays a tooltip from the label', () => {
-    expect(wrapper.find('span[data-toggle="popover"]').length).toEqual(1)
+    expect(wrapper.find('a[data-toggle="popover"]').length).toEqual(1)
   })
 
   it('renders an info icon', () => {

--- a/src/components/editor/property/PropertyLabelInfoTooltip.jsx
+++ b/src/components/editor/property/PropertyLabelInfoTooltip.jsx
@@ -11,17 +11,22 @@ const PropertyLabelInfoTooltip = (props) => {
 
   useEffect(() => {
     window.$('[data-toggle="popover"]').popover()
+    window.$('.popover-dismiss').popover({ trigger: 'focus' })
   })
 
   return (
-    <span data-toggle="popover"
-          data-placement="right"
-          data-container="body"
-          title={props.propertyTemplate.label}
-          data-content={props.propertyTemplate.remark}
-          key={key} >
+    <a data-toggle="popover"
+       data-trigger="focus"
+       data-placement="right"
+       data-container="body"
+       tabIndex="0"
+       className="prop-remark"
+       title={props.propertyTemplate.label}
+       data-content={props.propertyTemplate.remark}
+       href="#"
+       key={key} >
       <FontAwesomeIcon className="info-icon" icon={faInfoCircle} />
-    </span>
+    </a>
   )
 }
 


### PR DESCRIPTION
SEE ALTERNATE APPROACH IN #1678 

fixes #1659 by simply dismissing the popover on next click anywhere

using documentation from https://getbootstrap.com/docs/4.0/components/popovers/ that indicates we need to switch this to an `<a>` element to produce the desired behavior