### PR TITLE
Always use the 2 column login layout.

### DIFF
--- a/__tests__/components/home/NewsPanel.test.js
+++ b/__tests__/components/home/NewsPanel.test.js
@@ -1,19 +1,15 @@
 // Copyright 2019 Stanford University see LICENSE for license
 
 import React from 'react'
-import { shallow } from 'enzyme'
+import { renderWithRedux, createReduxStore, createBlankState } from 'testUtils'
 import NewsPanel from 'components/home/NewsPanel'
-import NewsItem from 'components/home/NewsItem'
-import LoginPanel from 'components/home/LoginPanel'
 
 describe('<NewsPanel />', () => {
-  const wrapper = shallow(<NewsPanel.WrappedComponent />)
-
-  it('renders <NewsItem /> component', () => {
-    expect(wrapper.find(NewsItem)).toBeDefined()
-  })
-
-  it('renders <LoginPanel /> component', () => {
-    expect(wrapper.find(LoginPanel)).toBeDefined()
+  it('renders', () => {
+    const store = createReduxStore(createBlankState())
+    const { queryByText } = renderWithRedux(
+      <NewsPanel />, store,
+    )
+    expect(queryByText('Latest news')).toBeInTheDocument()
   })
 })

--- a/src/components/home/NewsPanel.jsx
+++ b/src/components/home/NewsPanel.jsx
@@ -1,53 +1,25 @@
 // Copyright 2019 Stanford University see LICENSE for license
 
-import React, { Component } from 'react'
-import PropTypes from 'prop-types'
+import React from 'react'
 import NewsItem from './NewsItem'
 import LoginPanel from './LoginPanel'
-import { connect } from 'react-redux'
-import { getCurrentUser } from 'authSelectors'
 
-class NewsPanel extends Component {
-  render() {
-    const loggedInPanel = (
-      <React.Fragment>
-        <div className="col-md-12">
-          <NewsItem /><LoginPanel />
-        </div>
-      </React.Fragment>
-    )
-
-    const notLoggedInPanel = (
-      <React.Fragment>
-        <div className="col-md-6">
-          <NewsItem />
-        </div>
-        <div className="col-md-6">
-          <LoginPanel />
-        </div>
-      </React.Fragment>
-    )
-
-    return (
-      <div className="jumbotron banner center-block">
-        <div className="card panel-news">
-          <div className="card-body">
-            <div className="row">
-              { this.props.currentUser ? loggedInPanel : notLoggedInPanel }
-            </div>
+const NewsPanel = () => (
+  <div className="jumbotron banner center-block">
+    <div className="card panel-news">
+      <div className="card-body">
+        <div className="row">
+          <div className="col-md-6">
+            <NewsItem />
+          </div>
+          <div className="col-md-6">
+            <LoginPanel />
           </div>
         </div>
       </div>
-    )
-  }
-}
+    </div>
+  </div>
+)
 
-NewsPanel.propTypes = {
-  currentUser: PropTypes.object,
-}
 
-const mapStateToProps = state => ({
-  currentUser: getCurrentUser(state),
-})
-
-export default connect(mapStateToProps)(NewsPanel)
+export default NewsPanel


### PR DESCRIPTION
Previously it was using a one-column layout if there were login errors.

Fixes #1907 