### PR TITLE
Adds test for downloads links of Sinopia export files

### DIFF
--- a/__tests__/feature/exportFile.test.js
+++ b/__tests__/feature/exportFile.test.js
@@ -1,0 +1,24 @@
+import { renderApp, createHistory, createStore } from 'testUtils'
+import { createState } from 'stateUtils'
+import { screen } from '@testing-library/react'
+import Config from 'Config'
+
+describe('downloading a file that was exported from Sinopia AWS', () => {
+  const state = createState({ buildExports: true })
+  const store = createStore(state)
+  const history = createHistory(['/exports'])
+
+
+  it('has a list of the downloadable zip files that were built', () => {
+    renderApp(store, history)
+
+    const link1 = screen.getByText('sinopia_export_all_2020-01-01T00:00:00.000Z.zip')
+    const link2 = screen.getByText('stanford_2020-01-01T00:00:00.000Z.zip')
+
+    expect(link1.href)
+      .toBe(`${Config.exportBucketUrl}/sinopia_export_all_2020-01-01T00:00:00.000Z.zip`)
+
+    expect(link2.href)
+      .toBe(`${Config.exportBucketUrl}/stanford_2020-01-01T00:00:00.000Z.zip`)
+  })
+})

--- a/__tests__/testUtilities/stateUtils.js
+++ b/__tests__/testUtilities/stateUtils.js
@@ -11,9 +11,19 @@ export const createState = (options = {}) => {
   buildResourceWithContractedLiteral(state, options)
   buildResourceWithNestedResource(state, options)
   buildResourceWithContractedNestedResource(state, options),
-  buildResourceWithError(state, options)
+  buildResourceWithError(state, options),
+  buildExports(state, options)
 
   return state
+}
+
+const buildExports = (state, options) => {
+  if (!options.buildExports) return
+
+  state.selectorReducer.entities.exports = [
+    'sinopia_export_all_2020-01-01T00:00:00.000Z.zip',
+    'stanford_2020-01-01T00:00:00.000Z.zip',
+  ]
 }
 
 const buildAuthenticate = (state, options) => {
@@ -504,6 +514,5 @@ const buildResourceWithContractedNestedResource = (state, options) => {
   }
   state.selectorReducer.entities.values = {}
 }
-
 
 export const noop = () => {}


### PR DESCRIPTION
## Why was this change made?
Fixes #2273. Tests that download links appear on the exports page. Otherwise the actual downloading is just the normal browser download behavior.