### PR TITLE
Removed unnecessary ellipsis

### DIFF
--- a/__tests__/components/editor/SaveAlert.test.js
+++ b/__tests__/components/editor/SaveAlert.test.js
@@ -15,7 +15,7 @@ describe('<SaveAlert />', () => {
     )
 
     it('does not render', () => {
-      expect(queryByText('Saved ...')).not.toBeInTheDocument()
+      expect(queryByText('Saved')).not.toBeInTheDocument()
     })
   })
 
@@ -29,7 +29,7 @@ describe('<SaveAlert />', () => {
     )
 
     it('is not displayed', () => {
-      expect(queryByText('Saved ...')).not.toBeInTheDocument()
+      expect(queryByText('Saved')).not.toBeInTheDocument()
     })
   })
 })

--- a/src/components/editor/SaveAlert.jsx
+++ b/src/components/editor/SaveAlert.jsx
@@ -10,7 +10,7 @@ const SaveAlert = () => {
 
   return (
     <ExpiringMessage timestamp={lastSave}>
-      Saved ...
+      Saved
     </ExpiringMessage>)
 }
 


### PR DESCRIPTION
An ellipsis indicates an ommission of a word or phrase, but it's unclear what is omitted in this case.