### PR TITLE
scroll to top on edit template error

### DIFF
--- a/src/components/search/QASearchResults.jsx
+++ b/src/components/search/QASearchResults.jsx
@@ -1,6 +1,8 @@
 // Copyright 2019 Stanford University see LICENSE for license
 
-import React, { useMemo, useState, useEffect } from 'react'
+import React, {
+  useMemo, useState, useEffect, useRef,
+} from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import PropTypes from 'prop-types'
 import { clearErrors, appendError } from 'actions/index'
@@ -11,12 +13,15 @@ import useResource from 'hooks/useResource'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCopy } from '@fortawesome/free-solid-svg-icons'
 import Alerts from '../Alerts'
+import { findErrors } from 'selectors/resourceSelectors'
 
 // Errors from retrieving a resource from this page.
 export const searchQARetrieveErrorKey = 'searchqaresource'
 
 const QASearchResults = (props) => {
   const dispatch = useDispatch()
+
+  const errorsRef = useRef(null)
 
   const searchResults = useSelector(state => state.selectorReducer.search.results)
   const searchUri = useSelector(state => state.selectorReducer.search.uri)
@@ -38,6 +43,11 @@ const QASearchResults = (props) => {
       .then(resourceN3 => setResourceN3(resourceN3))
       .catch(err => dispatch(appendError(`Error retrieving resource: ${err.toString()}`)))
   }, [dispatch, resourceId, resourceURI, searchUri])
+
+  const errors = useSelector(state => findErrors(state, searchQARetrieveErrorKey))
+  useEffect(() => {
+    window.scrollTo(0, errorsRef.current.offsetTop)
+  }, [errors])
 
   // Transform the results into the format to be displayed in the table.
   const tableData = useMemo(() => searchResults.map((result) => {
@@ -125,7 +135,7 @@ const QASearchResults = (props) => {
 
   return (
     <div id="search-results" className="row">
-      <Alerts errorKey={searchQARetrieveErrorKey} />
+      <div ref={errorsRef}><Alerts errorKey={searchQARetrieveErrorKey} /></div>
       <div className="col">
         <table className="table table-bordered">
           <thead>

--- a/src/components/search/SinopiaSearchResults.jsx
+++ b/src/components/search/SinopiaSearchResults.jsx
@@ -1,7 +1,7 @@
 // Copyright 2019 Stanford University see LICENSE for license
 /* eslint max-params: ["error", 4] */
 
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useRef } from 'react'
 import { connect } from 'react-redux'
 import { bindActionCreators } from 'redux'
 import PropTypes from 'prop-types'
@@ -20,6 +20,8 @@ export const searchRetrieveErrorKey = 'searchresource'
 
 const SinopiaSearchResults = (props) => {
   const [navigateEditor, setNavigateEditor] = useState(false)
+
+  const errorsRef = useRef(null)
 
   const groupName = (uri) => {
     const groupSlug = uri.split('/')[4]
@@ -42,6 +44,10 @@ const SinopiaSearchResults = (props) => {
     // Forces a wait until the resource has been set in state
     if (navigateEditor && props.rootResource && _.isEmpty(props.errors)) {
       props.history.push('/editor')
+    }
+    else if (!_.isEmpty(props.errors))
+    {
+      window.scrollTo(0, errorsRef.current.offsetTop)
     }
   })
 
@@ -86,7 +92,7 @@ const SinopiaSearchResults = (props) => {
 
   return (
     <React.Fragment>
-      <Alerts errorKey={searchRetrieveErrorKey} />
+      <div ref={errorsRef}><Alerts errorKey={searchRetrieveErrorKey} /></div>
       <div id="search-results" className="row">
         <div className="col">
           <table className="table table-bordered" id="search-results-list">


### PR DESCRIPTION
fixes #1758 

- added scroll to top for opening a template from QA search results
- added new scroll to top code for the error case of opening a resource that triggers an error (like a validation error on the resource template)