### PR TITLE
Sets correct option key for URIs vs. strings

### DIFF
--- a/__tests__/components/editor/property/renderTypeaheadFunctions.test.js
+++ b/__tests__/components/editor/property/renderTypeaheadFunctions.test.js
@@ -38,6 +38,25 @@ describe('Rendering Typeahead Menu', () => {
       expect(menuWrapper.childAt(4).html()).toEqual('<li class="dropdown-header">New URI</li>')
       expect(menuWrapper.childAt(5).childAt(0).text()).toEqual('http://id.loc.gov/authorities/subjects/123456789')
     })
+
+    it('sets the correct for customOptions', () => {
+      const lookupConfigs = findAuthorityConfigs(['urn:ld4p:qa:agrovoc'])
+      const customOptions = [
+        {
+          customOption: true,
+          label: 'http://schema.org/Food',
+        },
+        {
+          customOption: true,
+          label: 'A piece of corn-on-the-cob',
+        },
+      ]
+      const menuWrapper = shallow(renderMenuFunc(customOptions, p2Props, lookupConfigs))
+      expect(menuWrapper.childAt(1).childAt(0).text()).toEqual('New URI')
+      expect(menuWrapper.childAt(2).childAt(0).text()).toEqual('http://schema.org/Food')
+      expect(menuWrapper.childAt(3).childAt(0).text()).toEqual('New Literal')
+      expect(menuWrapper.childAt(4).childAt(0).text()).toEqual('A piece of corn-on-the-cob')
+    })
   })
 
   describe('Rendering Tokens', () => {

--- a/src/components/editor/property/renderTypeaheadFunctions.js
+++ b/src/components/editor/property/renderTypeaheadFunctions.js
@@ -57,12 +57,13 @@ export const renderMenuFunc = (results, menuProps, lookupConfigs) => {
 
   const customOption = results.filter((result) => result.customOption)
   customOption.forEach((result) => {
-    const headerLabel = isValidURI(result.label) ? 'New URI' : 'New Literal'
+    const isURI = isValidURI(result.label)
+    const headerLabel = isURI ? 'New URI' : 'New Literal'
     const option = {
       id: result.label,
       label: result.label,
-      content: result.label,
     }
+    isURI ? option.uri = result.label : option.content = result.label
     items.push(<Menu.Header key="customOption-header">{headerLabel}</Menu.Header>)
     items.push(<MenuItem key={result.label} option={option} data-testid="customOption-link">{result.label}</MenuItem>)
   })


### PR DESCRIPTION
Currently the editor when is doing a lookup, if the user adds a valid URI (not found in the lookup itself) the correct label is being displayed but we're not adding an "uri"
![Screen Shot 2020-01-27 at 1 43 26 PM](https://user-images.githubusercontent.com/71847/73212233-0571a100-410b-11ea-83aa-e92e3517fdec.png)

In the RDF preview, the following RDF is generated with both values being literals:
![Screen Shot 2020-01-27 at 1 44 09 PM](https://user-images.githubusercontent.com/71847/73212329-3a7df380-410b-11ea-8fc4-836e172ea658.png)

This PR fixes this bug and results in the following:
![Screen Shot 2020-01-27 at 1 47 22 PM](https://user-images.githubusercontent.com/71847/73215564-8cc21300-4111-11ea-8580-5ef4847a64fe.png)

