### PR TITLE
Lookup URI labels now persist and also load from RDF

### DIFF
--- a/__tests__/GraphBuilder.test.js
+++ b/__tests__/GraphBuilder.test.js
@@ -267,4 +267,39 @@ describe('GraphBuilder', () => {
       expect(result.length).toEqual(0)
     })
   })
+
+  describe('when the state has item labels', () => {
+    const state = createBlankState()
+    state.selectorReducer.entities.resourceTemplates = {
+      'ld4p:RT:bf2:Agents:RWO:Country': {
+        resourceURI: 'http://id.loc.gov/ontologies/bibframe/Work',
+      },
+    }
+    state.selectorReducer.resource = {
+      'ld4p:RT:bf2:Agents:RWO:Country': {
+        'http://www.loc.gov/mads/rdf/v1#associatedLocale': {
+          items: [
+            {
+              uri: 'http://id.loc.gov/authorities/names/n85149930',
+              id: 'n 85149930',
+              label: 'Palisade (Colo.)',
+            },
+          ],
+        },
+        'http://www.loc.gov/mads/rdf/v1#activityStartDate': {},
+        'http://www.loc.gov/mads/rdf/v1#activityEndDate': {},
+      },
+    }
+    const builder = new GraphBuilder(state.selectorReducer)
+
+    it('graph contains authority URI and label', () => {
+      const graph = builder.graph
+      const labelTriple = rdf.quad(
+        rdf.namedNode('http://id.loc.gov/authorities/names/n85149930'),
+        rdf.namedNode('http://www.w3.org/2000/01/rdf-schema#label'),
+        rdf.literal('Palisade (Colo.)'),
+      )
+      expect(graph.has(labelTriple)).toBeTruthy()
+    })
+  })
 })

--- a/__tests__/ResourceStateBuilder.test.js
+++ b/__tests__/ResourceStateBuilder.test.js
@@ -169,7 +169,8 @@ describe('ResourceStateBuilder', () => {
     const resource = `<http://example/123> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Work> .
   <http://example/123> <http://sinopia.io/vocabulary/hasResourceTemplate> "test:RT:genreform" .
   <http://example/123> <http://id.loc.gov/ontologies/bibframe/genreForm> <http://id.loc.gov/authorities/genreForms/gf2014026879> .
-  <http://id.loc.gov/authorities/genreForms/gf2014026879> <http://www.w3.org/2000/01/rdf-schema#label> "Jazz"@en .`
+  <http://id.loc.gov/authorities/genreForms/gf2014026879> <http://www.w3.org/2000/01/rdf-schema#label> "Jazz"@en .
+  <https://example/1234> <http://schema.org/name> "Jazz Genre"@en .`
 
     const dataset = await rdfDatasetFromN3(resource)
 
@@ -184,14 +185,14 @@ describe('ResourceStateBuilder', () => {
           items: {
             abc123: {
               uri: 'http://id.loc.gov/authorities/genreForms/gf2014026879',
-              label: 'http://id.loc.gov/authorities/genreForms/gf2014026879',
+              label: 'Jazz',
             },
           },
         },
       },
     })
 
-    const unmatched = `<http://id.loc.gov/authorities/genreForms/gf2014026879> <http://www.w3.org/2000/01/rdf-schema#label> "Jazz"@en .
+    const unmatched = `<https://example/1234> <http://schema.org/name> "Jazz Genre"@en .
 `
     expect(unusedDataset.toCanonical()).toEqual(unmatched)
   })

--- a/src/GraphBuilder.js
+++ b/src/GraphBuilder.js
@@ -29,7 +29,6 @@ export default class GraphBuilder {
       this.buildTriplesForNode(resourceURI,
         resourceTemplateId,
         this.getPredicateList(resource[resourceTemplateId]))
-
       this.addGeneratedByTriple(resourceURI, resourceTemplateId)
     })
     return this.dataset
@@ -93,12 +92,18 @@ export default class GraphBuilder {
       if (_.isEmpty(value)) {
         continue
       }
-
+      const labelNode = rdf.namedNode('http://www.w3.org/2000/01/rdf-schema#label')
       if (value.items) {
         Object.keys(value.items).forEach((key) => {
           const item = value.items[key]
           const object = item.uri ? rdf.namedNode(item.uri) : this.createLiteral(item)
           this.dataset.add(rdf.quad(baseURI, rdf.namedNode(predicate), object))
+          // If the item is a uri and has a label, adds a label triple to the graph
+          if (item.uri && item.label) {
+            this.dataset.add(rdf.quad(rdf.namedNode(item.uri),
+              labelNode,
+              rdf.literal(item.label)))
+          }
         })
       } else { // It's a deeply nested object
         Object.keys(value).filter(elem => elem !== 'errors').forEach((key) => {

--- a/src/ResourceStateBuilder.js
+++ b/src/ResourceStateBuilder.js
@@ -106,10 +106,17 @@ export default class ResourceStateBuilder {
    */
   buildItem(quad) {
     const item = {}
+    const labelNode = rdf.namedNode('http://www.w3.org/2000/01/rdf-schema#label')
     if (quad.object.termType === 'NamedNode') {
       item.uri = quad.object.value
-      // Until we have a way of looking up label values, use the URI as the label
-      item.label = item.uri
+      const label = this.dataset.match(item.uri, labelNode).toArray()
+      if (label.length > 0) {
+        item.label = label[0].object.value // Use first match
+        // Remove quad(s) from dataset
+        this.dataset.removeMatches(item.uri, labelNode)
+      } else {
+        item.label = item.uri
+      }
     } else {
       // A literal
       item.content = quad.object.value


### PR DESCRIPTION
When labels for URIs are present in a component's items, the label is used to generate a triple using `rdfs:label` in the Graph builder. When loading RDF back into the editor, the items label is set if to the `<uri> rdfs:label <label> ` is present.

Fixes #1641 