### PR TITLE
Only build graph when RDFModal is displayed.

### DIFF
--- a/src/components/editor/RDFModal.jsx
+++ b/src/components/editor/RDFModal.jsx
@@ -41,7 +41,9 @@ const RDFModal = (props) => {
                 <SaveAndPublishButton class="modal-save" />
               </div>
             </div>
-            <RDFDisplay rdf={props.rdf()} />
+            { props.show
+              && <RDFDisplay rdf={props.rdf()} />
+            }
           </div>
         </div>
       </div>


### PR DESCRIPTION
Reduces this expensive operation to only when RDFModal is visible.