### PR TITLE
feature tests for user authentication

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -124,6 +124,7 @@ module.exports = {
     "no-undefined": "off",
     "no-underscore-dangle": "off",
     "no-unused-expressions": "off",
+    "no-unused-vars": ['error', { 'argsIgnorePattern': '^_.*'  }],
     "no-use-before-define": "off",
     "no-useless-constructor": "warn",
     "no-var": "error",

--- a/__tests__/feature/userAuthentication.test.js
+++ b/__tests__/feature/userAuthentication.test.js
@@ -1,0 +1,82 @@
+// Copyright 2018 Stanford University see LICENSE for license
+
+import * as awsCognito from 'amazon-cognito-identity-js'
+import {
+  fireEvent, screen, waitForElementToBeRemoved,
+} from '@testing-library/react'
+
+import { createState } from 'stateUtils'
+import { createStore, renderApp } from 'testUtils'
+
+jest.mock('amazon-cognito-identity-js')
+
+function MockCognitoUserAuthenticationSuccess(_userData) {
+  this.username = 'Baz Le Quux'
+  this.authenticateUser = (_authnDetails, callbacks) => {
+    callbacks.onSuccess({ currentSession: { idToken: {} } })
+  }
+}
+
+function MockCognitoUserAuthenticationFailure(_userData) {
+  this.username = 'Baz Le Quux'
+  this.authenticateUser = (_authnDetails, callbacks) => {
+    callbacks.onFailure({
+      code: 'NotAuthorizedException', name: 'NotAuthorizedException', message: 'Incorrect username or password.',
+    })
+  }
+}
+
+
+describe('user authentication', () => {
+  it('allows a logged in user to log out and allows a new one to login', async () => {
+    renderApp()
+    screen.getByText(/Foo McBar/) // user Foo McBar should be logged in already when using default test redux store
+
+    // logout, and confirm that the UI gets rid of the old user name
+    // and removes elements that require authentication to view
+    fireEvent.click(screen.getByRole('link', { name: 'Logout' }))
+
+    // likely that things will have already re-rendered, but if not, wait for it
+    if (screen.queryByText(/Foo McBar/)) {
+      await waitForElementToBeRemoved(() => screen.getByText(/Foo McBar/))
+    }
+    // check for elements indicating we were sent back to the login page
+    expect(screen.queryByRole('link', { name: 'Logout' })).not.toBeInTheDocument()
+    screen.getByText(/Latest news/)
+    screen.getByText(/Sinopia Version \d+.\d+.\d+ highlights/)
+    screen.getByRole('link', { name: 'Sinopia help site' })
+
+    awsCognito.CognitoUser.mockImplementation(MockCognitoUserAuthenticationSuccess)
+
+    // login as a different user
+    fireEvent.change(screen.getByLabelText('User name'), { target: { value: 'baz.le.quux@example.edu' } })
+    fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'Password2' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Login' }))
+
+    // make sure we get the expected username and page elements
+    await screen.findByText(/Baz Le Quux/)
+    await screen.findByRole('link', { name: 'Logout' })
+  })
+
+  it('presents a helpful error when the user enters the wrong password', async () => {
+    const state = createState({ notAuthenticated: true })
+    const store = createStore(state)
+    renderApp(store)
+
+    // confirm that it appears user is not logged in
+    expect(screen.queryByRole('link', { name: 'Logout' })).not.toBeInTheDocument()
+    screen.getByText(/Latest news/)
+    screen.getByText(/Sinopia Version \d+.\d+.\d+ highlights/)
+    screen.getByRole('link', { name: 'Sinopia help site' })
+
+    awsCognito.CognitoUser.mockImplementation(MockCognitoUserAuthenticationFailure)
+
+    // try to login
+    fireEvent.change(screen.getByLabelText('User name'), { target: { value: 'baz.le.quux@example.edu' } })
+    fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'password1' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Login' }))
+
+    // an error message should be presented
+    await screen.findByText(/Incorrect username or password./)
+  })
+})

--- a/__tests__/testUtilities/stateUtils.js
+++ b/__tests__/testUtilities/stateUtils.js
@@ -26,6 +26,7 @@ const buildAuthenticate = (state, options) => {
     },
     currentUser: {
       username: 'Foo McBar',
+      globalSignOut: (resultHandler) => { resultHandler.onSuccess() },
     },
   }
 }


### PR DESCRIPTION
* tests for logout, login as another user, and login with the wrong password
* eslint config tweak to allow placeholder params in mocks
* tweak to default state to provide signout callback for user

## Why was this change made?

to increase feature test coverage.

closes #2274

## How was this change tested?

PR is solely additional feature tests.

## Which documentation and/or configurations were updated?

minor tweak to eslint config to allow `_` prefixed params to be ignored by the `no-unused-vars` rule, so that mock params can match those of the real life object (even though the mock implementation doesn't need the param).