### PR TITLE
Make resource close button close the expected tab

### DIFF
--- a/src/components/editor/actions/CloseButton.jsx
+++ b/src/components/editor/actions/CloseButton.jsx
@@ -37,7 +37,7 @@ const CloseButton = (props) => {
 
   return (
     <React.Fragment>
-      <CloseResourceModal />
+      <CloseResourceModal resourceKey={resourceKey} />
       <button type="button"
               className={buttonClasses}
               aria-label="Close"

--- a/src/components/editor/actions/CloseResourceModal.jsx
+++ b/src/components/editor/actions/CloseResourceModal.jsx
@@ -1,20 +1,19 @@
 // Copyright 2019 Stanford University see LICENSE for license
 
 import React from 'react'
+import PropTypes from 'prop-types'
 import { hideModal } from 'actions/modals'
 import { useDispatch, useSelector } from 'react-redux'
 import { clearResource } from 'actions/resources'
 import ModalWrapper, { useDisplayStyle, useModalCss } from '../../ModalWrapper'
 import { selectModalType } from 'selectors/modals'
 import { useHistory } from 'react-router-dom'
-import { selectCurrentResourceKey } from 'selectors/resources'
 
-const CloseResourceModal = () => {
+const CloseResourceModal = (props) => {
   const dispatch = useDispatch()
   const history = useHistory()
 
   const show = useSelector((state) => selectModalType(state) === 'CloseResourceModal')
-  const resourceKey = useSelector((state) => selectCurrentResourceKey(state))
 
   const handleClose = (event) => {
     dispatch(hideModal())
@@ -22,7 +21,7 @@ const CloseResourceModal = () => {
   }
 
   const handleCloseResource = (event) => {
-    dispatch(clearResource(resourceKey))
+    dispatch(clearResource(props.resourceKey))
     dispatch(hideModal())
     // In case this is /editor/<rtId>, clear
     history.push('/editor')
@@ -59,6 +58,10 @@ const CloseResourceModal = () => {
     </div>)
 
   return (<ModalWrapper modal={modal} />)
+}
+
+CloseResourceModal.propTypes = {
+  resourceKey: PropTypes.string.isRequired,
 }
 
 export default CloseResourceModal


### PR DESCRIPTION
Fixes #2057

## Why was this change made?

The prior implementation of CloseResourceModal used the selectCurrentResourceKey to figure out which resource the CloseButton should close, and that was the bug. Instead, the CloseButton should tell the CloseResourceModal what its resource is and it should close that resource.


## How was this change tested?

This change was tested in the browser and confirmed working. See linked screen capture:

![Peek 2020-09-03 15-58](https://user-images.githubusercontent.com/131982/92537783-dfa89080-f1f1-11ea-9b94-b6249eb1f994.gif)

I briefly entertained the idea of adding unit tests for CloseButton and CloseResourceModal but it seemed of little value to test properties injection which is core React functionality. Given also that 1) such tests would not make it apparent that this bug is related to the tests, 2) my familiarity with React testing is relatively low, and 3) this is fixing a production bug, I decided not to add any automated tests in this commit. Happy to reconsider.

## Which documentation and/or configurations were updated?

None.

