### PR TITLE
Tests Language Reducer

### DIFF
--- a/__tests__/reducers/languages.test.js
+++ b/__tests__/reducers/languages.test.js
@@ -1,0 +1,97 @@
+// Copyright 2020 Stanford University see LICENSE for license
+
+import {
+  fetchingLanguages, languagesReceived, setLanguage,
+} from 'reducers/languages'
+
+import { createReducer } from 'reducers/index'
+import { createState } from 'stateUtils'
+
+const reducers = {
+  FETCHING_LANGUAGES: fetchingLanguages,
+  LANGUAGE_SELECTED: setLanguage,
+  LANGUAGES_RECEIVED: languagesReceived,
+}
+const reducer = createReducer(reducers)
+
+describe('fetchingLanguages()', () => {
+  it('sets loading in state', () => {
+    const oldState = {
+      entities: {
+        languages: {
+          loading: false,
+        },
+      },
+    }
+
+    const action = {
+      type: 'FETCHING_LANGUAGES',
+    }
+
+    const newState = reducer(oldState, action)
+    expect(newState).toStrictEqual({
+      entities: {
+        languages: {
+          loading: true,
+        },
+      },
+    })
+  })
+})
+
+describe('languagesReceived()', () => {
+  it('creates a hash of options that it renders in the form field', () => {
+    const lcLanguage = [
+      {
+        '@id': 'http://id.loc.gov/vocabulary/iso639-2/sna',
+        'http://www.loc.gov/mads/rdf/v1#authoritativeLabel': [
+          {
+            '@language': 'en',
+            '@value': 'Shona',
+          },
+        ],
+      },
+      {
+        '@id': 'http://id.loc.gov/vocabulary/languages/oops',
+      },
+    ]
+
+    const oldState = {
+      entities: {
+        resourceTemplates: {},
+      },
+    }
+
+    const action = {
+      type: 'LANGUAGES_RECEIVED',
+      payload: lcLanguage,
+    }
+
+    const newState = reducer(oldState, action)
+    expect(newState).toEqual({
+      entities: {
+        resourceTemplates: {},
+        languages: {
+          loading: false,
+          options: [{ id: 'sna', label: 'Shona' }],
+        },
+      },
+    })
+  })
+})
+
+describe('setLanguage', () => {
+  it('sets value language', () => {
+    const oldState = createState({ hasResourceWithLiteral: true })
+    const action = {
+      type: 'LANGUAGE_SELECTED',
+      payload: {
+        valueKey: 'CxGx7WMh2',
+        lang: 'spa',
+      },
+    }
+
+    const newState = reducer(oldState.selectorReducer, action)
+    expect(newState.entities.values.CxGx7WMh2.lang).toBe('spa')
+  })
+})

--- a/src/reducers/languages.js
+++ b/src/reducers/languages.js
@@ -1,3 +1,5 @@
+// Copyright 2020 Stanford University see LICENSE for license
+
 export const setLanguage = (state, action) => {
   const newState = { ...state }
 


### PR DESCRIPTION
Two new tests and copied `languagesReceived()` from `__tests__/reducers/entities.test.xjs` for  `reducers/languages.js`. Fixes #2247 