### PR TITLE
Fix close button bug by passing in resourceKey as a prop

### DIFF
--- a/__tests__/components/editor/actions/CloseButton.test.js
+++ b/__tests__/components/editor/actions/CloseButton.test.js
@@ -72,7 +72,7 @@ const createInitialState = () => {
 // Clicking the button is covered by previewSaveIncompleteResource and previewSaveResource
 describe('<CloseButton />', () => {
   setupModal()
-  it('renders', () => {
+  it('renders a default close button', () => {
     const store = createReduxStore(createInitialState())
     const { getByTitle, getByTestId } = renderWithReduxAndRouter(
       <CloseButton />, store,
@@ -82,6 +82,26 @@ describe('<CloseButton />', () => {
     expect(getByTestId('close-resource-modal').classList.contains('show')).toBe(false)
   })
 
+  describe('customized close button', () => {
+    const state = createInitialState()
+    // See resourceHasChangesSinceLastSave() for checksum
+    state.selectorReducer.editor.lastSaveChecksum.abc123 = '5267eb8da0ab5ef646cae0190cf13a7c'
+    const store = createReduxStore(state)
+
+    it('renders with props', () => {
+      const { container, getByTitle } = renderWithReduxAndRouter(
+        <CloseButton label={'x'} css={'button'} resourceKey={'abc123'}/>, store,
+      )
+      
+      expect(getByTitle('x', { selector: 'button' })).toBeInTheDocument()
+      expect(container.querySelector('button[class="btn button"]')).toBeInTheDocument()
+
+      fireEvent.click(getByTitle('x'))
+
+      // Resource has been cleared
+      expect(store.getState().selectorReducer.editor.currentResource).toEqual(undefined)
+    })
+  })
   describe('closing when resource has not changed', () => {
     const state = createInitialState()
     // See resourceHasChangesSinceLastSave() for checksum

--- a/__tests__/components/editor/actions/CloseButton.test.js
+++ b/__tests__/components/editor/actions/CloseButton.test.js
@@ -92,7 +92,7 @@ describe('<CloseButton />', () => {
       const { container, getByTitle } = renderWithReduxAndRouter(
         <CloseButton label={'x'} css={'button'} resourceKey={'abc123'}/>, store,
       )
-      
+
       expect(getByTitle('x', { selector: 'button' })).toBeInTheDocument()
       expect(container.querySelector('button[class="btn button"]')).toBeInTheDocument()
 

--- a/src/components/editor/ResourcesNav.jsx
+++ b/src/components/editor/ResourcesNav.jsx
@@ -34,7 +34,7 @@ const ResourcesNav = () => {
       linkClasses.push('active')
       itemClasses.push('active')
     } else {
-      closeButton = <CloseButton label={'x'} css={'button'} />
+      closeButton = <CloseButton label={'x'} css={'button'} resourceKey={resourceKey}/>
     }
     return (
       <li className={itemClasses.join(' ')} key={resourceKey}>

--- a/src/components/editor/actions/CloseButton.jsx
+++ b/src/components/editor/actions/CloseButton.jsx
@@ -27,9 +27,10 @@ const CloseButton = (props) => {
   const btnClass = props.css || 'btn-primary'
   const buttonLabel = props.label || 'Close'
   const buttonClasses = `btn ${btnClass}`
+  const closeResourceKey = props.resourceKey || resourceKey
 
   const closeResource = () => {
-    dispatch(clearResource(resourceKey))
+    dispatch(clearResource(closeResourceKey))
     // In case this is /editor/<rtId>, clear
     history.push('/editor')
   }

--- a/src/components/editor/actions/CloseButton.jsx
+++ b/src/components/editor/actions/CloseButton.jsx
@@ -52,6 +52,7 @@ const CloseButton = (props) => {
 CloseButton.propTypes = {
   css: PropTypes.string,
   label: PropTypes.string,
+  resourceKey: PropTypes.string,
 }
 
 export default CloseButton


### PR DESCRIPTION
The default CloseButton will use the resourceKey of the current resource, but it will also accept a resourceKey as a prop to handle the case when it should close a different resource than the current one.

![closeButtonFix](https://user-images.githubusercontent.com/3093850/69669084-ffe1d700-1045-11ea-8af3-d23e502e7bd4.gif)
