### PR TITLE
toBeDisabled always returns a positive the correct call is toBeDisbled()

### DIFF
--- a/__tests__/feature/editing/editingLiteral.test.js
+++ b/__tests__/feature/editing/editingLiteral.test.js
@@ -32,12 +32,12 @@ describe('editing a literal property', () => {
     // There is language button.
     expect(screen.getByRole('button', { name: 'Change language for foo' })).toHaveTextContent('Language: English')
     // Input is disabled and empty
-    expect(input).toBeDisabled
+    expect(input).toBeDisabled()
     expect(input).toHaveValue('')
 
     // Clicking edit
     fireEvent.click(editBtn)
-    expect(input).not.toBeDisabled
+    expect(input).not.toBeDisabled()
     expect(input).toHaveValue('foo')
     expect(screen.queryAllByText('foo').length).toBeFalsy()
 
@@ -50,7 +50,7 @@ describe('editing a literal property', () => {
     fireEvent.click(removeBtn)
 
     expect(screen.queryAllByText('foobar').length).toBeFalsy()
-    expect(input).not.toBeDisabled
+    expect(input).not.toBeDisabled()
     expect(input).toHaveValue('')
   })
 
@@ -88,7 +88,7 @@ describe('editing a literal property', () => {
     expect(screen.getByRole('button', { name: 'Change language for bar' })).toHaveTextContent('Language: English')
 
     // Input is not disabled and empty
-    expect(input).not.toBeDisabled
+    expect(input).not.toBeDisabled()
     expect(input).toHaveValue('')
   })
 

--- a/__tests__/feature/editing/editingUri.test.js
+++ b/__tests__/feature/editing/editingUri.test.js
@@ -30,12 +30,12 @@ describe('editing a URI property', () => {
     const editBtn = screen.getByRole('button', { name: 'Edit http://id.loc.gov/authorities/names/n79032058' })
     expect(editBtn).toHaveTextContent('Edit')
     // Input is disabled and empty
-    expect(input).toBeDisabled
+    expect(input).toBeDisabled()
     expect(input).toHaveValue('')
 
     // Clicking edit
     fireEvent.click(editBtn)
-    expect(input).not.toBeDisabled
+    expect(input).not.toBeDisabled()
     expect(input).toHaveValue('http://id.loc.gov/authorities/names/n79032058')
     expect(screen.queryAllByText('http://id.loc.gov/authorities/names/n79032058').length).toBeFalsy()
 
@@ -48,7 +48,7 @@ describe('editing a URI property', () => {
     fireEvent.click(removeBtn)
 
     expect(screen.queryAllByText('http://id.loc.gov/authorities/names/n79056054').length).toBeFalsy()
-    expect(input).not.toBeDisabled
+    expect(input).not.toBeDisabled()
     expect(input).toHaveValue('')
   })
 
@@ -79,7 +79,7 @@ describe('editing a URI property', () => {
     expect(screen.getByRole('button', { name: 'Edit http://id.loc.gov/authorities/names/n79056054' })).toHaveTextContent('Edit')
 
     // Input is not disabled and empty
-    expect(input).not.toBeDisabled
+    expect(input).not.toBeDisabled()
     expect(input).toHaveValue('')
   })
 


### PR DESCRIPTION
## Why was this change made?

A small bug fix in tests. I found that `toBeDisabled` always returns true because it's actually a function and should be called as `toBeDisabled()` - I'm unclear why this isn't an error.

## How was this change tested?

N/A

## Which documentation and/or configurations were updated?

N/A
