### PR TITLE
Expand current property navigation item only

### DIFF
--- a/__tests__/feature/editing/openAndCloseResource.test.js
+++ b/__tests__/feature/editing/openAndCloseResource.test.js
@@ -14,7 +14,8 @@ describe('switching between multiple resources', () => {
     renderApp(store, history)
 
     await screen.findAllByRole('heading', { name: 'Abbreviated Title' })
-    const abbreviatedTitleTab = await screen.findByRole('button', { name: 'Abbreviated Title' })
+    // NOTE: There are two buttons with this name, so retrieve element using a selector
+    const abbreviatedTitleTab = screen.getByText('Abbreviated Title', { selector: 'button.nav-link' })
     expect(abbreviatedTitleTab).toHaveClass('active')
   })
 
@@ -47,7 +48,8 @@ describe('closing the resources', () => {
   it('removes the navigation tabs and the resources from view', async () => {
     renderApp(store, history)
 
-    const abbreviatedTitleTab = await screen.findByRole('button', { name: 'Abbreviated Title' })
+    // NOTE: There are two buttons with this name, so retrieve element using a selector
+    const abbreviatedTitleTab = screen.getByText('Abbreviated Title', { selector: 'button.nav-link' })
     const noteTab = await screen.findByRole('button', { name: 'Note' })
 
     // Closing the active tab will reveal the inactive resource as the one shown

--- a/src/components/editor/property/PanelResourcePropertyNavItem.jsx
+++ b/src/components/editor/property/PanelResourcePropertyNavItem.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import PanelResourceNavItem from './PanelResourceNavItem'
 import PanelResourceTopNavItem from './PanelResourceTopNavItem'
+import { selectCurrentComponentKey } from 'selectors/index'
 import { selectProperty } from 'selectors/resources'
 import { useSelector } from 'react-redux'
 import PanelResourceSubjectNavItem from './PanelResourceSubjectNavItem'
@@ -9,10 +10,11 @@ import _ from 'lodash'
 
 const PanelResourcePropertyNavItem = (props) => {
   const property = useSelector((state) => selectProperty(state, props.propertyKey))
-
   const hasValue = !_.isEmpty(property.values) && property.values.some((value) => value.literal || value.uri)
-
   const hasError = !_.isEmpty(property.errors)
+
+  const currentComponentKey = useSelector((state) => selectCurrentComponentKey(state, props.resourceKey))
+  const isCurrentComponent = props.propertyKey === currentComponentKey
 
   const navItems = []
   if (props.level === 1) {
@@ -34,7 +36,7 @@ const PanelResourcePropertyNavItem = (props) => {
         hasValue={hasValue}
         hasError={hasError} />)
   }
-  if (property.values) {
+  if (property.values && isCurrentComponent) {
     property.values.forEach((value) => {
       if (value.valueSubject) { navItems.push(<PanelResourceSubjectNavItem
         key={value.valueSubject.key}
@@ -47,6 +49,7 @@ const PanelResourcePropertyNavItem = (props) => {
 
 PanelResourcePropertyNavItem.propTypes = {
   propertyKey: PropTypes.string.isRequired,
+  resourceKey: PropTypes.string.isRequired,
   level: PropTypes.number.isRequired,
 }
 

--- a/src/components/editor/property/PanelResourceSubjectNavItem.jsx
+++ b/src/components/editor/property/PanelResourceSubjectNavItem.jsx
@@ -19,7 +19,12 @@ const PanelResourceSubjectNavItem = (props) => {
   }
   subject.properties.forEach((property) => {
     if (props.level > 0 && !property.valueKeys) return
-    navItems.push(<PanelResourcePropertyNavItem key={property.key} propertyKey={property.key} level={props.level + 1} />)
+    navItems.push(
+      <PanelResourcePropertyNavItem key={property.key}
+                                    propertyKey={property.key}
+                                    resourceKey={subject.resourceKey}
+                                    level={props.level + 1} />,
+    )
   })
   return navItems
 }

--- a/src/components/editor/property/PanelResourceTopNavItem.jsx
+++ b/src/components/editor/property/PanelResourceTopNavItem.jsx
@@ -17,9 +17,10 @@ const PanelResourceTopNavItem = (props) => {
   if (displayValidations && props.hasError) classNames.push('text-danger')
 
   return (<button
-    type="button"
-    className={classNames.join(' ')}
-    onClick={() => dispatch(setCurrentComponent(props.resourceKey, props.componentKey))}>
+            type="button"
+            className={classNames.join(' ')}
+            aria-label={props.label}
+            onClick={() => dispatch(setCurrentComponent(props.resourceKey, props.componentKey))}>
     <h5>
       {prefixMark} {props.label}
     </h5>


### PR DESCRIPTION
Fixes #2419

## Why was this change made?

To fix #2419.

This commit has a few different components:

* Subject nav items should inject the resource key property into its property nav items
* Property nav items should check their resource key (see prior bullet) to determine if they are the currently selected property nav item and, if and only if they are, they should render their child navigation items
* Top-level navigation items should include an aria-label, partly for a11y purposes and partly to facilitate integration testing

## How was this change tested?

CI and local in-browser testing. See demo of changes here:

![Peek 2020-09-09 10-16](https://user-images.githubusercontent.com/131982/92633042-11b80200-f287-11ea-9b7b-e390c0ffe439.gif)


## Which documentation and/or configurations were updated?


None
