### PR TITLE
hide popovers when a nav link is clicked

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -8,6 +8,12 @@ import { connect } from 'react-redux'
 import _ from 'lodash'
 
 class Header extends Component {
+  hidePopovers() {
+    if (window.$('.popover').popover) {
+      window.$('.popover').popover('hide')
+    }
+  }
+
   render() {
     return (
       <div className="editor-navbar">
@@ -29,12 +35,12 @@ class Header extends Component {
         </div>
         <ul className="nav nav-tabs editor-navtabs">
           { /* Navlinks enable highlighting the appropriate tab based on route, active style is defined in css */}
-          <li className="nav-item"><NavLink className="nav-link" to="/search">Search</NavLink></li>
-          <li className="nav-item"><NavLink className="nav-link" to="/templates">Resource Templates</NavLink></li>
-          <li className="nav-item"><NavLink className="nav-link" to="/load">Load RDF</NavLink></li>
-          <li className="nav-item"><NavLink className="nav-link" to="/exports">Exports</NavLink></li>
+          <li className="nav-item"><NavLink onClick={this.hidePopovers} className="nav-link" to="/search">Search</NavLink></li>
+          <li className="nav-item"><NavLink onClick={this.hidePopovers} className="nav-link" to="/templates">Resource Templates</NavLink></li>
+          <li className="nav-item"><NavLink onClick={this.hidePopovers} className="nav-link" to="/load">Load RDF</NavLink></li>
+          <li className="nav-item"><NavLink onClick={this.hidePopovers} className="nav-link" to="/exports">Exports</NavLink></li>
           { this.props.hasResource
-           && <li className="nav-item"><NavLink className="nav-link" to="/editor">Editor</NavLink></li>
+           && <li className="nav-item"><NavLink onClick={this.hidePopovers} className="nav-link" to="/editor">Editor</NavLink></li>
           }
         </ul>
       </div>


### PR DESCRIPTION
alternate approach to fix #1659 (as compared to work in #1675)

popover documentation at https://getbootstrap.com/docs/4.0/components/popovers/

this simply hides all popovers when a navigation/tab is clicked