### PR TITLE
allow for recent templates to be editable with button

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ The following are only in the resource subject (that is, the base subject).
 {
   key: <resource template id, e.g., resourceTemplate:bf2:Monograph:Instance>,
   id: <resource template id, e.g., resourceTemplate:bf2:Monograph:Instance>,
+  uri: <resource template uri, e.g. http://datastore/repository/resourceTemplate:bf2:Monograph:Instance>,
   class: <resource URI, e.g., http://id.loc.gov/ontologies/bibframe/Instance>,
   label: <resource label, e.g., "BIBFRAME Instance">,
   author: <author>,

--- a/__tests__/TemplatesBuilder.test.js
+++ b/__tests__/TemplatesBuilder.test.js
@@ -17,6 +17,7 @@ describe('TemplatesBuilder', () => {
     expect(subjectTemplate).toStrictEqual({
       key: 'resourceTemplate:testing:uber1',
       id: 'resourceTemplate:testing:uber1',
+      uri: '',
       class: 'http://id.loc.gov/ontologies/bibframe/Uber1',
       label: 'Uber template1',
       author: 'Justin Littman',

--- a/__tests__/__action_fixtures__/expandProperty-ADD_VALUE.json
+++ b/__tests__/__action_fixtures__/expandProperty-ADD_VALUE.json
@@ -71,6 +71,7 @@
               "date": null,
               "label": "Uber template2",
               "remark": "Template for testing purposes with single repeatable literal.",
+              "uri": "http://localhost:3000/repository/resourceTemplate:testing:uber2",
               "propertyTemplateKeys": [
                 "resourceTemplate:testing:uber2 > http://id.loc.gov/ontologies/bibframe/uber/template2/property1"
               ],

--- a/__tests__/__action_fixtures__/loadResource-ADD_SUBJECT.json
+++ b/__tests__/__action_fixtures__/loadResource-ADD_SUBJECT.json
@@ -10,6 +10,7 @@
       "label": "Uber template1",
       "author": "Justin Littman",
       "remark": "Template for testing purposes.",
+      "uri": "http://localhost:3000/repository/resourceTemplate:testing:uber1",
       "date": "2020-07-27",
       "propertyTemplateKeys": [
         "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property1",
@@ -571,6 +572,7 @@
                 "label": "Uber template3",
                 "author": null,
                 "remark": "Template for testing purposes with multiple literal.",
+                "uri": "http://localhost:3000/repository/resourceTemplate:testing:uber3",
                 "date": null,
                 "propertyTemplateKeys": [
                   "resourceTemplate:testing:uber3 > http://id.loc.gov/ontologies/bibframe/uber/template3/property1",
@@ -665,6 +667,7 @@
                 "label": "Uber template2",
                 "author": null,
                 "remark": "Template for testing purposes with single repeatable literal.",
+                "uri": "http://localhost:3000/repository/resourceTemplate:testing:uber2",
                 "date": null,
                 "propertyTemplateKeys": [
                   "resourceTemplate:testing:uber2 > http://id.loc.gov/ontologies/bibframe/uber/template2/property1"
@@ -990,6 +993,7 @@
                 "label": "Uber template4",
                 "author": null,
                 "remark": "Template for testing purposes with single repeatable, required literal.",
+                "uri": "http://localhost:3000/repository/resourceTemplate:testing:uber4",
                 "date": null,
                 "propertyTemplateKeys": [
                   "resourceTemplate:testing:uber4 > http://id.loc.gov/ontologies/bibframe/uber/template4/property1"

--- a/__tests__/__action_fixtures__/newResource-ADD_SUBJECT.json
+++ b/__tests__/__action_fixtures__/newResource-ADD_SUBJECT.json
@@ -10,6 +10,7 @@
       "label": "Uber template1",
       "author": "Justin Littman",
       "remark": "Template for testing purposes.",
+      "uri": "http://localhost:3000/repository/resourceTemplate:testing:uber1",
       "date": "2020-07-27",
       "propertyTemplateKeys": [
         "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property1",
@@ -711,6 +712,7 @@
                 "label": "Uber template4",
                 "author": null,
                 "remark": "Template for testing purposes with single repeatable, required literal.",
+                "uri": "http://localhost:3000/repository/resourceTemplate:testing:uber4",
                 "date": null,
                 "propertyTemplateKeys": [
                   "resourceTemplate:testing:uber4 > http://id.loc.gov/ontologies/bibframe/uber/template4/property1"

--- a/__tests__/__action_fixtures__/newResourceFromDataset-ADD_SUBJECT.json
+++ b/__tests__/__action_fixtures__/newResourceFromDataset-ADD_SUBJECT.json
@@ -10,6 +10,7 @@
       "label": "Uber template1",
       "author": "Justin Littman",
       "remark": "Template for testing purposes.",
+      "uri": "http://localhost:3000/repository/resourceTemplate:testing:uber1",
       "date": "2020-07-27",
       "propertyTemplateKeys": [
         "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property1",
@@ -571,6 +572,7 @@
                 "label": "Uber template3",
                 "author": null,
                 "remark": "Template for testing purposes with multiple literal.",
+                "uri": "http://localhost:3000/repository/resourceTemplate:testing:uber3",
                 "date": null,
                 "propertyTemplateKeys": [
                   "resourceTemplate:testing:uber3 > http://id.loc.gov/ontologies/bibframe/uber/template3/property1",
@@ -665,6 +667,7 @@
                 "label": "Uber template2",
                 "author": null,
                 "remark": "Template for testing purposes with single repeatable literal.",
+                "uri": "http://localhost:3000/repository/resourceTemplate:testing:uber2",
                 "date": null,
                 "propertyTemplateKeys": [
                   "resourceTemplate:testing:uber2 > http://id.loc.gov/ontologies/bibframe/uber/template2/property1"
@@ -900,6 +903,7 @@
                 "label": "Uber template4",
                 "author": null,
                 "remark": "Template for testing purposes with single repeatable, required literal.",
+                "uri": "http://localhost:3000/repository/resourceTemplate:testing:uber4",
                 "date": null,
                 "propertyTemplateKeys": [
                   "resourceTemplate:testing:uber4 > http://id.loc.gov/ontologies/bibframe/uber/template4/property1"

--- a/src/TemplatesBuilder.js
+++ b/src/TemplatesBuilder.js
@@ -5,6 +5,7 @@ import rdf from 'rdf-ext'
 export default class TemplatesBuilder {
   constructor(dataset, uri) {
     this.dataset = dataset
+    this.uri = uri
     this.resourceTerm = rdf.namedNode(uri)
     this.subjectTemplate = null
   }
@@ -22,6 +23,7 @@ export default class TemplatesBuilder {
     this.subjectTemplate = {
       // This key will be unique for resource templates
       key: this.valueFor(this.resourceTerm, 'http://sinopia.io/vocabulary/hasResourceId'),
+      uri: this.uri,
       id: this.valueFor(this.resourceTerm, 'http://sinopia.io/vocabulary/hasResourceId'),
       class: this.valueFor(this.resourceTerm, 'http://sinopia.io/vocabulary/hasClass'),
       label: this.valueFor(this.resourceTerm, 'http://www.w3.org/2000/01/rdf-schema#label'),

--- a/src/components/templates/SinopiaResourceTemplates.jsx
+++ b/src/components/templates/SinopiaResourceTemplates.jsx
@@ -32,6 +32,7 @@ const SinopiaResourceTemplates = (props) => {
       id: template.key,
       resourceLabel: template.label,
       resourceURI: template.class,
+      uri: template.uri,
       author: template.author,
       remark: template.remark,
       date: template.date,


### PR DESCRIPTION
## Why was this change made?

To fix #2362 

Although the same component is being used to render resource template rows in both the recent and full list, the data structure passed to the component is not the same, and in the case of the recent templates, it didn't have the expected full template URI.  This adds it.

`props.row.uri` was undefined in the recent templates structure here: https://github.com/LD4P/sinopia_editor/blob/master/src/components/templates/ResourceTemplateRow.jsx#L37


## How was this change tested?

localhost development environment


## Which documentation and/or configurations were updated?



