### PR TITLE
Update styles for resource tabs

### DIFF
--- a/__tests__/feature/editing/openAndCloseResource.test.js
+++ b/__tests__/feature/editing/openAndCloseResource.test.js
@@ -10,34 +10,29 @@ describe('switching between multiple resources', () => {
   const state = createState({ hasTwoLiteralResources: true })
   const store = createStore(state)
 
-  it('has a resource loaded into state and is shown as the active button tab', async () => {
+  it('has a resource loaded into state', async () => {
     renderApp(store, history)
 
     await screen.findByText('Abbreviated Title', { selector: 'h3' })
-    // NOTE: There are two buttons with this name, so retrieve element using a selector
-    const abbreviatedTitleTab = screen.getByText('Abbreviated Title', { selector: 'button.nav-link' })
-    expect(abbreviatedTitleTab).toHaveClass('active')
+    await screen.findByText('Abbreviated Title', { selector: '.nav-item.active .nav-link' })
   })
 
   it('has a second resource shown as the inactive button tab', async () => {
     renderApp(store, history)
 
-    const noteTab = await screen.findByText('Note', { selector: 'button' })
-    expect(noteTab).not.toHaveClass('active')
+    await screen.findByText('Note', { selector: '.nav-item:not(.active) .nav-link' })
   })
 
   it('switches between the active and inactive resources', async () => {
     renderApp(store, history)
 
-    // Click the inactive button tab
-    const noteTab = await screen.findByText('Note', { selector: 'button' })
+    // Click the inactive tab
+    const noteTab = await screen.findByText('Note', { selector: '.nav-link' })
     fireEvent.click(noteTab)
-    expect(noteTab).toHaveClass('active')
 
     // Note is now the active resource and Abbreviated Title is now the inactive resource
     await screen.findByText('Note', { selector: 'h3' })
-    const abbreviatedTitleTab = await screen.findByText('Abbreviated Title', { selector: 'button' })
-    expect(abbreviatedTitleTab).not.toHaveClass('active')
+    await screen.findByText('Abbreviated Title', { selector: '.nav-item:not(.active) .nav-link' })
   })
 })
 
@@ -48,9 +43,8 @@ describe('closing the resources', () => {
   it('removes the navigation tabs and the resources from view', async () => {
     renderApp(store, history)
 
-    // NOTE: There are two buttons with this name, so retrieve element using a selector
-    const abbreviatedTitleTab = screen.getByText('Abbreviated Title', { selector: 'button.nav-link' })
-    const noteTab = await screen.findByText('Note', { selector: 'button' })
+    const abbreviatedTitleTab = screen.getByText('Abbreviated Title', { selector: '.nav-link' })
+    const noteTab = await screen.findByText('Note', { selector: '.nav-link' })
 
     // Closing the active tab will reveal the inactive resource as the one shown
     const closeBtn = screen.getAllByText('Close', { selector: 'button' })

--- a/__tests__/feature/editing/saveAndCopyResource.test.js
+++ b/__tests__/feature/editing/saveAndCopyResource.test.js
@@ -59,9 +59,8 @@ describe('saving a resource', () => {
       screen.findByText(/Copied http:\/\/localhost\/something\/or\/other to new resource./)
 
       // There are nav tabs and a duplicate resource with the same content
-      const tabBtns = await screen.findAllByText('Title note', { selector: 'button' })
-      expect(tabBtns[0]).not.toHaveClass('active')
-      expect(tabBtns[1]).toHaveClass('active')
+      await screen.findAllByText('Title note', { selector: '.nav-item.active .nav-link' })
+      await screen.findAllByText('Title note', { selector: '.nav-item:not(.active) .nav-link' })
       expect(editBtn).toHaveTextContent('Edit')
     })
   })

--- a/__tests__/feature/searchAndOpenTemplate.test.js
+++ b/__tests__/feature/searchAndOpenTemplate.test.js
@@ -66,8 +66,7 @@ describe('searching and opening a resource', () => {
     await screen.findByText('Title note', { selector: 'h3' })
 
     // There are nav tabs and a duplicate resource
-    const tabBtns = await screen.findAllByText('Title note', { selector: 'button' })
-    expect(tabBtns[0]).not.toHaveClass('active')
-    expect(tabBtns[1]).toHaveClass('active')
+    await screen.findAllByText('Title note', { selector: '.nav-item.active .nav-link' })
+    await screen.findAllByText('Title note', { selector: '.nav-item:not(.active) .nav-link' })
   })
 })

--- a/src/components/editor/ResourcesNav.jsx
+++ b/src/components/editor/ResourcesNav.jsx
@@ -24,21 +24,19 @@ const ResourcesNav = () => {
   })
 
   const createResourceTemplateNavItem = (resourceKey, active) => {
-    const linkClasses = ['nav-link', 'btn']
     const itemClasses = ['nav-item']
     let closeButton
     if (active) {
-      linkClasses.push('active')
       itemClasses.push('active')
     } else {
-      closeButton = <CloseButton label={'x'} css={'button'} resourceKey={resourceKey}/>
+      closeButton = <CloseButton label={'×'} css={'button'} resourceKey={resourceKey}/>
     }
     return (
       <li className={itemClasses.join(' ')} key={resourceKey}>
         <div className="btn-group">
-          <button className={linkClasses.join(' ')}
-                  href="#"
-                  onClick={(event) => handleResourceNavClick(event, resourceKey)}>{navLabels[resourceKey]}</button>
+          <a className="nav-link"
+             href="#resourceTemplate"
+             onClick={(event) => handleResourceNavClick(event, resourceKey)}>{navLabels[resourceKey]}</a>
           {closeButton}
         </div>
       </li>
@@ -58,7 +56,7 @@ const ResourcesNav = () => {
   return (
     <div className="row">
       <div className="col">
-        <ul className="nav nav-tabs resources-nav-tabs" style={{ marginBottom: '5px' }}>
+        <ul className="nav nav-tabs resources-nav-tabs">
           { resourceTemplateNavItems }
         </ul>
       </div>

--- a/src/styles/header.scss
+++ b/src/styles/header.scss
@@ -1,0 +1,22 @@
+/** For header tabs **/
+.editor-navtabs {
+  color: #2F2424;
+  /** top right bottom left **/
+  margin:0 5px -15px 5px;
+  border:0px;
+}
+
+.editor-navtabs .nav-link.active {
+  font-weight: 900;
+  text-decoration: none;
+}
+
+.editor-navtabs .hover {
+  background-color:transparent;
+}
+
+.editor-navtabs a {
+  color: #2F2424;
+  font-weight: 500;
+  line-height: 1.2;
+}

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -6,7 +6,11 @@ $modal-content-border-radius: 2px;
 $enable-shadows: true;
 $modal-content-box-shadow-xs: 0 .125rem .25rem rgba(black, .075) !default;
 $modal-content-border-color: gray;
-$modal-content-bg: #F8F6EF;
+$modal-content-bg: #f8f6ef;
+
+$resource-tab-active-bg: #b26f16;
+// $tab-background-active: #b26f16;
+
 @import "~bootstrap/scss/bootstrap";
 
 .left-space {
@@ -235,28 +239,7 @@ div.rbt-input-multi {
   padding: 20px 25px 20px 20px;
 }
 
-/** For header tabs **/
-.editor-navtabs {
-  color: #2F2424;
-  /** top right bottom left **/
-  margin:0 5px -15px 5px;
-  border:0px;
-}
-
-.editor-navtabs .nav-link.active {
-  font-weight: 900;
-  text-decoration: none;
-}
-
-.editor-navtabs .hover {
-  background-color:transparent;
-}
-
-.editor-navtabs a {
-  color: #2F2424;
-  font-weight: 500;
-  line-height: 1.2;
-}
+@import 'header';
 
 /** For lookup menu headers **/
 .dropdown-header {
@@ -359,23 +342,7 @@ button.btn-add-instance {
   text-decoration: underline;
 }
 
-ul.resources-nav-tabs > li.nav-item {
-  margin-bottom: 0px;
-  margin-right: 10px;
-}
-
-ul.resources-nav-tabs > li.nav-item:not(.active) {
-  background-color: #8C8A83;
-}
-
-ul.resources-nav-tabs button:not(.active) {
-  color: #FFFFFF;
-}
-
-ul.resources-nav-tabs button.active {
-  font-weight: bold;
-  text-decoration: underline;
-}
+@import 'resourceTabs';
 
 .icon-lg {
   font-size: 20px;

--- a/src/styles/resourceTabs.scss
+++ b/src/styles/resourceTabs.scss
@@ -1,0 +1,28 @@
+.resources-nav-tabs {
+  margin-bottom: 5px;
+
+  .nav-item {
+    border: 1px solid $gray-600;
+    margin-bottom: -1px;
+    margin-right: 10px;
+
+    .nav-link {
+      border: 0;
+      border-radius: 0;
+      color: $gray-600;
+      text-decoration: none;
+    }
+  }
+
+  .nav-item.active {
+    border: 0;
+    background-color: $resource-tab-active-bg;
+
+
+    .nav-link {
+      background-color: transparent;
+      color: $white;
+      font-weight: 600;
+    }
+  }
+}


### PR DESCRIPTION
Looks like this now:
<img width="558" alt="Screen Shot 2020-09-11 at 4 59 23 PM" src="https://user-images.githubusercontent.com/92044/92976501-42976300-f450-11ea-8f8e-28f103195483.png">


## Why was this change made?

Fixes #2438

## How was this change tested?



## Which documentation and/or configurations were updated?



