### PR TITLE
Adds re-ordering of nested resources.

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ The following are only in the resource subject (that is, the base subject).
   label: <label for uri>,
   valueSubjectKey: <key for subject for a nested resource>,
   -> valueSubject: {<subject>}
+  -> index: <1 based index of the value (relative to siblings)>
 }
 ```
 -> Added by selector, not stored in state.

--- a/__tests__/__action_fixtures__/newResourceCopy-ADD_SUBJECT.json
+++ b/__tests__/__action_fixtures__/newResourceCopy-ADD_SUBJECT.json
@@ -45,6 +45,7 @@
             "values": [
               {
                 "key": "abc2",
+                "index": 1,
                 "resourceKey": "t9zVwg2zO",
                 "literal": "foo",
                 "lang": "eng",

--- a/__tests__/actionCreators/templateValidationHelpers.test.js
+++ b/__tests__/actionCreators/templateValidationHelpers.test.js
@@ -399,7 +399,7 @@ describe('validateTemplates()', () => {
         error: 'The following referenced resource templates are not available in Sinopia: lc:RT:bf2:Identifiers:Barcode, lc:RT:bf2:Identifiers:Copyright',
       }
       expect(store.getActions()).toHaveAction('ADD_ERROR', payload)
-    })
+    }, 10000)
   })
 
   describe('template with non-unique property template refs', () => {

--- a/__tests__/feature/editing/reordering.test.js
+++ b/__tests__/feature/editing/reordering.test.js
@@ -1,0 +1,78 @@
+import Config from 'Config'
+import { renderApp, createHistory } from 'testUtils'
+import {
+  fireEvent, screen, getAllByPlaceholderText, getByTestId, waitFor,
+} from '@testing-library/react'
+
+jest.spyOn(Config, 'useResourceTemplateFixtures', 'get').mockReturnValue(true)
+
+// Mock jquery
+global.$ = jest.fn().mockReturnValue({ popover: jest.fn() })
+// Mock out document.elementFromPoint used by useNavigableComponent.
+global.document.elementFromPoint = jest.fn()
+// Mock out scrollIntoView used by useNavigableComponent. See https://github.com/jsdom/jsdom/issues/1695
+Element.prototype.scrollIntoView = jest.fn()
+
+describe('reordering properties', () => {
+  it('reorders nested properties', async () => {
+    const history = createHistory(['/editor/resourceTemplate:testing:uber1'])
+    const { container } = renderApp(null, history)
+
+    await screen.findByText('Uber template1', { selector: 'h3' })
+
+    // Add a panel property
+    screen.getByText('Uber template1, property19', { selector: 'span' })
+    fireEvent.click(screen.getByTestId('Add Uber template1, property19'))
+
+    await screen.findByText('Uber template4')
+
+    const nestedResource1 = container.querySelector('div[data-label="Uber template1, property19"] div.nested-resource')
+
+    // No arrows.
+    expect(nestedResource1.querySelector('.btn-moveup')).toBeFalsy()
+    expect(nestedResource1.querySelector('.btn-movedown')).toBeFalsy()
+
+    // Add a value
+    const inputs1 = getAllByPlaceholderText(nestedResource1, 'Uber template4, property1')
+    fireEvent.change(inputs1[0], { target: { value: 'a' } })
+    fireEvent.keyPress(inputs1[0], { key: 'Enter', code: 13, charCode: 13 })
+
+    // Add more nested resources
+    const panel = container.querySelector('div[data-label="Uber template1, property19"]')
+    fireEvent.click(getByTestId(panel, 'Add another Uber template4'))
+    fireEvent.click(getByTestId(panel, 'Add another Uber template4'))
+    await waitFor(() => expect(container.querySelectorAll('div[data-label="Uber template1, property19"] div.nested-resource')).toHaveLength(3))
+
+    const inputs2 = getAllByPlaceholderText(panel, 'Uber template4, property1')
+    fireEvent.change(inputs2[1], { target: { value: 'b' } })
+    fireEvent.keyPress(inputs2[1], { key: 'Enter', code: 13, charCode: 13 })
+    fireEvent.change(inputs2[2], { target: { value: 'c' } })
+    fireEvent.keyPress(inputs2[2], { key: 'Enter', code: 13, charCode: 13 })
+
+    const nestedResources1 = container.querySelectorAll('div[data-label="Uber template1, property19"] div.nested-resource')
+
+    // First has down arrow.
+    expect(nestedResources1[0].querySelector('.btn-moveup')).toBeFalsy()
+    expect(nestedResources1[0].querySelector('.btn-movedown')).toBeTruthy()
+    // Second has up and down arrow
+    expect(nestedResources1[1].querySelector('.btn-moveup')).toBeTruthy()
+    expect(nestedResources1[1].querySelector('.btn-movedown')).toBeTruthy()
+    // Third has up arrow
+    expect(nestedResources1[2].querySelector('.btn-moveup')).toBeTruthy()
+    expect(nestedResources1[2].querySelector('.btn-movedown')).toBeFalsy()
+
+    // Move "b" up
+    nestedResources1[1].querySelector('.btn-moveup').click()
+    const values1 = panel.querySelectorAll('div.rbt-token')
+    expect(values1[0]).toHaveTextContent(/b/)
+    expect(values1[1]).toHaveTextContent(/a/)
+    expect(values1[2]).toHaveTextContent(/c/)
+
+    // Move "a" down
+    nestedResources1[0].querySelector('.btn-movedown').click()
+    const values2 = panel.querySelectorAll('div.rbt-token')
+    expect(values2[0]).toHaveTextContent(/b/)
+    expect(values2[1]).toHaveTextContent(/c/)
+    expect(values2[2]).toHaveTextContent(/a/)
+  }, 20000)
+})

--- a/__tests__/reducers/resources.test.js
+++ b/__tests__/reducers/resources.test.js
@@ -5,6 +5,7 @@ import {
   hideProperty, removeProperty, removeSubject,
   removeValue, saveResourceFinished, setBaseURL, setCurrentResource,
   setUnusedRDF, showProperty, loadResourceFinished, setResourceGroup,
+  setValueOrder,
 } from 'reducers/resources'
 
 import { createState } from 'stateUtils'
@@ -25,6 +26,7 @@ const reducers = {
   SET_CURRENT_RESOURCE: setCurrentResource,
   SET_UNUSED_RDF: setUnusedRDF,
   SET_RESOURCE_GROUP: setResourceGroup,
+  SET_VALUE_ORDER: setValueOrder,
   SHOW_PROPERTY: showProperty,
 }
 
@@ -726,5 +728,25 @@ describe('setResourceGroup()', () => {
         },
       },
     })
+  })
+})
+
+describe('setValueOrder()', () => {
+  it('sets value order', () => {
+    const oldState = createState({ hasResourceWithTwoNestedResources: true })
+
+    expect(oldState.selectorReducer.entities.properties.v1o90QO1Qx.valueKeys).toEqual(['VDOeQCnFA8', 'VDOeQCnFA9'])
+
+    const action = {
+      type: 'SET_VALUE_ORDER',
+      payload: {
+        valueKey: 'VDOeQCnFA9',
+        index: 1,
+      },
+    }
+
+    const newState = reducer(oldState.selectorReducer, action)
+
+    expect(newState.entities.properties.v1o90QO1Qx.valueKeys).toEqual(['VDOeQCnFA9', 'VDOeQCnFA8'])
   })
 })

--- a/__tests__/selectors/resources.test.js
+++ b/__tests__/selectors/resources.test.js
@@ -36,7 +36,9 @@ describe('selectValue()', () => {
 
   it('returns value', () => {
     const state = createState({ hasResourceWithNestedResource: true })
-    expect(selectValue(state, 'VDOeQCnFA8')).toBeValue('VDOeQCnFA8')
+    const value = selectValue(state, 'VDOeQCnFA8')
+    expect(value).toBeValue('VDOeQCnFA8')
+    expect(value.index).toBe(1)
   })
 })
 

--- a/__tests__/testUtilities/stateUtils.js
+++ b/__tests__/testUtilities/stateUtils.js
@@ -11,6 +11,7 @@ export const createState = (options = {}) => {
   buildResourceWithUri(state, options)
   buildResourceWithContractedLiteral(state, options)
   buildResourceWithNestedResource(state, options)
+  buildResourceWithTwoNestedResources(state, options)
   buildResourceWithContractedNestedResource(state, options),
   buildResourceWithError(state, options),
   buildExports(state, options)
@@ -673,4 +674,180 @@ const buildLookups = (state, options) => {
     ],
   }
 }
+
+const buildResourceWithTwoNestedResources = (state, options) => {
+  if (!options.hasResourceWithTwoNestedResources) return
+
+  state.selectorReducer.editor.currentResource = 'ljAblGiBW'
+  state.selectorReducer.entities.subjectTemplates = {
+    'resourceTemplate:testing:uber1': {
+      key: 'resourceTemplate:testing:uber1',
+      id: 'resourceTemplate:testing:uber1',
+      class: 'http://id.loc.gov/ontologies/bibframe/Uber1',
+      label: 'Uber template1',
+      remark: 'Template for testing purposes.',
+      propertyTemplateKeys: [
+        'resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property1',
+      ],
+    },
+    'resourceTemplate:testing:uber2': {
+      key: 'resourceTemplate:testing:uber2',
+      id: 'resourceTemplate:testing:uber2',
+      class: 'http://id.loc.gov/ontologies/bibframe/Uber2',
+      label: 'Uber template2',
+      remark: 'Template for testing purposes with single repeatable literal.',
+      propertyTemplateKeys: [
+        'resourceTemplate:testing:uber2 > http://id.loc.gov/ontologies/bibframe/uber/template2/property1',
+      ],
+    },
+  }
+  state.selectorReducer.entities.propertyTemplates = {
+    'resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property1': {
+      key: 'resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property1',
+      subjectTemplateKey: 'resourceTemplate:testing:uber1',
+      label: 'Uber template1, property1',
+      uri: 'http://id.loc.gov/ontologies/bibframe/uber/template1/property1',
+      required: false,
+      repeatable: true,
+      defaults: [],
+      remark: 'Nested, repeatable resource template.',
+      remarkUrl: null,
+      type: 'resource',
+      component: 'InputURI',
+      valueSubjectTemplateKeys: [
+        'resourceTemplate:testing:uber2',
+      ],
+      authorities: [],
+    },
+    'resourceTemplate:testing:uber2 > http://id.loc.gov/ontologies/bibframe/uber/template2/property1': {
+      key: 'resourceTemplate:testing:uber2 > http://id.loc.gov/ontologies/bibframe/uber/template2/property1',
+      subjectTemplateKey: 'resourceTemplate:testing:uber2',
+      label: 'Uber template2, property1',
+      uri: 'http://id.loc.gov/ontologies/bibframe/uber/template2/property1',
+      required: false,
+      repeatable: true,
+      defaults: [],
+      remark: 'A repeatable literal',
+      remarkUrl: null,
+      type: 'literal',
+      component: 'InputLiteral',
+      authorities: [],
+    },
+  }
+  state.selectorReducer.entities.subjects = {
+    ljAblGiBW: {
+      key: 'ljAblGiBW',
+      uri: null,
+      resourceKey: 'ljAblGiBW',
+      subjectTemplateKey: 'resourceTemplate:testing:uber1',
+      propertyKeys: [
+        'v1o90QO1Qx',
+      ],
+      changed: false,
+      bfAdminMetadataRefs: [],
+      bfInstanceRefs: [],
+      bfItemRefs: [],
+      bfWorkRefs: [],
+      group: null,
+    },
+    XPb8jaPWo: {
+      key: 'XPb8jaPWo',
+      uri: null,
+      subjectTemplateKey: 'resourceTemplate:testing:uber2',
+      resourceKey: 'ljAblGiBW',
+      propertyKeys: [
+        '7caLbfwwle',
+      ],
+    },
+    XPb8jaPWp: {
+      key: 'XPb8jaPWp',
+      uri: null,
+      subjectTemplateKey: 'resourceTemplate:testing:uber2',
+      resourceKey: 'ljAblGiBW',
+      propertyKeys: [
+        '7caLbfwwlf',
+      ],
+    },
+  }
+  state.selectorReducer.entities.properties = {
+    v1o90QO1Qx: {
+      key: 'v1o90QO1Qx',
+      subjectKey: 'ljAblGiBW',
+      resourceKey: 'ljAblGiBW',
+      propertyTemplateKey: 'resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property1',
+      valueKeys: [
+        'VDOeQCnFA8',
+        'VDOeQCnFA9',
+      ],
+      show: true,
+      errors: options.error || [],
+    },
+    '7caLbfwwle': {
+      key: '7caLbfwwle',
+      subjectKey: 'XPb8jaPWo',
+      resourceKey: 'ljAblGiBW',
+      propertyTemplateKey: 'resourceTemplate:testing:uber2 > http://id.loc.gov/ontologies/bibframe/uber/template2/property1',
+      valueKeys: [
+        'pRJ0lO_mT-',
+      ],
+      show: true,
+      errors: [],
+    },
+    '7caLbfwwlf': {
+      key: '7caLbfwwlf',
+      subjectKey: 'XPb8jaPWp',
+      resourceKey: 'ljAblGiBW',
+      propertyTemplateKey: 'resourceTemplate:testing:uber2 > http://id.loc.gov/ontologies/bibframe/uber/template2/property1',
+      valueKeys: [
+        'pRJ0lO_mU-',
+      ],
+      show: true,
+      errors: [],
+    },
+  }
+  state.selectorReducer.entities.values = {
+    VDOeQCnFA8: {
+      key: 'VDOeQCnFA8',
+      propertyKey: 'v1o90QO1Qx',
+      resourceKey: 'ljAblGiBW',
+      literal: null,
+      lang: null,
+      uri: null,
+      label: null,
+      valueSubjectKey: 'XPb8jaPWo',
+    },
+    VDOeQCnFA9: {
+      key: 'VDOeQCnFA9',
+      propertyKey: 'v1o90QO1Qx',
+      resourceKey: 'ljAblGiBW',
+      literal: null,
+      lang: null,
+      uri: null,
+      label: null,
+      valueSubjectKey: 'XPb8jaPWp',
+    },
+    'pRJ0lO_mT-': {
+      key: 'pRJ0lO_mT-',
+      propertyKey: '7caLbfwwle',
+      resourceKey: 'ljAblGiBW',
+      literal: 'foo',
+      lang: 'eng',
+      uri: null,
+      label: null,
+      valueSubjectKey: null,
+    },
+    'pRJ0lO_mU-': {
+      key: 'pRJ0lO_mU-',
+      propertyKey: '7caLbfwwlf',
+      resourceKey: 'ljAblGiBW',
+      literal: 'bar',
+      lang: 'eng',
+      uri: null,
+      label: null,
+      valueSubjectKey: null,
+    },
+  }
+}
+
+
 export const noop = () => {}

--- a/src/actionCreators/templates.js
+++ b/src/actionCreators/templates.js
@@ -43,7 +43,7 @@ export const loadResourceTemplateWithoutValidation = (resourceTemplateId, resour
 
   const templateUri = `${Config.sinopiaApiBase}/resource/${resourceTemplateId}`
 
-  const newResourceTemplatePromise = fetchResource(templateUri)
+  const newResourceTemplatePromise = fetchResource(templateUri, true)
     .then(([dataset]) => {
       const subjectTemplate = new TemplatesBuilder(dataset, templateUri).build()
       dispatch(addTemplates(subjectTemplate))

--- a/src/actions/resources.js
+++ b/src/actions/resources.js
@@ -75,3 +75,11 @@ export const removeProperty = (propertyKey) => ({
   type: 'REMOVE_PROPERTY',
   payload: propertyKey,
 })
+
+export const setValueOrder = (valueKey, index) => ({
+  type: 'SET_VALUE_ORDER',
+  payload: {
+    valueKey,
+    index,
+  },
+})

--- a/src/components/editor/property/NestedResource.jsx
+++ b/src/components/editor/property/NestedResource.jsx
@@ -16,7 +16,7 @@ const NestedResource = (props) => {
   /* eslint-disable jsx-a11y/click-events-have-key-events */
   /* eslint-disable jsx-a11y/no-static-element-interactions */
   return (
-    <div ref={navEl} onClick={navClickHandler}>
+    <div className='nested-resource' ref={navEl} onClick={navClickHandler}>
       <div className="row" key={props.valueKey}>
         <section className="col-md-6">
           <h5>{ props.value.valueSubject.subjectTemplate.label }</h5>

--- a/src/components/editor/property/NestedResourceActionButtons.jsx
+++ b/src/components/editor/property/NestedResourceActionButtons.jsx
@@ -5,11 +5,11 @@ import PropTypes from 'prop-types'
 import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faTrashAlt } from '@fortawesome/free-solid-svg-icons'
+import { faTrashAlt, faArrowUp, faArrowDown } from '@fortawesome/free-solid-svg-icons'
 import { resourceEditErrorKey } from '../Editor'
 import { selectCurrentResourceKey, selectProperty } from 'selectors/resources'
 import { addSiblingValueSubject } from 'actionCreators/resources'
-import { removeValue } from 'actions/resources'
+import { removeValue, setValueOrder } from 'actions/resources'
 import _ from 'lodash'
 
 const NestedResourceActionButtons = (props) => {
@@ -21,12 +21,27 @@ const NestedResourceActionButtons = (props) => {
   const showAddButton = props.property.propertyTemplate.repeatable && props.value.key === _.first(siblingValues).key
   // Show delete button if more than one.
   const showRemoveButton = siblingValues.length > 1
-
-  const trashIcon = faTrashAlt
+  const showMoveUpButton = props.value.property.propertyTemplate.ordered && props.value.index > 1
+  const showMoveDownButton = props.value.property.propertyTemplate.ordered && props.value.index < props.property.values.length
 
   const addAnother = (event) => {
     event.preventDefault()
     return props.addSiblingValueSubject(_.last(siblingValues).key, resourceEditErrorKey(props.resourceKey))
+  }
+
+  const moveUp = (event) => {
+    props.setValueOrder(props.value.key, props.value.index - 1)
+    event.preventDefault()
+  }
+
+  const moveDown = (event) => {
+    props.setValueOrder(props.value.key, props.value.index + 1)
+    event.preventDefault()
+  }
+
+  const removeValue = (event) => {
+    props.removeValue(props.value.key)
+    event.preventDefault()
   }
 
   return (<div className="btn-group pull-right" role="group">
@@ -39,10 +54,24 @@ const NestedResourceActionButtons = (props) => {
     }
     { showRemoveButton
       && <button
-        className="btn btn-sm btn-remove-another"
+        className="btn btn-sm btn-remove-another btn-nested-resource"
         aria-label={`Remove ${props.value.valueSubject.subjectTemplate.label}`}
         data-testid={`Remove ${props.value.valueSubject.subjectTemplate.label}`}
-        onClick={() => props.removeValue(props.value.key)}><FontAwesomeIcon icon={trashIcon} /></button>
+        onClick={removeValue}><FontAwesomeIcon icon={faTrashAlt} /></button>
+    }
+    { showMoveUpButton
+      && <button
+          className="btn btn-sm btn-nested-resource btn-moveup"
+          aria-label={`Move up ${props.value.valueSubject.subjectTemplate.label}`}
+          data-testid={`Move up ${props.value.valueSubject.subjectTemplate.label}`}
+          onClick={moveUp}><FontAwesomeIcon icon={faArrowUp} /></button>
+    }
+    { showMoveDownButton
+      && <button
+          className="btn btn-sm btn-nested-resource btn-movedown"
+          aria-label={`Move down ${props.value.valueSubject.subjectTemplate.label}`}
+          data-testid={`Move down ${props.value.valueSubject.subjectTemplate.label}`}
+          onClick={moveDown}><FontAwesomeIcon icon={faArrowDown} /></button>
     }
 
   </div>)
@@ -52,6 +81,7 @@ NestedResourceActionButtons.propTypes = {
   value: PropTypes.object.isRequired,
   addSiblingValueSubject: PropTypes.func,
   removeValue: PropTypes.func,
+  setValueOrder: PropTypes.func,
   property: PropTypes.object,
 }
 
@@ -62,6 +92,6 @@ const mapStateToProps = (state, ownProps) => ({
 })
 
 
-const mapDispatchToProps = (dispatch) => bindActionCreators({ addSiblingValueSubject, removeValue }, dispatch)
+const mapDispatchToProps = (dispatch) => bindActionCreators({ addSiblingValueSubject, removeValue, setValueOrder }, dispatch)
 
 export default connect(mapStateToProps, mapDispatchToProps)(NestedResourceActionButtons)

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -13,7 +13,7 @@ import {
   addSubject, addProperty, addValue, removeValue,
   removeProperty, removeSubject, clearResource,
   saveResourceFinished, loadResourceFinished,
-  setResourceGroup,
+  setResourceGroup, setValueOrder,
 } from './resources'
 import {
   setLanguage, fetchingLanguages, languagesReceived,
@@ -88,6 +88,7 @@ const handlers = {
   SET_SEARCH_RESULTS: setSearchResults,
   SET_TEMPLATE_SEARCH_RESULTS: setTemplateSearchResults,
   SET_UNUSED_RDF: setUnusedRDF,
+  SET_VALUE_ORDER: setValueOrder,
   SHOW_COPY_NEW_MESSAGE: showCopyNewMessage,
   SHOW_DIACRITICS: showDiacriticsSelection,
   SHOW_GROUP_CHOOSER: showGroupChooser,

--- a/src/reducers/resources.js
+++ b/src/reducers/resources.js
@@ -170,6 +170,9 @@ const addValueToNewState = (newState, value, siblingValueKey) => {
   newValue.propertyKey = newValue.property.key
   delete newValue.property
 
+  // Remove index
+  delete newValue.index
+
   // Add value to state
   const oldValue = newState.entities.values[newValue.key]
   newState.entities.values[newValue.key] = newValue
@@ -381,6 +384,20 @@ export const setResourceGroup = (state, action) => {
   const newState = { ...state }
 
   newState.entities.subjects[action.payload.resourceKey].group = action.payload.group
+
+  return newState
+}
+
+export const setValueOrder = (state, action) => {
+  const newState = { ...state }
+
+  const valueKey = action.payload.valueKey
+  const index = action.payload.index
+  const newValue = newState.entities.values[valueKey]
+  const newProperty = newState.entities.properties[newValue.propertyKey]
+
+  const filterValueKeys = newProperty.valueKeys.filter((key) => key !== valueKey)
+  newProperty.valueKeys = [...filterValueKeys.slice(0, index - 1), valueKey, ...filterValueKeys.slice(index - 1)]
 
   return newState
 }

--- a/src/selectors/resources.js
+++ b/src/selectors/resources.js
@@ -42,6 +42,7 @@ export const selectValue = (state, key) => {
   const newProperty = { ...property }
   newProperty.propertyTemplate = selectPropertyTemplate(state, newProperty.propertyTemplateKey)
   newValue.property = newProperty
+  newValue.index = newProperty.valueKeys.indexOf(value.key) + 1
   newValue.valueSubject = selectSubject(state, newValue.valueSubjectKey)
   return newValue
 }

--- a/src/sinopiaApi.js
+++ b/src/sinopiaApi.js
@@ -13,14 +13,18 @@ import Auth from '@aws-amplify/auth'
  * @return {Promise{[rdf.Dataset, Object]} resource as dataset, response JSON.
  * @throws when error occurs retrieving or parsing the resource template.
  */
-export const fetchResource = (uri) => {
+export const fetchResource = (uri, isTemplate) => {
   let fetchPromise
+  // Templates have special handling when using fixtures.
+  // A template will raise when found; other resources will try API.
   if (Config.useResourceTemplateFixtures && hasFixtureResource(uri)) {
     try {
       fetchPromise = Promise.resolve(getFixtureResource(uri))
     } catch (err) {
       fetchPromise = Promise.reject(err)
     }
+  } else if (Config.useResourceTemplateFixtures && isTemplate) {
+    fetchPromise = Promise.reject(new Error('Not found'))
   } else {
     fetchPromise = fetch(uri, {
       headers: { Accept: 'application/json' },

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -370,3 +370,8 @@ a.list-group-item {
 .list-group-top-item {
   padding-top: 5px;
 }
+
+ .btn-nested-resource {
+   padding-left: 2px;
+   padding-right: 2px;
+ }


### PR DESCRIPTION
closes #2358

## Why was this change made?
Support re-ordering of nested resources, in particular, re-ordering of property templates when editing a resource template.

![image](https://user-images.githubusercontent.com/588335/92954906-45835b00-f432-11ea-9219-1cbd21832818.png)

This can be tested when creating a new resource template or using Uber template 1 > property 19.

## How was this change tested?
Unit tests, feature test, locally.


## Which documentation and/or configurations were updated?
NA


