### PR TITLE
Removes request as a dependency.

### DIFF
--- a/__tests__/feature/editing/editingLiteral.test.js
+++ b/__tests__/feature/editing/editingLiteral.test.js
@@ -92,7 +92,7 @@ describe('editing a literal property', () => {
     // Input is not disabled and empty
     expect(input).not.toBeDisabled()
     expect(input).toHaveValue('')
-  })
+  }, 10000)
 
   it('allows entering diacritics', async () => {
     renderApp(null, history)
@@ -117,7 +117,7 @@ describe('editing a literal property', () => {
     // Close it
     fireEvent.click(diacriticBtn)
     expect(screen.queryAllByText('Latin Extended').length).toBeFalsy()
-  })
+  }, 10000)
 
   it('allows selecting a language', async () => {
     renderApp(null, history)

--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
     "react-textarea-autosize": "^8.2.0",
     "redux": "^4.0.1",
     "redux-thunk": "^2.3.0",
-    "request": "^2.88.2",
     "reselect": "^4.0.0",
     "set-value": "^3.0.2",
     "shortid": "^2.2.14",


### PR DESCRIPTION
closes #2432

## Why was this change made?
We have `request` listed as a dependency, but don't use it directly.


## How was this change tested?
Unit / integration


## Which documentation and/or configurations were updated?
NA


