### PR TITLE
Handles null property template date.

### DIFF
--- a/__tests__/components/LongDate.test.js
+++ b/__tests__/components/LongDate.test.js
@@ -12,4 +12,9 @@ describe('<LongDate />', () => {
     const { container } = render(<LongDate datetime="foo"/>)
     expect(container).toBeEmpty()
   })
+
+  it('does not render if null', async () => {
+    const { container } = render(<LongDate datetime={null} />)
+    expect(container).toBeEmpty()
+  })
 })

--- a/src/components/LongDate.jsx
+++ b/src/components/LongDate.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types'
 
 const LongDate = (props) => {
   const date = new Date(props.datetime)
-  if (!date || !date.getTime || Number.isNaN(date.getTime())) return null
+  if (!props.datetime || !date || !date.getTime || Number.isNaN(date.getTime())) return null
   const options = {
     month: 'short', day: 'numeric', year: 'numeric', timeZone: props.timeZone,
   }


### PR DESCRIPTION
closes #2363

## Why was this change made?
So that null resource template dates are not rendered.


## How was this change tested?
Unit test


## Which documentation and/or configurations were updated?
NA


