### PR TITLE
Auto-resize input literals to reduce scrolling

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ To start all of the supporting services (ElasticSearch, Trellis, etc.):
 `docker-compose up -d`
 
 Note that this will bring up the sinopia-editor app on port 8000, but it will NOT be in a mode where
-you can make code changes and see them live.  To do this, start the Express web server and run the
+you can make code changes and see them live.  To do this, start the Express web server (via `npm start`) and run the
 application at [http://localhost:8888](http://localhost:8888):
 
 `npm run dev-start`

--- a/__tests__/feature/editing/editingLiteral.test.js
+++ b/__tests__/feature/editing/editingLiteral.test.js
@@ -41,7 +41,7 @@ describe('editing a literal property', () => {
     fireEvent.click(editBtn)
     expect(input).not.toBeDisabled()
     expect(input).toHaveValue('foo')
-    expect(screen.queryAllByText('foo').length).toBeFalsy()
+    expect(screen.queryAllByText('foo').length).toBeLessThan(2)
 
     // Clicking remove
     fireEvent.change(input, { target: { value: 'foobar' } })

--- a/cypress/integration/end2end.spec.js
+++ b/cypress/integration/end2end.spec.js
@@ -85,7 +85,7 @@ describe('End-to-end test', () => {
   it('Populates a resource template', () => {
     // Add a value for the Preferred Title
     cy.get('button[aria-label="Add Preferred Title for Work"]').click()
-    cy.get('input[placeholder="Preferred Title for Work"]')
+    cy.get('textarea[placeholder="Preferred Title for Work"]')
       .type(`${title}{enter}`)
     cy.get('div.rbt-token').contains(title)
   })

--- a/cypress/integration/leftNav.spec.js
+++ b/cypress/integration/leftNav.spec.js
@@ -69,7 +69,7 @@ describe('Left-nav test', () => {
   })
 
   it('Marks properties with values with a check', () => {
-    cy.get('input[placeholder="Uber template1, property4"]')
+    cy.get('textarea[placeholder="Uber template1, property4"]')
       .type('foo{enter}')
     cy.get('button.active > h5')
       .should('contain', 'Uber template1, property4')
@@ -86,7 +86,7 @@ describe('Left-nav test', () => {
     cy.contains('button', 'Item of').click()
     // Wait for scroll
     // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(1000)
+    cy.wait(1500)
     cy.isInViewport('div[data-label="Item of"]')
     cy.get('button.active > h5').should('contain', 'Item of')
   })

--- a/package-lock.json
+++ b/package-lock.json
@@ -14016,6 +14016,16 @@
         "scheduler": "^0.19.1"
       }
     },
+    "react-textarea-autosize": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.2.0.tgz",
+      "integrity": "sha512-grajUlVbkx6VdtSxCgzloUIphIZF5bKr21OYMceWPKkniy7H0mRAT/AXPrRtObAe+zUePnNlBwUc4ivVjUGIjw==",
+      "requires": {
+        "@babel/runtime": "^7.10.2",
+        "use-composed-ref": "^1.0.0",
+        "use-latest": "^1.0.0"
+      }
+    },
     "react-transition-group": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.9.0.tgz",
@@ -16193,6 +16203,11 @@
         }
       }
     },
+    "ts-essentials": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-2.0.12.tgz",
+      "integrity": "sha512-3IVX4nI6B5cc31/GFFE+i8ey/N2eA0CZDbo6n0yrz0zDX8ZJ8djmU1p+XRz7G3is0F3bB3pu2pAroFdAWQKU3w=="
+    },
     "tsconfig-paths": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
@@ -16505,6 +16520,27 @@
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
+    },
+    "use-composed-ref": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.0.0.tgz",
+      "integrity": "sha512-RVqY3NFNjZa0xrmK3bIMWNmQ01QjKPDc7DeWR3xa/N8aliVppuutOE5bZzPkQfvL+5NRWMMp0DJ99Trd974FIw==",
+      "requires": {
+        "ts-essentials": "^2.0.3"
+      }
+    },
+    "use-isomorphic-layout-effect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.0.0.tgz",
+      "integrity": "sha512-JMwJ7Vd86NwAt1jH7q+OIozZSIxA4ND0fx6AsOe2q1H8ooBUp5aN6DvVCqZiIaYU6JaMRJGyR0FO7EBCIsb/Rg=="
+    },
+    "use-latest": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/use-latest/-/use-latest-1.1.0.tgz",
+      "integrity": "sha512-gF04d0ZMV3AMB8Q7HtfkAWe+oq1tFXP6dZKwBHQF5nVXtGsh2oAYeeqma5ZzxtlpOcW8Ro/tLcfmEodjDeqtuw==",
+      "requires": {
+        "use-isomorphic-layout-effect": "^1.0.0"
+      }
     },
     "util": {
       "version": "0.11.1",

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "react-offcanvas": "^0.4.0",
     "react-redux": "^7.2.1",
     "react-router-dom": "^5.2.0",
+    "react-textarea-autosize": "^8.2.0",
     "redux": "^4.0.1",
     "redux-thunk": "^2.3.0",
     "request": "^2.88.2",

--- a/src/components/editor/property/InputLiteral.jsx
+++ b/src/components/editor/property/InputLiteral.jsx
@@ -4,6 +4,7 @@ import React, { useRef, useState } from 'react'
 import PropTypes from 'prop-types'
 import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
+import TextareaAutosize from 'react-textarea-autosize'
 import {
   hideDiacritics, showDiacritics,
   setLiteralContent,
@@ -100,7 +101,7 @@ const InputLiteral = (props) => {
   return (
     <div className={groupClasses}>
       <div className="input-group" onBlur={handleBlur} id={id}>
-        <input
+        <TextareaAutosize
               required={required}
               className="form-control"
               placeholder={props.property.propertyTemplate.label}


### PR DESCRIPTION
Fixes #2177

## Why was this change made?

Note that a UI change here is switching from an input element to a textarea element for all input literals. Why? Because as far as I can tell, input elements are not auto-resizable in HTML.

I briefly looked into rolling my own auto-resize logic but it is over my head, even without all the React machinery in the way. I also looked into using contentEditable but I believe that approach is geared towards divs and spans rather than input elements (such as textarea) within a form.

I'm not sure if the small test change is sufficient to test this commit. Advice welcome! I suspect that the line I removed from the input literal test, which began failing, is due to moving from an input element to a textarea element.

Also includes:

* Clarify in README how to start Express server

## How was this change tested?

In browser. See screencaps of adding a new resizable element and editing an existing one:

![Peek 2020-09-03 11-45](https://user-images.githubusercontent.com/131982/92155189-d2e40100-eddb-11ea-8b54-866761ecd716.gif)

![Peek 2020-09-03 11-46](https://user-images.githubusercontent.com/131982/92155194-d4adc480-eddb-11ea-99a7-1d7ba15809e6.gif)

## Which documentation and/or configurations were updated?

README.

