### PR TITLE
hide popovers when a nav link is clicked

### DIFF
--- a/src/components/editor/property/PropertyLabelInfoTooltip.jsx
+++ b/src/components/editor/property/PropertyLabelInfoTooltip.jsx
@@ -11,6 +11,7 @@ const PropertyLabelInfoTooltip = (props) => {
 
   useEffect(() => {
     window.$('[data-toggle="popover"]').popover()
+    window.$('a.nav-link').on('click',function(e) {window.$('.popover').popover('hide')})
   })
 
   return (


### PR DESCRIPTION
another possible fix for #1659 (as opposed to work in #1675)

this option just hides any popovers when a navigation link (i.e. the tabs) are clicked

using documentation from https://getbootstrap.com/docs/4.0/components/popovers/