### PR TITLE
New tests for actionCreators/resources

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10826,6 +10826,12 @@
         "@jest/types": "^24.9.0"
       }
     },
+    "jest-mock-console": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/jest-mock-console/-/jest-mock-console-1.0.1.tgz",
+      "integrity": "sha512-Bn+Of/cvz9LOEEeEg5IX5Lsf8D2BscXa3Zl5+vSVJl37yiT8gMAPPKfE09jJOwwu1zbagL11QTrH+L/Gn8udOg==",
+      "dev": true
+    },
     "jest-pnp-resolver": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.1.tgz",

--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
     "jest": "^24.8.0",
     "jest-junit": "^10.0.0",
     "jest-localstorage-mock": "^2.4.3",
+    "jest-mock-console": "^1.0.1",
     "jest-prop-type-error": "^1.1.0",
     "jsdom": "15.2.1",
     "jsdom-global": "3.0.2",

--- a/src/actionCreators/resources.js
+++ b/src/actionCreators/resources.js
@@ -13,7 +13,7 @@ import {
   addProperty as addPropertyAction,
   addValue as addValueAction, addSubject as addSubjectAction,
   showProperty, setBaseURL, setCurrentResource, saveResourceFinished,
-  setUnusedRDF, loadResourceFinished, setResourceGroup,
+  setUnusedRDF, loadResourceFinished, setResourceGroup, removeProperty,
 } from 'actions/resources'
 import { newValueSubject } from 'utilities/valueFactory'
 
@@ -128,7 +128,7 @@ const resourceTemplateIdFromDataset = (uri, dataset) => {
 export const saveNewResource = (resourceKey, currentUser, group, errorKey) => (dispatch, getState) => {
   const resource = selectFullSubject(getState(), resourceKey)
 
-  postResource(resource, currentUser, group)
+  return postResource(resource, currentUser, group)
     .then((resourceUrl) => {
       dispatch(setBaseURL(resourceKey, resourceUrl))
       dispatch(setResourceGroup(resourceKey, group))
@@ -144,7 +144,7 @@ export const saveNewResource = (resourceKey, currentUser, group, errorKey) => (d
 export const saveResource = (resourceKey, currentUser, errorKey) => (dispatch, getState) => {
   const resource = selectFullSubject(getState(), resourceKey)
 
-  putResource(resource, currentUser)
+  return putResource(resource, currentUser)
     .then(() => dispatch(saveResourceFinished(resourceKey)))
     .catch((err) => {
       console.error(err)
@@ -183,6 +183,7 @@ export const expandProperty = (propertyKey, errorKey) => (dispatch, getState) =>
 export const contractProperty = (propertyKey) => (dispatch, getState) => {
   const property = selectProperty(getState(), propertyKey)
   property.values = null
+  dispatch(removeProperty(propertyKey))
   dispatch(addPropertyAction(property))
 }
 


### PR DESCRIPTION
## Why was this change made?
Fixes #2239, adds missing action to `contractProperty`.


## How was this change tested?
Run test suite


## Which documentation and/or configurations were updated?
n/a


