### PR TITLE
Extends saveResource test to also test copying the resource

### DIFF
--- a/__tests__/feature/editing/saveAndCopyResource.test.js
+++ b/__tests__/feature/editing/saveAndCopyResource.test.js
@@ -11,19 +11,21 @@ jest.spyOn(sinopiaApi, 'postResource').mockResolvedValue('http://localhost:3000/
 global.document.elementFromPoint = jest.fn()
 
 describe('saving a resource', () => {
-  describe('when creating a new resource', () => {
+  describe('after opening a new resource', () => {
     window.HTMLElement.prototype.scrollIntoView = jest.fn() // required to allow scrolling in the jsdom
+    window.HTMLElement.prototype.scrollIntoView = function foo() {} // required to allow scrolling in the jsdom
     const history = createHistory(['/editor/resourceTemplate:bf2:Title:Note'])
+    renderApp(null, history)
 
-    it('opens the resource template', async () => {
-      renderApp(null, history)
-
+    it('edits, saves, and copies the resource template', async () => {
       await screen.findByRole('heading', { name: 'Title note' })
 
       const addBtn = screen.getByRole('button', { name: 'Add Note Text' })
       const saveBtn = screen.getAllByRole('button', { name: 'Save' })[0] // there are multiple save buttons, grab the first
+      const copyBtn = await screen.getAllByRole('button', { name: 'Copy this resource to a new resource' })[0]
 
       expect(saveBtn).toBeDisabled()
+      expect(copyBtn).toBeDisabled()
 
       fireEvent.click(addBtn)
       const input = screen.getByPlaceholderText('Note Text')
@@ -45,9 +47,22 @@ describe('saving a resource', () => {
       expect(saveBtn).not.toBeDisabled()
       fireEvent.click(saveBtn)
 
+      // A modal for group choice and save appears
       const modalSave = screen.getByRole('button', { name: 'Save Group' })
       fireEvent.click(modalSave)
+      // The resource is saves and is assigned a URI
       await screen.findByText(/URI for this resource/)
+
+      // The copy resource button is active
+      expect(copyBtn).not.toBeDisabled()
+      fireEvent.click(copyBtn)
+      await screen.findByText(/Copied http:\/\/localhost\/something\/or\/other to new resource./)
+
+      // There are nav tabs and a duplicate resource with the same content
+      const tabBtns = await screen.findAllByRole('button', { name: 'Title note' })
+      expect(tabBtns[0]).not.toHaveClass('active')
+      expect(tabBtns[1]).toHaveClass('active')
+      expect(editBtn).toHaveTextContent('Edit')
     })
   })
 })

--- a/__tests__/feature/editing/saveAndCopyResource.test.js
+++ b/__tests__/feature/editing/saveAndCopyResource.test.js
@@ -56,7 +56,7 @@ describe('saving a resource', () => {
       // The copy resource button is active
       expect(copyBtn).not.toBeDisabled()
       fireEvent.click(copyBtn)
-      await screen.findByText(/Copied http:\/\/localhost\/something\/or\/other to new resource./)
+      screen.findByText(/Copied http:\/\/localhost\/something\/or\/other to new resource./)
 
       // There are nav tabs and a duplicate resource with the same content
       const tabBtns = await screen.findAllByRole('button', { name: 'Title note' })


### PR DESCRIPTION
## Why was this change made?
Extends saveResource test to also test copying the saved resource to a new duplicate resource
Fixes #2260 #2267 