### PR TITLE
Create the value onBlur

### DIFF
--- a/src/components/editor/property/InputLiteral.jsx
+++ b/src/components/editor/property/InputLiteral.jsx
@@ -91,8 +91,14 @@ const InputLiteral = (props) => {
     return false
   }
 
+  const hasInput = () => !_.isEmpty(props.content)
+
   const handleBlur = (e) => {
-    if (!focusIn(e, 'diacritics-selection') && !focusIn(e, id) && props.property.valueKeys.length > 0) {
+    if (focusIn(e, 'diacritics-selection') || focusIn(e, id)) {
+      return
+    }
+
+    if (hasInput()) {
       addItem()
       props.hideDiacritics()
     }


### PR DESCRIPTION
## Why was this change made?

This will allow the form to be valid without having to press the enter key.

Fixes #2361

This was caused by https://github.com/LD4P/sinopia_editor/commit/869e3ca1c0cbb6add1771aed45faebdbddf3609f#diff-c8159322c93a06854f45e72e68ffdfd3R95


## How was this change tested?



## Which documentation and/or configurations were updated?



