### PR TITLE
update some deprecated styles in bootstrap 4

### DIFF
--- a/__tests__/components/editor/property/InputLookupSinopia.test.js
+++ b/__tests__/components/editor/property/InputLookupSinopia.test.js
@@ -87,7 +87,7 @@ describe('<InputLookupSinopia />', () => {
     const wrapper = shallow(<InputLookupSinopia.WrappedComponent displayValidations={true} errors={errors} {...plProps}/>)
 
     it('displays the errors', () => {
-      expect(wrapper.find('span.help-block-error').text()).toEqual('Required')
+      expect(wrapper.find('span.text-danger').text()).toEqual('Required')
     })
 
     it('sets the has-error class', () => {

--- a/__tests__/components/editor/property/OutlineHeader.test.js
+++ b/__tests__/components/editor/property/OutlineHeader.test.js
@@ -51,7 +51,7 @@ describe('<OutlineHeader />', () => {
       const wrapper = shallow(<OutlineHeader.WrappedComponent displayValidations={true} errors={errors} {...headerProps}/>)
 
       it('displays the errors', () => {
-        expect(wrapper.find('span.help-block').text()).toEqual('Required')
+        expect(wrapper.find('span.text-danger').text()).toEqual('Required')
       })
 
       it('sets the has-error class', () => {

--- a/__tests__/integration/validationErrors.ppt.js
+++ b/__tests__/integration/validationErrors.ppt.js
@@ -21,7 +21,7 @@ describe('Validation errors', () => {
 
     await pupExpect(page).toMatch('There was a problem saving this resource.')
     await pupExpect(page).toMatch('BIBFRAME Instance > Agent Contribution: Required')
-    await pupExpect(page).toMatchElement('span.help-block', { text: 'Required' })
+    await pupExpect(page).toMatchElement('span.text-danger', { text: 'Required' })
     await pupExpect(page).toMatchElement('div.has-error')
   })
 })

--- a/src/components/editor/property/InputListLOC.jsx
+++ b/src/components/editor/property/InputListLOC.jsx
@@ -123,7 +123,7 @@ const InputListLOC = (props) => {
         filterBy={filterBy}
         onKeyDown={onKeyDown}
       />
-      {error && <span className="help-block help-block-error">{error}</span>}
+      {error && <span className="text-danger">{error}</span>}
     </div>
   )
 }

--- a/src/components/editor/property/InputLiteral.jsx
+++ b/src/components/editor/property/InputLiteral.jsx
@@ -87,7 +87,7 @@ const InputLiteral = (props) => {
             disabled={disabled}
             ref={inputLiteralRef}
       />
-      {error && <span className="help-block help-block-error">{error}</span>}
+      {error && <span className="text-danger">{error}</span>}
       {addedList}
     </div>
   )

--- a/src/components/editor/property/InputLookupQA.jsx
+++ b/src/components/editor/property/InputLookupQA.jsx
@@ -150,7 +150,7 @@ const InputLookupQA = (props) => {
                       {...typeaheadProps}
                       filterBy={() => true}
       />
-      {error && <span className="help-block help-block-error">{error}</span>}
+      {error && <span className="text-danger">{error}</span>}
     </div>
   )
 }

--- a/src/components/editor/property/InputLookupSinopia.jsx
+++ b/src/components/editor/property/InputLookupSinopia.jsx
@@ -85,8 +85,8 @@ const InputLookupSinopia = (props) => {
                       allowNew={() => true }
                       id="sinopia-lookup" />
 
-      <span className="help-block">Use a * to wildcard your search.</span>
-      {error && <span className="help-block help-block-error">{error}</span>}
+      <span className="text-muted">Use a * to wildcard your search.</span>
+      {error && <span className="text-danger">{error}</span>}
     </div>
   )
 }

--- a/src/components/editor/property/InputURI.jsx
+++ b/src/components/editor/property/InputURI.jsx
@@ -107,7 +107,7 @@ const InputURI = (props) => {
              onBlur={addItem}
              ref={inputLiteralRef}
       />
-      {error && <span className="help-block help-block-error">{error}</span>}
+      {error && <span className="text-danger">{error}</span>}
       {addedList}
     </div>
   )

--- a/src/components/editor/property/OutlineHeader.jsx
+++ b/src/components/editor/property/OutlineHeader.jsx
@@ -35,7 +35,7 @@ const OutlineHeader = (props) => {
           + Add <strong><PropertyLabel propertyTemplate={props.property} /></strong>
         </button>
         <PropertyLabelInfo propertyTemplate={ props.property } />
-        { error && <span className="help-block help-block-error">{error}</span>}
+        { error && <span className="text-danger">{error}</span>}
       </div>
     )
   }

--- a/src/components/exports/Exports.jsx
+++ b/src/components/exports/Exports.jsx
@@ -23,7 +23,7 @@ const Exports = (props) => {
       <Header triggerEditorMenu={props.triggerHandleOffsetMenu}/>
       <h4>Exports</h4>
       <Alerts errorKey={exportsErrorKey} />
-      <p className="help-block">Exports are regenerated weekly. Each zip file contains separate files per record (as JSON-LD).</p>
+      <p className="text-muted">Exports are regenerated weekly. Each zip file contains separate files per record (as JSON-LD).</p>
       <ul className="list-unstyled">
         {exportFileList}
       </ul>

--- a/src/components/load/LoadByRDFForm.jsx
+++ b/src/components/load/LoadByRDFForm.jsx
@@ -82,17 +82,17 @@ const LoadByRDFForm = (props) => {
           <label htmlFor="resourceTextArea">RDF</label>
           <textarea className="form-control" id="resourceTextArea" rows="15" value={n3}
                     onChange={event => changeN3(event)} placeholder={n3PlaceHolder}></textarea>
-          <p className="help-block">Accepts Turtle, TriG, N-Triples, N-Quads, and Notation3 (N3).</p>
+          <p className="text-muted">Accepts Turtle, TriG, N-Triples, N-Quads, and Notation3 (N3).</p>
         </div>
         <div className="form-group">
           <label htmlFor="uriInput">Base URI</label>
           <input type="url" className="form-control" id="uriInput" value={baseURI}
                  onChange={event => setBaseURI(event.target.value)}
                  placeholder={baseURIPlaceholder} />
-          <p className="help-block">Omit brackets. If base URI is &lt;&gt;, leave blank.</p>
+          <p className="text-muted">Omit brackets. If base URI is &lt;&gt;, leave blank.</p>
         </div>
         <button type="submit" disabled={ _.isEmpty(n3) } className="btn btn-primary">Submit</button>
-        <p className="help-block">This will create a new resource that can be saved in Sinopia.</p>
+        <p className="text-muted">This will create a new resource that can be saved in Sinopia.</p>
       </form>
       <ResourceTemplateChoiceModal choose={chooseResourceTemplate} />
     </div>

--- a/src/components/search/Search.jsx
+++ b/src/components/search/Search.jsx
@@ -116,7 +116,7 @@ const Search = (props) => {
             </div>
           </form>
         </div>
-        <span className="help-block">Sinopia search: use * as wildcard;
+        <span className="text-muted">Sinopia search: use * as wildcard;
           default operator for multiple terms is AND; use | (pipe) as OR operator;
           use quotation marks for exact match. For more details see <a href="https://github.com/LD4P/sinopia/wiki/Searching-in-Sinopia">Searching in Sinopia</a>.
         </span>


### PR DESCRIPTION
fixes #1714 (and some related items)

see https://getbootstrap.com/docs/4.3/migration/#forms-1 for bootstrap update documentation

It is possible we may also need to remove the `.has-error` class on form elements and decorate those elements with `required`, but that may require changes to the components that render the form elements, so not undertaking that here.