### PR TITLE
bump version to 2.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sinopia_editor",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "editor",
     "rdf"
   ],
-  "version": "2.0.4",
+  "version": "2.0.5",
   "homepage": "http://github.com/LD4P/sinopia_editor/",
   "repository": {
     "type": "git",


### PR DESCRIPTION
was unable to push to master per release issue template instructions, creating PR for version bump.

~~discussed w/ @jermnelson, who suggested just approving and merging myself, since i'd have pushed directly to master.~~
actually i am not allowed to self-approve (makes sense).