### PR TITLE
Do not restart docker resources

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,6 @@ services:
   #     - elasticsearch
   mongo:
     image: mongo:4.4
-    restart: always
     ports:
       - 27017:27017
       - 28017:28017
@@ -62,11 +61,9 @@ services:
     #   dockerfile: Dockerfile-setup
     depends_on:
       - mongo
-    restart: "no"
   # Uncomment to use Mongo-Express to monitor Mongo. Do not commit docker-compose.yml.
   # mongo-express:
   #   image: mongo-express
-  #   restart: always
   #   ports:
   #     - 8082:8081
   #   environment:
@@ -78,7 +75,6 @@ services:
     # build:
     #   context: ../sinopia_api
     #   dockerfile: Dockerfile
-    restart: always
     ports:
       - 3000:3000
     environment:


### PR DESCRIPTION
## Why was this change made?

This may be something only I'm seeing, or there may be a better approach, but the `restart: always` configs here mean that the mongo resources are configured to always start when docker-desktop starts. This is not ideal for local resources where we don't want an extraneous service running when we're not working on this project.

In order to remove the restart directive, `docker-compose up -d` needs to run with this config (including the `restart: "no"`, we can likely eventually just remove the restart directive all together, but if you've already run the current config, you need to force it to get the new no-restart.

If we need the restart directive, perhaps `restart: unless-stopped` would be more appropriate so we can actually stop the thing.

## How was this change tested?

Locally

## Which documentation and/or configurations were updated?

N/A


