### PR TITLE
add underlines to all links

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -9,6 +9,10 @@ body {
   margin: 0 10%;
 }
 
+a {
+  text-decoration: underline;
+}
+
 pre {
   background-color: #f5f5f5;
   border: 1px solid #ccc;
@@ -20,6 +24,7 @@ pre {
 
 .btn-link {
   border-color: transparent !important;
+  text-decoration: underline;
 }
 
 .btn-linky {


### PR DESCRIPTION
override css so that any <a> hyperlink or button acting like a link should now have an underline (as discussed in today's planning meeting)

hover will sometimes make the underline disappear depending on bootstrap styles being applied, do we want to override this too?