### PR TITLE
Search result updates for Elasticsearch Upgrade

### DIFF
--- a/__tests__/sinopiaSearch.test.js
+++ b/__tests__/sinopiaSearch.test.js
@@ -15,7 +15,7 @@ describe('getSearchResults', () => {
       failed: 0,
     },
     hits: {
-      total: 2,
+      total: { value: 2 },
       max_score: 0.2876821,
       hits: [{
         _index: 'sinopia_resources',
@@ -186,7 +186,7 @@ describe('getSearchResultsWithFacets', () => {
       failed: 0,
     },
     hits: {
-      total: 2,
+      total: { value: 2 },
       max_score: 1,
       hits: [
         {
@@ -380,7 +380,7 @@ describe('getLookupResults', () => {
       failed: 0,
     },
     hits: {
-      total: 0,
+      total: { value: 0 },
       max_score: null,
       hits: [],
     },
@@ -396,7 +396,7 @@ describe('getLookupResults', () => {
       failed: 0,
     },
     hits: {
-      total: 1,
+      total: { value: 1 },
       max_score: 0.53412557,
       hits: [
         {

--- a/src/sinopiaSearch.js
+++ b/src/sinopiaSearch.js
@@ -96,7 +96,7 @@ export const getSearchResultsWithFacets = async (query, options = {}) => {
 
 const hitsToResult = (hits) => (
   {
-    totalHits: hits.total,
+    totalHits: hits.total.value,
     results: hits.hits.map((row) => ({
       uri: row._source.uri,
       label: row._source.label,
@@ -159,7 +159,7 @@ export const getTemplateSearchResults = async (query, options = {}) => {
         }
       }
       return {
-        totalHits: json.hits.total,
+        totalHits: json.hits.total.value,
         results: json.hits.hits.map((row) => row._source),
         error: undefined,
       }


### PR DESCRIPTION
We are moving to using multiple nodes in our AWS Elasticsearch cluster; as part of this work we needed to upgrade to 
AWS Elasticsearch version 7.4. The search result object returned from Elasticsearch slightly changed with the total hits moving from a integer to a object containing a value key. This PR updates the sinopiaSearch along with updating the tests to support this change. This PR depends on a new `sinopia_indexing_pipeline` PR https://github.com/LD4P/sinopia_indexing_pipeline/pull/212 being merged and available. We will need this PR merged before upgrading Elasticsearch on stage and production. 

