### PR TITLE
Comment out monitoring apps in docker-compose.

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,20 @@ To trigger a test exception, doubleclick "The underdrawing for the new world of 
 ### Monitoring ElasticSearch
 DejaVu is available for monitoring local ElasticSearch.
 
-To use DejaVu, browse to http://localhost:1358, and when prompted, enter `http://localhost:9200` as the ElasticSearch URL and `*` as the index name.
+To use DejaVu:
+1. Uncomment the appropriate section in `docker-compose.yml`. (Do not commit this change.)
+2. `docker-compose up -d`
+3. Browse to http://localhost:1358.
+4. When prompted, enter `http://localhost:9200` as the ElasticSearch URL and `*` as the index name.
+
+### Monitoring Mongo
+Mongo-Express is available for monitoring local Mongo.
+
+To use Mongo-Express:
+1. Uncomment the appropriate section in `docker-compose.yml`. (Do not commit this change.)
+2. `docker-compose up -d`
+3. Browse to http://localhost:8082.
+
 
 #### Changes to environment variables
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - api
   pipeline:
     image: ld4p/sinopia_indexing_pipeline:latest
+    # Replace image with build to build from local code. Do not commit docker-compose.yml.
     # build:
     #   context: ../sinopia_indexing_pipeline
     environment:
@@ -36,12 +37,13 @@ services:
     ports:
       - 9200:9200
       - 9300:9300
-  elasticsearch-ui:
-    image: appbaseio/dejavu:latest
-    ports:
-      - 1358:1358
-    depends_on:
-      - elasticsearch
+  # Uncomment to use Dejavu to monitor Elasticsearch. Do not commit docker-compose.yml.
+  # elasticsearch-ui:
+  #   image: appbaseio/dejavu:latest
+  #   ports:
+  #     - 1358:1358
+  #   depends_on:
+  #     - elasticsearch
   mongo:
     image: mongo:4.4
     restart: always
@@ -54,6 +56,7 @@ services:
     entrypoint: [ "/usr/bin/mongod", "--bind_ip_all", "--replSet", "rs0" ]
   mongo-setup:
     image: ld4p/sinopia_dev_setup:latest
+    # Replace image with build to build from local code. Do not commit docker-compose.yml.
     # build:
     #   context: ../sinopia_api
     #   dockerfile: Dockerfile-setup
@@ -61,16 +64,18 @@ services:
       - mongo
       - pipeline
     restart: "no"
-  mongo-express:
-    image: mongo-express
-    restart: always
-    ports:
-      - 8082:8081
-    environment:
-      ME_CONFIG_MONGODB_ADMINUSERNAME: root
-      ME_CONFIG_MONGODB_ADMINPASSWORD: sekret
+  # Uncomment to use Mongo-Express to monitor Mongo. Do not commit docker-compose.yml.
+  # mongo-express:
+  #   image: mongo-express
+  #   restart: always
+  #   ports:
+  #     - 8082:8081
+  #   environment:
+  #     ME_CONFIG_MONGODB_ADMINUSERNAME: root
+  #     ME_CONFIG_MONGODB_ADMINPASSWORD: sekret
   api:
     image: ld4p/sinopia_api:latest
+    # Replace image with build to build from local code. Do not commit docker-compose.yml.
     # build:
     #   context: ../sinopia_api
     #   dockerfile: Dockerfile


### PR DESCRIPTION
## Why was this change made?
Reduce the number of containers run by default.


## How was this change tested?
NA


## Which documentation and/or configurations were updated?
README.


