### PR TITLE
update version bump instructions

### DIFF
--- a/.github/ISSUE_TEMPLATE/tagged-release.md
+++ b/.github/ISSUE_TEMPLATE/tagged-release.md
@@ -13,11 +13,11 @@ assignees: ''
 - [ ] Create release.
   - [ ] Pull latest master.
   - For the sinopia_editor only (sinopia_indexing_pipeline does not need to update the version number in the package.json file):
-    - [ ] Update the version in *package.json*
+    - [ ] Check out a branch and update the version in *package.json*
     - [ ] `npm i` to regenerate *package-lock.json*
     - [ ] `npm publish` to publish the version to [npm registry](https://npmjs.com).
-  - [ ] Commit change to master and push.
-  - [ ] Publish a [new release](https://github.com/LD4P/sinopia_editor/releases/new) with a version like `v1.0.2` and wait for Circleci to complete building and pushing docker images.
+    - [ ] Commit change to branch and push; create PR for version bump.  (You can't push directly to master, since it's a protected branch).
+    - [ ] Once PR is merged, publish a [new release](https://github.com/LD4P/sinopia_editor/releases/new) with a version like `v1.0.2` and wait for Circleci to complete building and pushing docker images.
 - [ ] AWS Images for supporting projects - the Sinopia stack requires
   a number of other projects to run successfully both locally and on AWS. If any of
   these projects changed between tagged releases, you will need to update and tag the


### PR DESCRIPTION
can't push directly to master per old instructions, since it's a protected branch.  results in error like:
```
$ git push
Enumerating objects: 7, done.
Counting objects: 100% (7/7), done.
Delta compression using up to 8 threads
Compressing objects: 100% (4/4), done.
Writing objects: 100% (4/4), 423 bytes | 211.00 KiB/s, done.
Total 4 (delta 3), reused 0 (delta 0)
remote: Resolving deltas: 100% (3/3), completed with 3 local objects.
remote: error: GH006: Protected branch update failed for refs/heads/master.
remote: error: At least 1 approving review is required by reviewers with write access.
To github.com:LD4P/sinopia_editor.git
 ! [remote rejected]   master -> master (protected branch hook declined)
error: failed to push some refs to 'git@github.com:LD4P/sinopia_editor.git'
```

i also fixed up the indentation in that section so that everything related to the version bump would be nested under the right bullet point.

alternatively, we could close this PR, and unprotect master.  no preference either way from me -- pushing version bumps to master is nice, but protecting from accidental merges and force pushes is probably worth the inconvenience?  🤷‍♂ 