### PR TITLE
Test selector errors

### DIFF
--- a/__tests__/selectors/errors.test.js
+++ b/__tests__/selectors/errors.test.js
@@ -51,7 +51,7 @@ describe('selectValidationErrors()', () => {
   })
 
   it('returns errors for a property given a subject key', () => {
-    const state = createState({ hasResourceWithLiteral: true })
+    const state = createState({ hasResourceWithLiteral: true, error: ['error 1'] })
     const errors = selectValidationErrors(state, 't9zVwg2zO')
     expect(errors.length).toBe(1)
     expect(errors[0].message).toEqual('error 1')
@@ -60,7 +60,7 @@ describe('selectValidationErrors()', () => {
   })
 
   it('returns errors for a property with a nested resource given a subject key', () => {
-    const state = createState({ hasResourceWithNestedResource: true })
+    const state = createState({ hasResourceWithNestedResource: true, error: ['error 2'] })
     const errors = selectValidationErrors(state, 'ljAblGiBW')
     expect(errors[0].message).toEqual('error 2')
     expect(errors[0].propertyKey).toEqual('v1o90QO1Qx')
@@ -76,7 +76,7 @@ describe('selectCurrentResourceValidationErrors()', () => {
   })
 
   it('returns errors for a given property in state', () => {
-    const state = createState({ hasResourceWithLiteral: true })
+    const state = createState({ hasResourceWithLiteral: true, error: ['error 1'] })
     const errors = selectCurrentResourceValidationErrors(state)
     expect(errors.length).toBe(1)
     expect(errors[0].message).toEqual('error 1')
@@ -85,7 +85,7 @@ describe('selectCurrentResourceValidationErrors()', () => {
   })
 
   it('returns errors for a property in state with a nested resource', () => {
-    const state = createState({ hasResourceWithNestedResource: true })
+    const state = createState({ hasResourceWithNestedResource: true, error: ['error 2'] })
     const errors = selectCurrentResourceValidationErrors(state)
     expect(errors[0].message).toEqual('error 2')
     expect(errors[0].propertyKey).toEqual('v1o90QO1Qx')

--- a/__tests__/selectors/errors.test.js
+++ b/__tests__/selectors/errors.test.js
@@ -1,0 +1,94 @@
+import { createState } from 'stateUtils'
+import {
+  displayResourceValidations, selectErrors, selectValidationErrors, selectCurrentResourceValidationErrors,
+} from 'selectors/errors'
+
+describe('displayResourceValidations()', () => {
+  it('defaults to false', () => {
+    const state = createState()
+    expect(displayResourceValidations(state, null)).toBeFalsy()
+  })
+
+  it('is false for a non-existant reource key', () => {
+    const state = createState()
+    expect(displayResourceValidations(state, 'abc123')).toBeFalsy()
+  })
+
+  it('is true for a resource with a key set to true', () => {
+    const state = createState({ hasResourceWithError: true })
+    expect(displayResourceValidations(state, '3h4Fp8ANu')).toBeTruthy()
+  })
+})
+
+describe('selectErrors()', () => {
+  it('returns an empty array if there are no editor errors', () => {
+    const state = createState()
+    const errors = selectErrors(state, null)
+    expect(errors.length).toBe(0)
+  })
+
+  it('returns errors for a given error key', () => {
+    const state = createState({ hasResourceWithError: true })
+    const errors = selectErrors(state, '3h4Fp8ANu')
+    expect(errors.length).toBe(2)
+    expect(errors).toEqual(['error 1', 'error 2'])
+  })
+
+  it('returns errors for an error key of a given resource key', () => {
+    const state = createState({ hasResourceWithError: true })
+    const errors = selectErrors(state, 'lkqatmo20')
+    expect(Object.keys(errors).length).toBe(2)
+    expect(errors.dairdj42u).toEqual(['error 3'])
+    expect(errors.fQMouMqB0).toEqual(['error 4'])
+  })
+})
+
+describe('selectValidationErrors()', () => {
+  it('returns nothing if there is no subject', () => {
+    const state = createState()
+    const errors = selectValidationErrors(state, null)
+    expect(errors.length).toBe(0)
+  })
+
+  it('returns errors for a property given a subject key', () => {
+    const state = createState({ hasResourceWithLiteral: true })
+    const errors = selectValidationErrors(state, 't9zVwg2zO')
+    expect(errors.length).toBe(1)
+    expect(errors[0].message).toEqual('error 1')
+    expect(errors[0].propertyKey).toEqual('JQEtq-vmq8')
+    expect(errors[0].labelPath).toEqual(['Abbreviated Title', 'Abbreviated Title'])
+  })
+
+  it('returns errors for a property with a nested resource given a subject key', () => {
+    const state = createState({ hasResourceWithNestedResource: true })
+    const errors = selectValidationErrors(state, 'ljAblGiBW')
+    expect(errors[0].message).toEqual('error 2')
+    expect(errors[0].propertyKey).toEqual('v1o90QO1Qx')
+    expect(errors[0].labelPath).toEqual(['Uber template1', 'Uber template1, property1'])
+  })
+})
+
+describe('selectCurrentResourceValidationErrors()', () => {
+  it('returns nothing if there is no subject', () => {
+    const state = createState()
+    const errors = selectCurrentResourceValidationErrors(state)
+    expect(errors.length).toBe(0)
+  })
+
+  it('returns errors for a given property in state', () => {
+    const state = createState({ hasResourceWithLiteral: true })
+    const errors = selectCurrentResourceValidationErrors(state)
+    expect(errors.length).toBe(1)
+    expect(errors[0].message).toEqual('error 1')
+    expect(errors[0].propertyKey).toEqual('JQEtq-vmq8')
+    expect(errors[0].labelPath).toEqual(['Abbreviated Title', 'Abbreviated Title'])
+  })
+
+  it('returns errors for a property in state with a nested resource', () => {
+    const state = createState({ hasResourceWithNestedResource: true })
+    const errors = selectCurrentResourceValidationErrors(state)
+    expect(errors[0].message).toEqual('error 2')
+    expect(errors[0].propertyKey).toEqual('v1o90QO1Qx')
+    expect(errors[0].labelPath).toEqual(['Uber template1', 'Uber template1, property1'])
+  })
+})

--- a/__tests__/testUtilities/stateUtils.js
+++ b/__tests__/testUtilities/stateUtils.js
@@ -10,7 +10,8 @@ export const createState = (options = {}) => {
   buildTwoLiteralResources(state, options)
   buildResourceWithContractedLiteral(state, options)
   buildResourceWithNestedResource(state, options)
-  buildResourceWithContractedNestedResource(state, options)
+  buildResourceWithContractedNestedResource(state, options),
+  buildResourceWithError(state, options)
 
   return state
 }
@@ -38,6 +39,25 @@ const buildLanguages = (state, options) => {
     { id: 'tai', label: 'Tai languages' },
     { id: 'eng', label: 'English' },
   ]
+}
+
+const buildResourceWithError = (state, options) => {
+  if (!options.hasResourceWithError) return
+
+  state.selectorReducer.editor = {
+    resourceValidation: {
+      show: {
+        '3h4Fp8ANu': true,
+      },
+    },
+    errors: {
+      '3h4Fp8ANu': ['error 1', 'error 2'],
+      lkqatmo20: {
+        dairdj42u: ['error 3'],
+        fQMouMqB0: ['error 4'],
+      },
+    },
+  }
 }
 
 const buildResourceWithLiteral = (state, options) => {
@@ -94,7 +114,7 @@ const buildResourceWithLiteral = (state, options) => {
         'CxGx7WMh2',
       ],
       show: true,
-      errors: [],
+      errors: ['error 1'],
     },
   }
   state.selectorReducer.entities.values = {
@@ -386,7 +406,7 @@ const buildResourceWithNestedResource = (state, options) => {
         'VDOeQCnFA8',
       ],
       show: true,
-      errors: [],
+      errors: ['error 2'],
     },
     '7caLbfwwle': {
       key: '7caLbfwwle',

--- a/__tests__/testUtilities/stateUtils.js
+++ b/__tests__/testUtilities/stateUtils.js
@@ -114,7 +114,7 @@ const buildResourceWithLiteral = (state, options) => {
         'CxGx7WMh2',
       ],
       show: true,
-      errors: ['error 1'],
+      errors: options.error || [],
     },
   }
   state.selectorReducer.entities.values = {
@@ -406,7 +406,7 @@ const buildResourceWithNestedResource = (state, options) => {
         'VDOeQCnFA8',
       ],
       show: true,
-      errors: ['error 2'],
+      errors: options.error || [],
     },
     '7caLbfwwle': {
       key: '7caLbfwwle',


### PR DESCRIPTION
## Why was this change made?
Adds tests for `selectors/errors`. Fixes #2251  

## Which documentation and/or configurations were updated?
Updates `testUtilities/stateUtils` to add various errors to state objects that can be tested.


