### PR TITLE
Check if typeahead authorities are configured before checking for known tag names

### DIFF
--- a/__tests__/ResourceTemplateValidator.test.js
+++ b/__tests__/ResourceTemplateValidator.test.js
@@ -64,7 +64,7 @@ describe('validateResourceTemplate', () => {
     expect(reasons[0]).toEqual('Validation error for http://id.loc.gov/ontologies/bibframe/Instance: The following resource templates references for http://id.loc.gov/ontologies/bibframe/genreForm have the same resource URI (http://id.loc.gov/ontologies/bibframe/GenreForm), but must be unique: ld4p:RT:bf2:Form, ld4p:RT:bf2:RareMat:RBMS')
   })
 
-  it('returns reason for missing lookup valueConstrant URI', async () => {
+  it('returns reason for missing lookup valueConstraint URI', async () => {
     const templateResponse = await getFixtureResourceTemplate('test:RT:bf2:notFoundValueTemplateRefsURI')
     const reasons = await validateResourceTemplate(templateResponse.response.body)
     expect(reasons[0]).toEqual('Validation error for http://id.loc.gov/ontologies/bibframe/Identifier: Property templates http://id.loc.gov/ontologies/bibframe/geographicCoverage, http://id.loc.gov/ontologies/bibframe/geographicCoverage have value constraint lookup URIs that are not found in configuration: urn:ld4p:qa:names:place, urn:ld4p:qa:subjects:place')

--- a/src/ResourceTemplateValidator.js
+++ b/src/ResourceTemplateValidator.js
@@ -15,11 +15,18 @@ export const validateResourceTemplate = async resourceTemplate => [].concat(
   validateRepeatedPropertyTemplates(resourceTemplate),
   validateNoDefaultURIForLiterals(resourceTemplate),
   validateNoDefaultsForTemplateRefs(resourceTemplate),
-  validateTypeAheadAuthorityURIs(resourceTemplate),
+  validateLookupAuthorityOrKnownTagName(resourceTemplate),
   await validateTemplateRefsExist(resourceTemplate),
   await validateUniqueResourceURIs(resourceTemplate),
-  validateKnownTagName(resourceTemplate),
 )
+
+const validateLookupAuthorityOrKnownTagName = (resourceTemplate) => {
+  let validation = validateTypeAheadAuthorityURIs(resourceTemplate)
+  if (validation.length === 0) {
+    validation = validateKnownTagName(resourceTemplate)
+  }
+  return validation
+}
 
 /**
  * Validates that a resource template does not contain repeated property templates.

--- a/src/utilities/propertyTemplates.js
+++ b/src/utilities/propertyTemplates.js
@@ -21,11 +21,11 @@ export const getTagNameForPropertyTemplate = (propertyTemplate) => {
     case 'list':
       return 'InputListLOC'
     default:
-      return textFieldType(config, propertyTemplate)
+      return textFieldType(propertyTemplate)
   }
 }
 
-const textFieldType = (config, propertyTemplate) => {
+const textFieldType = (propertyTemplate) => {
   switch (propertyTemplate.type) {
     case 'literal':
       return 'InputLiteral'


### PR DESCRIPTION
Fixes #1858 

Also removed unused argument in function call and corrects a typo.