### PR TITLE
Persist RDF to Trellis using Turtle

### DIFF
--- a/__tests__/GraphBuilder.test.js
+++ b/__tests__/GraphBuilder.test.js
@@ -1,9 +1,8 @@
 // Copyright 2019 Stanford University see LICENSE for license
 
 import GraphBuilder from 'GraphBuilder'
+import rdf from 'rdf-ext'
 import { createBlankState } from 'testUtils'
-
-const rdf = require('rdf-ext')
 
 describe('GraphBuilder', () => {
   describe('when the state does not have a resourceURI', () => {
@@ -72,7 +71,6 @@ describe('GraphBuilder', () => {
 
     const builder = new GraphBuilder(state.selectorReducer.entities.resources.abc123, state.selectorReducer.entities.resourceTemplates)
 
-
     it('returns the graph', () => {
       const graph = builder.graph
 
@@ -104,6 +102,30 @@ describe('GraphBuilder', () => {
 
       // Literals from different notes have different blank node.
       expect(result1[0].subject).not.toEqual(result3[0].subject)
+    })
+
+    describe('toTurtle()', () => {
+      it('returns the graph as a string represented as Turtle', () => {
+        expect(builder.toTurtle()).toEqual(`<> a <http://id.loc.gov/ontologies/bibframe/Work>;
+    <http://id.loc.gov/ontologies/bibframe/content> <http://id.loc.gov/vocabulary/contentTypes/txt>.
+<http://id.loc.gov/vocabulary/contentTypes/txt> <http://www.w3.org/2000/01/rdf-schema#label> "text".
+<> <http://id.loc.gov/ontologies/bibframe/illustrativeContent> <http://id.loc.gov/vocabulary/millus/gnt>.
+<http://id.loc.gov/vocabulary/millus/gnt> <http://www.w3.org/2000/01/rdf-schema#label> "Genealogical tables".
+<> <http://id.loc.gov/ontologies/bibframe/colorContent> _:b1.
+_:b1 a <http://id.loc.gov/ontologies/bibframe/Note>;
+    <http://www.w3.org/2000/01/rdf-schema#label> "Very colorful"@eng, "Sparkly".
+<> <http://id.loc.gov/ontologies/bibframe/colorContent> _:b2.
+_:b2 a <http://id.loc.gov/ontologies/bibframe/Note>;
+    <http://www.w3.org/2000/01/rdf-schema#label> "Shiney".
+<> <http://sinopia.io/vocabulary/hasResourceTemplate> "resourceTemplate:bf2:Monograph:Work";
+    <http://id.loc.gov/ontologies/bibframe/colorContent> _:b3.
+_:b3 a <http://id.loc.gov/ontologies/bibframe/Note>;
+    <http://www.w3.org/2000/01/rdf-schema#label> "Very colorful"@eng, "Sparkly".
+<> <http://id.loc.gov/ontologies/bibframe/colorContent> _:b4.
+_:b4 a <http://id.loc.gov/ontologies/bibframe/Note>;
+    <http://www.w3.org/2000/01/rdf-schema#label> "Shiney".
+`)
+      })
     })
   })
 
@@ -161,7 +183,6 @@ describe('GraphBuilder', () => {
     }
 
     const builder = new GraphBuilder(state.selectorReducer.entities.resources.abc123, state.selectorReducer.entities.resourceTemplates)
-
 
     it('returns the graph', () => {
       const graph = builder.graph

--- a/__tests__/actionCreators/resources.test.js
+++ b/__tests__/actionCreators/resources.test.js
@@ -48,7 +48,7 @@ describe('update', () => {
     await store.dispatch(update('jkl012', currentUser, 'testerrorkey'))
 
     expect(store.getActions()).toEqual([
-      { type: 'SAVE_RESOURCE_FINISHED', payload: { resourceKey: 'jkl012', checksum: '5e30bd59d0186c5307065436240ba108' } },
+      { type: 'SAVE_RESOURCE_FINISHED', payload: { resourceKey: 'jkl012', checksum: 'e37c563187b12275acf955128f14f3f3' } },
     ])
   })
   it('dispatches actions when error occurs', async () => {
@@ -128,7 +128,7 @@ describe('retrieveResource', () => {
         { type: 'TOGGLE_COLLAPSE', payload: { reduxPath } },
         { type: 'RESOURCE_LOADED', payload: { resourceKey: 'abc123', resource: expectedResource, resourceTemplates: { [resourceTemplateId]: resourceTemplate } } },
         { type: 'SET_LAST_SAVE_CHECKSUM', payload: { resourceKey: 'abc123', checksum: undefined } },
-        { type: 'SET_LAST_SAVE_CHECKSUM', payload: { resourceKey: 'abc123', checksum: 'a4c091070fd59aeed47e608ad2194092' } },
+        { type: 'SET_LAST_SAVE_CHECKSUM', payload: { resourceKey: 'abc123', checksum: '547880ad2b8b81bfac4d15e0f856f248' } },
         { type: 'SET_UNUSED_RDF', payload: { resourceKey: 'abc123', rdf: '' } },
         { type: 'SET_CURRENT_RESOURCE', payload: 'abc123' },
       ])
@@ -236,7 +236,7 @@ describe('publishResource', () => {
     await store.dispatch(publishResource('jkl012', currentUser, group, 'testerrorkey'))
     expect(store.getActions()).toEqual([
       { type: 'SET_BASE_URL', payload: { resourceKey: 'jkl012', resourceURI: 'http://sinopia.io/repository/myGroup/myResource' } },
-      { type: 'SAVE_RESOURCE_FINISHED', payload: { resourceKey: 'jkl012', checksum: '5e30bd59d0186c5307065436240ba108' } },
+      { type: 'SAVE_RESOURCE_FINISHED', payload: { resourceKey: 'jkl012', checksum: 'e37c563187b12275acf955128f14f3f3' } },
     ])
   })
 
@@ -284,7 +284,7 @@ describe('newResource', () => {
         { type: 'CLEAR_ERRORS', payload: 'testerrorkey' },
         { type: 'RESOURCE_TEMPLATE_LOADED', payload: resourceTemplate },
         { type: 'RESOURCE_LOADED', payload: { resourceKey: 'abc123', resource: expectedResource, resourceTemplates: { [resourceTemplateId]: resourceTemplate } } },
-        { type: 'SET_LAST_SAVE_CHECKSUM', payload: { resourceKey: 'abc123', checksum: 'baf92a33bf689d599a41bb4563db42fc' } },
+        { type: 'SET_LAST_SAVE_CHECKSUM', payload: { resourceKey: 'abc123', checksum: 'bbf95e2eaec615f77fa4f230d746ff68' } },
         { type: 'SET_UNUSED_RDF', payload: { resourceKey: 'abc123', rdf: null } },
         { type: 'ADD_TEMPLATE_HISTORY', payload: resourceTemplate }])
     })

--- a/__tests__/actionCreators/resources.test.js
+++ b/__tests__/actionCreators/resources.test.js
@@ -135,6 +135,53 @@ describe('retrieveResource', () => {
     })
   })
 
+  describe('when relative URI', () => {
+    const received = `<> <http://www.w3.org/2000/01/rdf-schema#label> "splendid"@eng .
+  <> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Note> .
+  <> <http://sinopia.io/vocabulary/hasResourceTemplate> "resourceTemplate:bf2:Note" .`
+
+    sinopiaServer.loadRDFResource = jest.fn().mockResolvedValue({ response: { text: received } })
+
+    it('it dispatches actions', async () => {
+      const resourceTemplateId = 'resourceTemplate:bf2:Note'
+      const templateResponse = await getFixtureResourceTemplate(resourceTemplateId)
+      const resourceTemplate = templateResponse.response.body
+
+      sinopiaServer.getResourceTemplate.mockImplementation(getFixtureResourceTemplate)
+
+      expect(await store.dispatch(retrieveResource(currentUser, uri, 'testerrorkey'))).toBe(true)
+
+      const actions = store.getActions()
+      const expectedResource = {
+        'resourceTemplate:bf2:Note': {
+          'http://www.w3.org/2000/01/rdf-schema#label': {
+            items: {
+              def456: {
+                content: 'splendid',
+                label: 'splendid',
+                lang: 'eng',
+              },
+            },
+          },
+          resourceURI: 'http://sinopia.io/repository/stanford/123',
+        },
+      }
+      const reduxPath = ['entities', 'resources', 'abc123', 'resourceTemplate:bf2:Note', 'http://www.w3.org/2000/01/rdf-schema#label']
+
+      expect(actions).toEqual([
+        { type: 'CLEAR_ERRORS', payload: 'testerrorkey' },
+        { type: 'RESOURCE_TEMPLATES_LOADED', payload: { 'resourceTemplate:bf2:Note': resourceTemplate } },
+        { type: 'RESOURCE_TEMPLATE_LOADED', payload: resourceTemplate },
+        { type: 'TOGGLE_COLLAPSE', payload: { reduxPath } },
+        { type: 'RESOURCE_LOADED', payload: { resourceKey: 'abc123', resource: expectedResource, resourceTemplates: { [resourceTemplateId]: resourceTemplate } } },
+        { type: 'SET_LAST_SAVE_CHECKSUM', payload: { resourceKey: 'abc123', checksum: undefined } },
+        { type: 'SET_LAST_SAVE_CHECKSUM', payload: { resourceKey: 'abc123', checksum: '547880ad2b8b81bfac4d15e0f856f248' } },
+        { type: 'SET_UNUSED_RDF', payload: { resourceKey: 'abc123', rdf: '' } },
+        { type: 'SET_CURRENT_RESOURCE', payload: 'abc123' },
+      ])
+    })
+  })
+
   describe('as a new resource', () => {
     it('it dispatches actions', async () => {
       const resourceTemplateId = 'resourceTemplate:bf2:Note'

--- a/__tests__/actionCreators/resources.test.js
+++ b/__tests__/actionCreators/resources.test.js
@@ -64,9 +64,9 @@ describe('update', () => {
 
 describe('retrieveResource', () => {
   const uri = 'http://sinopia.io/repository/stanford/123'
-  const received = `<> <http://www.w3.org/2000/01/rdf-schema#label> "splendid"@eng .
-<> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Note> .
-<> <http://sinopia.io/vocabulary/hasResourceTemplate> "resourceTemplate:bf2:Note" .`
+  const received = `<${uri}> <http://www.w3.org/2000/01/rdf-schema#label> "splendid"@eng .
+<${uri}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Note> .
+<${uri}> <http://sinopia.io/vocabulary/hasResourceTemplate> "resourceTemplate:bf2:Note" .`
 
   sinopiaServer.loadRDFResource = jest.fn().mockResolvedValue({ response: { text: received } })
   let store
@@ -216,8 +216,8 @@ describe('retrieveResource', () => {
 describe('publishResource', () => {
   const group = 'myGroup'
   const received = `<http://sinopia.io/repository/myGroup/myResource> <http://www.w3.org/2000/01/rdf-schema#label> "splendid"@eng .
-<> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Note> .
-<> <http://sinopia.io/vocabulary/hasResourceTemplate> "profile:bf2:Note" .`
+<http://sinopia.io/repository/myGroup/myResource> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Note> .
+<http://sinopia.io/repository/myGroup/myResource> <http://sinopia.io/vocabulary/hasResourceTemplate> "profile:bf2:Note" .`
 
   let store
   beforeEach(() => {
@@ -329,7 +329,7 @@ describe('existingResource', () => {
       const resourceTemplate = resourceTemplateResponse.response.body
       sinopiaServer.getResourceTemplate.mockImplementation(getFixtureResourceTemplate)
 
-      const unusedRDF = '<> <http://id.loc.gov/ontologies/bibframe/mainTitle> "foo"@eng .'
+      const unusedRDF = `<${uri}> <http://id.loc.gov/ontologies/bibframe/mainTitle> "foo"@eng .`
 
       expect(await store.dispatch(existingResource(resource, unusedRDF, uri, 'testerrorkey'))).toBe(true)
       const expectedResource = {

--- a/__tests__/components/editor/actions/CloseButton.test.js
+++ b/__tests__/components/editor/actions/CloseButton.test.js
@@ -85,7 +85,7 @@ describe('<CloseButton />', () => {
   describe('customized close button', () => {
     const state = createInitialState()
     // See resourceHasChangesSinceLastSave() for checksum
-    state.selectorReducer.editor.lastSaveChecksum.abc123 = '5267eb8da0ab5ef646cae0190cf13a7c'
+    state.selectorReducer.editor.lastSaveChecksum.abc123 = '8300ef4c8fb6681ec4b62d2674502e84'
     const store = createReduxStore(state)
 
     it('renders with props', () => {
@@ -105,7 +105,7 @@ describe('<CloseButton />', () => {
   describe('closing when resource has not changed', () => {
     const state = createInitialState()
     // See resourceHasChangesSinceLastSave() for checksum
-    state.selectorReducer.editor.lastSaveChecksum.abc123 = '5267eb8da0ab5ef646cae0190cf13a7c'
+    state.selectorReducer.editor.lastSaveChecksum.abc123 = '8300ef4c8fb6681ec4b62d2674502e84'
     const store = createReduxStore(state)
 
     it('clears the resource', () => {

--- a/__tests__/components/editor/actions/SaveAndPublishButton.test.js
+++ b/__tests__/components/editor/actions/SaveAndPublishButton.test.js
@@ -87,7 +87,7 @@ describe('<SaveAndPublishButton />', () => {
   it('is disabled if resource has not changed', () => {
     const initialState = createInitialState()
     // See resourceHasChangesSinceLastSave() for checksum
-    initialState.selectorReducer.editor.lastSaveChecksum.abc123 = '5267eb8da0ab5ef646cae0190cf13a7c'
+    initialState.selectorReducer.editor.lastSaveChecksum.abc123 = '8300ef4c8fb6681ec4b62d2674502e84'
     const store = createReduxStore(initialState)
     const { getByText } = renderWithRedux(
       <SaveAndPublishButton class="test" />, store,

--- a/__tests__/selectors/resourceSelectors.test.js
+++ b/__tests__/selectors/resourceSelectors.test.js
@@ -179,7 +179,7 @@ describe('resourceHasChangesSinceLastSave', () => {
       state.selectorReducer.entities.resources.abc123 = resource
       state.selectorReducer.entities.resourceTemplates['resourceTemplate:bf2:Note'] = template
       // See resourceHasChangesSinceLastSave() for checksum
-      state.selectorReducer.editor.lastSaveChecksum.abc123 = '5a003d6032fe9e3cd7d7e5cf4b388e2a'
+      state.selectorReducer.editor.lastSaveChecksum.abc123 = '75021e66490d12ff17d7e3a6c5e94d26'
       expect(resourceHasChangesSinceLastSave(state, 'abc123')).toBe(false)
     })
   })

--- a/src/actionCreators/resources.js
+++ b/src/actionCreators/resources.js
@@ -39,7 +39,7 @@ export const retrieveResource = (currentUser, uri, errorKey, asNewResource) => (
       const data = response.response.text
       return rdfDatasetFromN3(data)
         .then((dataset) => {
-          const builder = new ResourceStateBuilder(dataset, null)
+          const builder = new ResourceStateBuilder(dataset, uri)
           const resourceKey = shortid.generate()
           const newURI = asNewResource ? undefined : uri
           return builder.buildState()

--- a/src/actionCreators/resources.js
+++ b/src/actionCreators/resources.js
@@ -25,7 +25,7 @@ import _ from 'lodash'
 export const update = (resourceKey, currentUser, errorKey) => (dispatch, getState) => {
   const state = getState()
   const uri = findResourceURI(state, resourceKey)
-  const rdf = new GraphBuilder(state.selectorReducer.entities.resources[resourceKey], state.selectorReducer.entities.resourceTemplates).graph.toCanonical()
+  const rdf = new GraphBuilder(state.selectorReducer.entities.resources[resourceKey], state.selectorReducer.entities.resourceTemplates).toTurtle()
   return updateRDFResource(currentUser, uri, rdf)
     .then(() => dispatch(saveResourceFinished(resourceKey, generateMD5(rdf))))
     .catch(err => dispatch(appendError(errorKey, `Error saving ${uri}: ${err.toString()}`)))
@@ -47,7 +47,7 @@ export const retrieveResource = (currentUser, uri, errorKey, asNewResource) => (
               dispatch(setResourceTemplates(resourceTemplates))
               return dispatch(existingResourceFunc(state, newURI, resourceKey, errorKey))
                 .then((result) => {
-                  const rdf = new GraphBuilder(result[0], result[1]).graph.toCanonical()
+                  const rdf = new GraphBuilder(result[0], result[1]).toTurtle()
                   if (!asNewResource) dispatch(setLastSaveChecksum(resourceKey, generateMD5(rdf)))
                   dispatch(setUnusedRDF(resourceKey, unusedDataset.toCanonical()))
                   dispatch(setCurrentResource(resourceKey))
@@ -81,7 +81,7 @@ export const retrieveResource = (currentUser, uri, errorKey, asNewResource) => (
 export const publishResource = (resourceKey, currentUser, group, errorKey) => (dispatch, getState) => {
   // Make a copy of state to prevent changes that will affect the publish.
   const state = _.cloneDeep(getState())
-  const rdf = new GraphBuilder(state.selectorReducer.entities.resources[resourceKey], state.selectorReducer.entities.resourceTemplates).graph.toCanonical()
+  const rdf = new GraphBuilder(state.selectorReducer.entities.resources[resourceKey], state.selectorReducer.entities.resourceTemplates).toTurtle()
 
   return publishRDFResource(currentUser, rdf, group).then((result) => {
     const resourceUrl = result.response.headers.location
@@ -101,7 +101,7 @@ export const newResource = (resourceTemplateId, errorKey) => (dispatch) => {
   return stubResource(resource, true, undefined, resourceKey, errorKey, dispatch)
     .then((result) => {
       const resourceTemplates = result[1]
-      const rdf = new GraphBuilder(result[0], resourceTemplates).graph.toCanonical()
+      const rdf = new GraphBuilder(result[0], resourceTemplates).toTurtle()
       dispatch(setLastSaveChecksum(resourceKey, generateMD5(rdf)))
       dispatch(setUnusedRDF(resourceKey, null))
       dispatch(addTemplateHistory(resourceTemplates[resourceTemplateId]))

--- a/src/selectors/resourceSelectors.js
+++ b/src/selectors/resourceSelectors.js
@@ -121,7 +121,7 @@ export const resourceHasChangesSinceLastSave = (state, resourceKey) => {
   if (lastSaveChecksum === undefined) {
     return true
   }
-  const rdf = new GraphBuilder(state.selectorReducer.entities.resources[thisResourceKey], state.selectorReducer.entities.resourceTemplates).graph.toCanonical()
+  const rdf = new GraphBuilder(state.selectorReducer.entities.resources[thisResourceKey], state.selectorReducer.entities.resourceTemplates).toTurtle()
   const resourceChecksum = generateMD5(rdf)
   return lastSaveChecksum !== resourceChecksum
 }

--- a/src/sinopiaServer.js
+++ b/src/sinopiaServer.js
@@ -99,7 +99,7 @@ export const updateResourceTemplate = async (templateObject, group, currentUser)
   return await instance.updateResourceWithHttpInfo(group, templateObject.id, templateObject, { contentType: 'application/json' })
 }
 
-const sendingNtriples = { contentType: 'application/n-triples' }
+const sendingTurtle = { contentType: 'text/turtle' }
 const returningNtriples = { accept: 'application/n-triples' }
 
 /**
@@ -175,7 +175,7 @@ const returningNtriples = { accept: 'application/n-triples' }
  */
 export const publishRDFResource = async (currentUser, rdf, group) => {
   await authenticate(currentUser)
-  return await instance.createResourceWithHttpInfo(group, rdf, sendingNtriples)
+  return await instance.createResourceWithHttpInfo(group, rdf, sendingTurtle)
 }
 
 /* eslint security/detect-unsafe-regex: ["off"] */
@@ -190,7 +190,7 @@ export const updateRDFResource = async (currentUser, uri, rdf) => {
   await authenticate(currentUser)
 
   const id = identifiersForUri(uri)
-  return await instance.updateResource(id.group, id.identifier, rdf, sendingNtriples)
+  return await instance.updateResource(id.group, id.identifier, rdf, sendingTurtle)
 }
 
 export const loadRDFResource = async (currentUser, uri) => {


### PR DESCRIPTION
Fixes #1753

To be discussed/tested before merging and going with this approach:

1. With the changes in this branch, how does/will the editor handle the currently broken triples coming back from Trellis? (I *think* they will load since we have code in place for handling null subjects in N-Triples data, but I could be mistaken.)
2. Assuming all is copacetic with (1) above, will the code in this branch automagically handle migration of data that needs fixing, or do we need a more intentional and systematic migration strategy for all the broken data?
3. When this is deployed, what effect will it have on open sessions (particularly w/ regard to the changes in this branch related to checking to see if a resource has changed, which used to do this check by hashing the N-Triples representation but now does it by hashing the Turtle representation)?
4. The `sinopiaServer` module is currently sending data as Turtle and receiving it is N-Triples. Do we want to change this behavior, or should we keep retrieving data from Trellis as N-Triples? (Because ... reasons.)

Big thanks to @justinlittman for sharing the writable stream technique; that was the key to convincing the N3Writer to operate in synchronous mode (which wasn't obvious to me from the N3 documentation, which is otherwise quite good). 