### PR TITLE
best attempt to get to design of new import button

### DIFF
--- a/__tests__/components/templates/ImportFileZone.test.js
+++ b/__tests__/components/templates/ImportFileZone.test.js
@@ -11,7 +11,7 @@ describe('<ImportFileZone />', () => {
     const wrapper = shallow(<ImportFileZone.WrappedComponent />)
 
     expect(wrapper.find('button#ImportProfile').exists()).toBeTruthy()
-    expect(wrapper.find('button#ImportProfile').text()).toEqual('Import a Profile or Resource Template')
+    expect(wrapper.find('button#ImportProfile').text()).toEqual('Import Profile / Resource Template')
   })
 
   describe('schema valid', () => {
@@ -157,19 +157,19 @@ describe('<DropZone />', () => {
 
   it('shows the dropzone div when button is clicked', () => {
     wrapper.setState({ showDropZone: false })
-    wrapper.find('button.btn').simulate('click')
+    wrapper.find('button.btn-link').simulate('click')
     expect(wrapper.find('DropZone > section > p').last().text())
       .toMatch('Drag and drop a profile or resource template file in the box or click it to select a file to upload:')
   })
 
   it('hides the dropzone div when button is clicked again', () => {
-    wrapper.find('button.btn').simulate('click')
+    wrapper.find('button.btn-link').simulate('click')
     expect(wrapper.find('DropZone > section > p').exists()).toBeFalsy()
   })
 
   it('hides the dropzone div when the file dialog is canceled', () => {
     wrapper.setState({ showDropZone: false })
-    wrapper.find('button.btn').simulate('click')
+    wrapper.find('button.btn-link').simulate('click')
     expect(wrapper.state('showDropZone')).toBeTruthy()
     wrapper.setState({ showDropZone: false })
     expect(wrapper.state('showDropZone')).toBeFalsy()
@@ -177,7 +177,7 @@ describe('<DropZone />', () => {
 
   it('hides the dropzone div when the resource template menu link is clicked', () => {
     wrapper.setState({ showDropZone: false })
-    wrapper.find('button.btn').simulate('click')
+    wrapper.find('button.btn-link').simulate('click')
     expect(wrapper.state('showDropZone')).toBeTruthy()
     wrapper.instance().handleClick()
     wrapper.setState({ showDropZone: false })

--- a/__tests__/components/templates/ImportResourceTemplate.test.js
+++ b/__tests__/components/templates/ImportResourceTemplate.test.js
@@ -18,7 +18,7 @@ describe('<ImportResourceTemplate />', () => {
 
   it('draws the templates page', () => {
     expect(getByText('LINKED DATA EDITOR')).toBeInTheDocument()
-    expect(getByText('Import a Profile or Resource Template')).toBeInTheDocument()
+    expect(getByText('Import Profile / Resource Template')).toBeInTheDocument()
     expect(getByText('Find a resource template')).toBeInTheDocument()
   })
 })

--- a/__tests__/integration/schemaValidation.test.js
+++ b/__tests__/integration/schemaValidation.test.js
@@ -23,7 +23,7 @@ describe('Loading an invalid resource template', () => {
   it('notifies the user that invalid', async () => {
     // Upload the resource template
     fireEvent.click(getByText('Linked Data Editor'))
-    fireEvent.click(getByText('Import a Profile or Resource Template'))
+    fireEvent.click(getByText('Import Profile / Resource Template'))
     expect(getByText(/Drag and drop a profile or resource template file/)).toBeInTheDocument()
     expect(queryByText(/The profile you provided was not valid JSON/)).not.toBeInTheDocument()
 

--- a/cypress/integration/end2end.spec.js
+++ b/cypress/integration/end2end.spec.js
@@ -37,7 +37,7 @@ describe('End-to-end test', () => {
     // Need to determine if should upload a resource template.
     cy.get('#resource-templates').then((rtDiv) => {
       if (rtDiv.find('div#no-rt-warning').length > 0) {
-        cy.contains('Import a Profile or Resource Template').click()
+        cy.contains('Import Profile / Resource Template').click()
         cy.contains('Drag and drop a profile or resource template file')
         const fileName = 'LD4P_BIBFRAME_2.0_Title_Information.json'
         cy.fixture(fileName).then((fileJson) => {

--- a/src/components/templates/ImportFileZone.jsx
+++ b/src/components/templates/ImportFileZone.jsx
@@ -4,6 +4,8 @@ import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import DropZone from './DropZone'
 import PropTypes from 'prop-types'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faUpload } from '@fortawesome/free-solid-svg-icons'
 import Ajv from 'ajv' // JSON schema validation
 import Config from 'Config'
 import { setResourceTemplates } from 'actionCreators/resourceTemplates'
@@ -189,7 +191,6 @@ class ImportFileZone extends Component {
     const importFileZone = {
       display: 'flex',
       justifyContent: 'right',
-      padding: '10px',
     }
     const dropzoneContainer = {
       display: 'flex',
@@ -209,9 +210,11 @@ class ImportFileZone extends Component {
     return (
       <section>
         <div className="ImportFileZone" style={importFileZone}>
+          <FontAwesomeIcon style={ { marginTop: '9px' } } icon={faUpload} />
           <button id="ImportProfile"
-                  className="btn btn-primary btn-lg"
-                  onClick={this.handleClick}>Import a Profile or Resource Template</button>
+                  className="btn btn-link"
+                  onClick={this.handleClick}>
+                  Import Profile / Resource Template</button>
         </div>
         <div className="dropzoneContainer" style={dropzoneContainer}>
           { this.state.showDropZone ? this.renderDropZone() : null }

--- a/src/components/templates/TemplateSearch.jsx
+++ b/src/components/templates/TemplateSearch.jsx
@@ -41,7 +41,7 @@ const TemplateSearch = () => {
         <div className="col">
           <form className="form-inline" onSubmit={event => event.preventDefault()}>
             <div className="form-group" style={{ paddingBottom: '10px', paddingTop: '10px' }}>
-              <label htmlFor="searchInput">Find a resource template</label>&nbsp;
+              <label className="font-weight-bold" htmlFor="searchInput">Find a resource template</label>&nbsp;
               <div className="input-group" style={{ width: '750px', paddingLeft: '5px' }}>
                 <input id="searchInput" type="text" className="form-control"
                        onChange={ event => search(event.target.value) }


### PR DESCRIPTION
(sort of) fixes #1792 

I was able to more or less get the search bar and import button on the same line, but if you shrink your screen down, the search box overruns the import button (due to a fixed pixel setting for the width of the search box).  If you do the right thing and make the search box width = 100%, then it comes out too small to show the placeholder text.  I can't figure out how to get the search bar and the import button to make better use of the space available otherwise.