### PR TITLE
figured out a working accessibility test for login form errors

### DIFF
--- a/__tests__/feature/userAuthentication.test.js
+++ b/__tests__/feature/userAuthentication.test.js
@@ -71,12 +71,15 @@ describe('user authentication', () => {
 
     awsCognito.CognitoUser.mockImplementation(MockCognitoUserAuthenticationFailure)
 
+    // we don't expect any alerts to be present yet...
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+
     // try to login
     fireEvent.change(screen.getByLabelText('User name'), { target: { value: 'baz.le.quux@example.edu' } })
     fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'password1' } })
     fireEvent.click(screen.getByRole('button', { name: 'Login' }))
 
-    // an error message should be presented
-    await screen.findByText(/Incorrect username or password./)
+    // ...and an accessible alert should be present now that a failed login attempt was made
+    await screen.findByRole('alert', { name: 'Incorrect username or password.' })
   })
 })

--- a/src/components/home/LoginPanel.jsx
+++ b/src/components/home/LoginPanel.jsx
@@ -96,9 +96,18 @@ class LoginPanel extends Component {
       </React.Fragment>
     )
 
+    const loginErrorMessageElement = (
+      <React.Fragment>
+        {
+          authenticationError
+            && <div className="alert alert-danger alert-dismissible" role="alert" aria-label={ authenticationError.message }>{ authenticationError.message }</div>
+        }
+      </React.Fragment>
+    )
+
     return (
       <React.Fragment>
-        { authenticationError && <div className="alert alert-danger alert-dismissible" role="alert" aria-label={ authenticationError.message }>{ authenticationError.message }</div> }
+        { loginErrorMessageElement }
         <form className="login-form" onSubmit={this.handleLoginSubmit}>
           { !currentSession && inlineLoginForm }
         </form>

--- a/src/components/home/LoginPanel.jsx
+++ b/src/components/home/LoginPanel.jsx
@@ -98,7 +98,7 @@ class LoginPanel extends Component {
 
     return (
       <React.Fragment>
-        { authenticationError && <div className="alert alert-danger alert-dismissible" role="alert">{ authenticationError.message }</div> }
+        { authenticationError && <div className="alert alert-danger alert-dismissible" role="alert" aria-label={ authenticationError.message }>{ authenticationError.message }</div> }
         <form className="login-form" onSubmit={this.handleLoginSubmit}>
           { !currentSession && inlineLoginForm }
         </form>


### PR DESCRIPTION
## Why was this change made?

test that there's an accessible `alert` element on the page when a user gets an error trying to log in.

after follow up conversation and fiddling, also attempts to make the login form more accessible (specifically the error message when login fails).  see also #2376 

## How was this change tested?

this just augments an existing feature test

## Which documentation and/or configurations were updated?

n/a