### PR TITLE
Do not restart mongo resources

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,6 @@ services:
       - api
   pipeline:
     image: ld4p/sinopia_indexing_pipeline:latest
-    # Replace image with build to build from local code. Do not commit docker-compose.yml.
     # build:
     #   context: ../sinopia_indexing_pipeline
     environment:
@@ -37,16 +36,14 @@ services:
     ports:
       - 9200:9200
       - 9300:9300
-  # Uncomment to use Dejavu to monitor Elasticsearch. Do not commit docker-compose.yml.
-  # elasticsearch-ui:
-  #   image: appbaseio/dejavu:latest
-  #   ports:
-  #     - 1358:1358
-  #   depends_on:
-  #     - elasticsearch
+  elasticsearch-ui:
+    image: appbaseio/dejavu:latest
+    ports:
+      - 1358:1358
+    depends_on:
+      - elasticsearch
   mongo:
     image: mongo:4.4
-    restart: always
     ports:
       - 27017:27017
       - 28017:28017
@@ -56,17 +53,15 @@ services:
     entrypoint: [ "/usr/bin/mongod", "--bind_ip_all", "--replSet", "rs0" ]
   mongo-setup:
     image: ld4p/sinopia_dev_setup:latest
-    # Replace image with build to build from local code. Do not commit docker-compose.yml.
     # build:
     #   context: ../sinopia_api
     #   dockerfile: Dockerfile-setup
     depends_on:
       - mongo
-    restart: "no"
+      - pipeline
   # Uncomment to use Mongo-Express to monitor Mongo. Do not commit docker-compose.yml.
   # mongo-express:
   #   image: mongo-express
-  #   restart: always
   #   ports:
   #     - 8082:8081
   #   environment:
@@ -74,11 +69,9 @@ services:
   #     ME_CONFIG_MONGODB_ADMINPASSWORD: sekret
   api:
     image: ld4p/sinopia_api:latest
-    # Replace image with build to build from local code. Do not commit docker-compose.yml.
     # build:
     #   context: ../sinopia_api
     #   dockerfile: Dockerfile
-    restart: always
     ports:
       - 3000:3000
     environment:
@@ -86,3 +79,4 @@ services:
       NO_AUTH: "true"
     depends_on:
       - mongo
+      - pipeline


### PR DESCRIPTION
## Why was this change made?

This may be something only I'm seeing, or there may be a better approach, but the `restart: always` configs here mean that the mongo resources are configured to always start when docker-desktop starts. This is not ideal for local resources where we don't want an extraneous service running when we're not working on this project.

In order to remove the restart directive, `docker-compose up -d` needs to run with this config (including the `restart: "no"`, we can likely eventually just remove the restart directive all together, but if you've already run the current config, you need to force it to get the new no-restart.

If we need the restart directive, perhaps `restart: unless-stopped` would be more appropriate so we can actually stop the thing.

## How was this change tested?

Locally

## Which documentation and/or configurations were updated?

N/A


