### PR TITLE
Adds test for loading an invalid template

### DIFF
--- a/__tests__/feature/editing/saveAndCopyResource.test.js
+++ b/__tests__/feature/editing/saveAndCopyResource.test.js
@@ -13,7 +13,7 @@ global.document.elementFromPoint = jest.fn()
 describe('saving a resource', () => {
   describe('after opening a new resource', () => {
     window.HTMLElement.prototype.scrollIntoView = jest.fn() // required to allow scrolling in the jsdom
-    window.HTMLElement.prototype.scrollIntoView = function foo() {} // required to allow scrolling in the jsdom
+
     const history = createHistory(['/editor/resourceTemplate:bf2:Title:Note'])
     renderApp(null, history)
 

--- a/__tests__/feature/invalidTemplate.test.js
+++ b/__tests__/feature/invalidTemplate.test.js
@@ -1,0 +1,63 @@
+import { renderApp, createHistory, createStore } from 'testUtils'
+import { act, fireEvent, screen } from '@testing-library/react'
+import * as sinopiaSearch from 'sinopiaSearch'
+import Config from 'Config'
+
+// This forces Sinopia server to use fixtures
+jest.spyOn(Config, 'useResourceTemplateFixtures', 'get').mockReturnValue(true)
+jest.mock('sinopiaSearch')
+
+// Mock jquery
+global.$ = jest.fn().mockReturnValue({ popover: jest.fn() })
+window.scrollTo = jest.fn()
+
+describe('an invalid resource template', () => {
+  const history = createHistory(['/templates'])
+  const store = createStore()
+  const promise = Promise.resolve()
+
+  sinopiaSearch.getTemplateSearchResults.mockResolvedValue({
+    results: [
+      {
+        id: 'test:RT:bf2:RareMat:Instance',
+        uri: 'http://localhost:3000/repository/test:RT:bf2:RareMat:Instance',
+        remark: '',
+        resourceLabel: 'Value template refs with non-unique resource URIs',
+        resourceURI: 'http://id.loc.gov/ontologies/bibframe/Instance',
+      },
+      {
+        id: 'test:RT:bf2:notFoundValueTemplateRefs',
+        uri: 'http://localhost:3000/repository/test:RT:bf2:notFoundValueTemplateRefs',
+        remark: '',
+        resourceLabel: 'Not found value template refs',
+        resourceURI: 'http://id.loc.gov/ontologies/bibframe/Identifier',
+      },
+    ],
+    totalHits: 2,
+    options: {
+      startOfRange: 0,
+      resultsPerPage: 10,
+    },
+  })
+
+  it('displays an error message when opened', async () => {
+    renderApp(store, history)
+
+    // Search for a template
+    const input = screen.getByPlaceholderText('Enter id, label, URI, remark, or author')
+    await fireEvent.change(input, { target: { value: 'Not found' } })
+
+    // try to open the template
+    const link = await screen.findByRole('link', { name: 'Not found value template refs' })
+    fireEvent.click(link)
+
+    // wait for the resource template to be loaded into the list of recently used templates
+    await act(() => promise)
+    // wait for the error message to be loaded
+    await act(() => promise)
+
+    // check that the dismissable error message appears
+    screen.findByText('The following referenced resource templates are not available in Sinopia:')
+    screen.findByRole('button', { name: 'x' })
+  })
+})

--- a/__tests__/feature/invalidTemplate.test.js
+++ b/__tests__/feature/invalidTemplate.test.js
@@ -6,9 +6,6 @@ import Config from 'Config'
 // This forces Sinopia server to use fixtures
 jest.spyOn(Config, 'useResourceTemplateFixtures', 'get').mockReturnValue(true)
 jest.mock('sinopiaSearch')
-
-// Mock jquery
-global.$ = jest.fn().mockReturnValue({ popover: jest.fn() })
 window.scrollTo = jest.fn()
 
 describe('an invalid resource template', () => {


### PR DESCRIPTION
## Why was this change made?
Fixes #2421 

(Also removes duplicate  `scrollIntoView = jest.fn()` mock found in saveAndCopyResource.test)