### PR TITLE
increase radio button size

### DIFF
--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -390,3 +390,7 @@ ul.resources-nav-tabs button.active {
 .icon-lg {
   font-size: 20px;
 }
+
+input[type='radio'] {
+  transform: scale(1.5);
+}


### PR DESCRIPTION
fixes #1909 

see screenshots below - we can also adjust it smaller/bigger than shown if desired

note: may not be supported in all browsers (tested in firefox and chrome mac, where it works fine, didn't notice a change in safari)