### PR TITLE
Adds a test for the NewsItem component

### DIFF
--- a/__tests__/feature/readNews.test.js
+++ b/__tests__/feature/readNews.test.js
@@ -1,0 +1,15 @@
+// Copyright 2020 Stanford University see LICENSE for license
+
+import { renderApp } from 'testUtils'
+import { screen } from '@testing-library/react'
+
+describe('reading the latest Sinopia news items', () => {
+  it('displays a div containing the latest news, version of Sinopia, link to github site, and a static text list', async () => {
+    renderApp()
+    await screen.findByText('Latest news')
+    await screen.findByText(/Sinopia Version \d\.\d\.\d highlights/)
+    screen.getByRole('link', { name: 'Sinopia help site' })
+    const list = screen.getAllByRole('listitem')
+    expect(list.length).not.toBeLessThan(4)
+  })
+})


### PR DESCRIPTION
Fixes #2275 

 If there is a better way to narrow the rendered listitems to just the specific component I could more precisely test the length of the list.


