### PR TITLE
Adds aria alert role to LoginPanel authentication error div

### DIFF
--- a/__tests__/components/home/LoginPanel.test.js
+++ b/__tests__/components/home/LoginPanel.test.js
@@ -81,6 +81,6 @@ describe('<LoginPanel /> when there is an authentication failure', () => {
   const wrapper = shallow(<LoginPanel.WrappedComponent authenticationError={authenticationError}/>)
 
   it('renders the failure message', () => {
-    expect(wrapper.find('.alert').text()).toMatch('borked!')
+    expect(wrapper.find('div[role="alert"]').text()).toMatch('borked!')
   })
 })

--- a/src/components/home/LoginPanel.jsx
+++ b/src/components/home/LoginPanel.jsx
@@ -98,7 +98,7 @@ class LoginPanel extends Component {
 
     return (
       <React.Fragment>
-        { authenticationError && <div className="alert alert-danger alert-dismissible">{ authenticationError.message }</div> }
+        { authenticationError && <div className="alert alert-danger alert-dismissible" role="alert">{ authenticationError.message }</div> }
         <form className="login-form" onSubmit={this.handleLoginSubmit}>
           { !currentSession && inlineLoginForm }
         </form>


### PR DESCRIPTION
## Why was this change made?
Fixes #2376 by adding the role attribute to the LoginPanel authentication error div

## How was this change tested?
Modified the existing test's CSS selector to look for the div's role attribute instead of the classname
