### PR TITLE
Adds test for searching for a template and then opening the template from the recently used list

### DIFF
--- a/__tests__/feature/editing/openAndCloseResource.test.js
+++ b/__tests__/feature/editing/openAndCloseResource.test.js
@@ -1,6 +1,6 @@
 import { renderApp, createHistory, createStore } from 'testUtils'
 import { fireEvent, screen } from '@testing-library/react'
-import { createState } from '../../testUtilities/stateUtils'
+import { createState } from 'stateUtils'
 
 // Mock jquery
 global.$ = jest.fn().mockReturnValue({ popover: jest.fn() })

--- a/__tests__/feature/searchAndOpenTemplate.test.js
+++ b/__tests__/feature/searchAndOpenTemplate.test.js
@@ -7,9 +7,6 @@ import Config from 'Config'
 jest.spyOn(Config, 'useResourceTemplateFixtures', 'get').mockReturnValue(true)
 jest.mock('sinopiaSearch')
 
-// Mock jquery
-global.$ = jest.fn().mockReturnValue({ popover: jest.fn() })
-
 describe('searching and opening a resource', () => {
   const history = createHistory(['/templates'])
   const store = createStore()

--- a/__tests__/feature/searchAndOpenTemplate.test.js
+++ b/__tests__/feature/searchAndOpenTemplate.test.js
@@ -1,0 +1,76 @@
+import { renderApp, createHistory, createStore } from 'testUtils'
+import { act, fireEvent, screen } from '@testing-library/react'
+import * as sinopiaSearch from 'sinopiaSearch'
+import Config from 'Config'
+
+// This forces Sinopia server to use fixtures
+jest.spyOn(Config, 'useResourceTemplateFixtures', 'get').mockReturnValue(true)
+jest.mock('sinopiaSearch')
+
+// Mock jquery
+global.$ = jest.fn().mockReturnValue({ popover: jest.fn() })
+
+describe('searching and opening a resource', () => {
+  const history = createHistory(['/templates'])
+  const store = createStore()
+  const promise = Promise.resolve()
+
+  sinopiaSearch.getTemplateSearchResults.mockResolvedValue({
+    results: [
+      {
+        id: 'resourceTemplate:bf2:Title',
+        uri: 'http://localhost:3000/repository/resourceTemplate:bf2:Title',
+        remark: 'Title information relating to a resource',
+        resourceLabel: 'Instance Title',
+        resourceURI: 'http://id.loc.gov/ontologies/bibframe/Title',
+      },
+      {
+        id: 'resourceTemplate:bf2:Title:Note',
+        uri: 'http://localhost:3000/repository/resourceTemplate:bf2:Title:Note',
+        remark: 'Note about the title',
+        resourceLabel: 'Title note',
+        resourceURI: 'http://id.loc.gov/ontologies/bibframe/Note',
+      },
+    ],
+    totalHits: 2,
+    options: {
+      startOfRange: 0,
+      resultsPerPage: 10,
+    },
+  })
+
+  it('adds the template to recently used template history', async () => {
+    renderApp(store, history)
+
+    // Search for a template
+    const input = screen.getByPlaceholderText('Enter id, label, URI, remark, or author')
+    await fireEvent.change(input, { target: { value: 'title' } })
+    await screen.findByText('resourceTemplate:bf2:Title:Note')
+
+    // open the template
+    const link = await screen.findByRole('link', { name: 'Title note' })
+    fireEvent.click(link)
+    await act(() => promise)
+
+    // return the the RT list
+    const rtLink = await screen.findByRole('link', { name: 'Resource Templates' })
+    fireEvent.click(rtLink)
+
+    // see the recently used RTs
+    const histTemplateBtn = await screen.findByRole('button', { name: 'Most recently used resource templates' })
+    fireEvent.click(histTemplateBtn)
+    const rtHeaders = screen.getAllByText('Label / ID')
+    expect(rtHeaders.length).toBe(2)
+
+    // open the recenly used RTs and click
+    const rtLinks = screen.getAllByRole('link', { name: 'Title note' })
+    expect(rtLinks.length).toBe(2)
+    fireEvent.click(rtLinks[0])
+    await screen.findByRole('heading', { name: 'Title note' })
+
+    // There are nav tabs and a duplicate resource
+    const tabBtns = await screen.findAllByRole('button', { name: 'Title note' })
+    expect(tabBtns[0]).not.toHaveClass('active')
+    expect(tabBtns[1]).toHaveClass('active')
+  })
+})


### PR DESCRIPTION
## Why was this change made?
Fixes #2258.

Did not test the error when opening an invalid resource template. I think that should be a separate test. If agreed, I can make a ticket for that and work on it.

(Also added to this PR, I truncated the import statement on `openAndCloseResource.test`)
