### PR TITLE
do not overwrite default values if exist

### DIFF
--- a/__tests__/__action_fixtures__/loadResource-ADD_SUBJECT.json
+++ b/__tests__/__action_fixtures__/loadResource-ADD_SUBJECT.json
@@ -36,7 +36,8 @@
         "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/hasInstance",
         "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/instanceOf",
         "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/hasItem",
-        "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/itemOf"
+        "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/itemOf",
+        "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property20"
       ],
       "propertyTemplates": [
         {
@@ -546,7 +547,32 @@
           ],
           "type": "uri",
           "component": "InputLookupSinopia"
-        }
+        },
+        {
+           "authorities": [],
+           "component": "InputLiteral",
+           "defaults": [
+             {
+               "lang": null,
+               "literal": "Default required literal1"
+             },
+             {
+               "lang": null,
+               "literal": "Default required literal2"
+             }
+           ],
+           "key": "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property20",
+           "label": "Uber template1, property20",
+           "ordered": false,
+           "remark": "A required, repeatable literal with defaults.",
+           "remarkUrl": null,
+           "repeatable": false,
+           "required": true,
+           "subjectTemplateKey": "resourceTemplate:testing:uber1",
+           "type": "literal",
+           "uri": "http://id.loc.gov/ontologies/bibframe/uber/template1/property20",
+           "valueSubjectTemplateKeys": []
+         }
       ]
     },
     "resourceKey": "abc0",
@@ -556,14 +582,14 @@
         "resourceKey": "abc0",
         "values": [
           {
-            "key": "abc61",
+            "key": "abc62",
             "resourceKey": "abc0",
             "literal": null,
             "lang": null,
             "uri": null,
             "label": null,
             "valueSubject": {
-              "key": "abc41",
+              "key": "abc42",
               "uri": null,
               "subjectTemplate": {
                 "key": "resourceTemplate:testing:uber3",
@@ -616,11 +642,11 @@
               "resourceKey": "abc0",
               "properties": [
                 {
-                  "key": "abc47",
+                  "key": "abc48",
                   "resourceKey": "abc0",
                   "values": [
                     {
-                      "key": "abc54",
+                      "key": "abc55",
                       "resourceKey": "abc0",
                       "literal": "Uber template3, property1",
                       "lang": "eng",
@@ -632,11 +658,11 @@
                   "show": false
                 },
                 {
-                  "key": "abc48",
+                  "key": "abc49",
                   "resourceKey": "abc0",
                   "values": [
                     {
-                      "key": "abc55",
+                      "key": "abc56",
                       "resourceKey": "abc0",
                       "literal": "Uber template3, property2",
                       "lang": "eng",
@@ -651,14 +677,14 @@
             }
           },
           {
-            "key": "abc62",
+            "key": "abc63",
             "resourceKey": "abc0",
             "literal": null,
             "lang": null,
             "uri": null,
             "label": null,
             "valueSubject": {
-              "key": "abc42",
+              "key": "abc43",
               "uri": null,
               "subjectTemplate": {
                 "key": "resourceTemplate:testing:uber2",
@@ -694,11 +720,11 @@
               "resourceKey": "abc0",
               "properties": [
                 {
-                  "key": "abc49",
+                  "key": "abc50",
                   "resourceKey": "abc0",
                   "values": [
                     {
-                      "key": "abc56",
+                      "key": "abc57",
                       "resourceKey": "abc0",
                       "literal": "Uber template2, property1",
                       "lang": "eng",
@@ -713,23 +739,23 @@
             }
           },
           {
-            "key": "abc63",
+            "key": "abc64",
             "resourceKey": "abc0",
             "literal": null,
             "lang": null,
             "uri": null,
             "label": null,
             "valueSubject": {
-              "key": "abc43",
+              "key": "abc44",
               "uri": null,
               "resourceKey": "abc0",
               "properties": [
                 {
-                  "key": "abc50",
+                  "key": "abc51",
                   "resourceKey": "abc0",
                   "values": [
                     {
-                      "key": "abc57",
+                      "key": "abc58",
                       "resourceKey": "abc0",
                       "literal": "Uber template2, property1b",
                       "lang": "eng",
@@ -751,7 +777,7 @@
         "resourceKey": "abc0",
         "values": [
           {
-            "key": "abc28",
+            "key": "abc29",
             "resourceKey": "abc0",
             "literal": "Uber template1, property2",
             "lang": "eng",
@@ -773,7 +799,7 @@
         "resourceKey": "abc0",
         "values": [
           {
-            "key": "abc29",
+            "key": "abc30",
             "resourceKey": "abc0",
             "literal": "Uber template1, property4",
             "lang": "eng",
@@ -789,7 +815,7 @@
         "resourceKey": "abc0",
         "values": [
           {
-            "key": "abc30",
+            "key": "abc31",
             "resourceKey": "abc0",
             "literal": null,
             "lang": null,
@@ -805,7 +831,7 @@
         "resourceKey": "abc0",
         "values": [
           {
-            "key": "abc31",
+            "key": "abc32",
             "resourceKey": "abc0",
             "literal": null,
             "lang": null,
@@ -833,7 +859,7 @@
         "resourceKey": "abc0",
         "values": [
           {
-            "key": "abc32",
+            "key": "abc33",
             "resourceKey": "abc0",
             "literal": "Uber template1, property9",
             "lang": "eng",
@@ -849,7 +875,7 @@
         "resourceKey": "abc0",
         "values": [
           {
-            "key": "abc33",
+            "key": "abc34",
             "resourceKey": "abc0",
             "literal": null,
             "lang": null,
@@ -865,7 +891,7 @@
         "resourceKey": "abc0",
         "values": [
           {
-            "key": "abc34",
+            "key": "abc35",
             "resourceKey": "abc0",
             "literal": null,
             "lang": null,
@@ -881,7 +907,7 @@
         "resourceKey": "abc0",
         "values": [
           {
-            "key": "abc35",
+            "key": "abc36",
             "resourceKey": "abc0",
             "literal": null,
             "lang": null,
@@ -897,7 +923,7 @@
         "resourceKey": "abc0",
         "values": [
           {
-            "key": "abc36",
+            "key": "abc37",
             "resourceKey": "abc0",
             "literal": null,
             "lang": null,
@@ -913,7 +939,7 @@
         "resourceKey": "abc0",
         "values": [
           {
-            "key": "abc37",
+            "key": "abc38",
             "resourceKey": "abc0",
             "literal": null,
             "lang": null,
@@ -929,7 +955,7 @@
         "resourceKey": "abc0",
         "values": [
           {
-            "key": "abc38",
+            "key": "abc39",
             "resourceKey": "abc0",
             "literal": null,
             "lang": null,
@@ -945,7 +971,7 @@
         "resourceKey": "abc0",
         "values": [
           {
-            "key": "abc39",
+            "key": "abc40",
             "resourceKey": "abc0",
             "literal": null,
             "lang": null,
@@ -961,7 +987,7 @@
         "resourceKey": "abc0",
         "values": [
           {
-            "key": "abc40",
+            "key": "abc41",
             "resourceKey": "abc0",
             "literal": null,
             "lang": null,
@@ -977,14 +1003,14 @@
         "resourceKey": "abc0",
         "values": [
           {
-            "key": "abc64",
+            "key": "abc65",
             "resourceKey": "abc0",
             "literal": null,
             "lang": null,
             "uri": null,
             "label": null,
             "valueSubject": {
-              "key": "abc44",
+              "key": "abc45",
               "uri": null,
               "subjectTemplate": {
                 "key": "resourceTemplate:testing:uber4",
@@ -1020,11 +1046,11 @@
               "resourceKey": "abc0",
               "properties": [
                 {
-                  "key": "abc51",
+                  "key": "abc52",
                   "resourceKey": "abc0",
                   "values": [
                     {
-                      "key": "abc58",
+                      "key": "abc59",
                       "resourceKey": "abc0",
                       "literal": "Uber template4, property1",
                       "lang": "eng",
@@ -1046,37 +1072,6 @@
         "resourceKey": "abc0",
         "values": [
           {
-            "key": "abc65",
-            "resourceKey": "abc0",
-            "literal": null,
-            "lang": null,
-            "uri": null,
-            "label": null,
-            "valueSubject": {
-              "key": "abc45",
-              "uri": null,
-              "resourceKey": "abc0",
-              "properties": [
-                {
-                  "key": "abc52",
-                  "resourceKey": "abc0",
-                  "values": [
-                    {
-                      "key": "abc59",
-                      "resourceKey": "abc0",
-                      "literal": "Uber template4, property1, first",
-                      "lang": "eng",
-                      "uri": null,
-                      "label": null,
-                      "valueSubject": null
-                    }
-                  ],
-                  "show": true
-                }
-              ]
-            }
-          },
-          {
             "key": "abc66",
             "resourceKey": "abc0",
             "literal": null,
@@ -1094,6 +1089,37 @@
                   "values": [
                     {
                       "key": "abc60",
+                      "resourceKey": "abc0",
+                      "literal": "Uber template4, property1, first",
+                      "lang": "eng",
+                      "uri": null,
+                      "label": null,
+                      "valueSubject": null
+                    }
+                  ],
+                  "show": true
+                }
+              ]
+            }
+          },
+          {
+            "key": "abc67",
+            "resourceKey": "abc0",
+            "literal": null,
+            "lang": null,
+            "uri": null,
+            "label": null,
+            "valueSubject": {
+              "key": "abc47",
+              "uri": null,
+              "resourceKey": "abc0",
+              "properties": [
+                {
+                  "key": "abc54",
+                  "resourceKey": "abc0",
+                  "values": [
+                    {
+                      "key": "abc61",
                       "resourceKey": "abc0",
                       "literal": "Uber template4, property1, second",
                       "lang": "eng",
@@ -1139,6 +1165,12 @@
         "resourceKey": "abc0",
         "values": null,
         "show": false
+      },
+      {
+         "key": "abc26",
+         "resourceKey": "abc0",
+         "show": true,
+         "values": []
       }
     ]
   }

--- a/__tests__/__action_fixtures__/newResource-ADD_SUBJECT.json
+++ b/__tests__/__action_fixtures__/newResource-ADD_SUBJECT.json
@@ -36,7 +36,8 @@
         "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/hasInstance",
         "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/instanceOf",
         "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/hasItem",
-        "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/itemOf"
+        "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/itemOf",
+        "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property20"
       ],
       "propertyTemplates": [
         {
@@ -546,6 +547,31 @@
           ],
           "type": "uri",
           "component": "InputLookupSinopia"
+        },
+        {
+         "authorities": [],
+         "component": "InputLiteral",
+         "defaults": [
+           {
+             "lang": null,
+             "literal": "Default required literal1"
+           },
+           {
+             "lang": null,
+             "literal": "Default required literal2"
+           }
+         ],
+         "key": "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property20",
+         "label": "Uber template1, property20",
+         "ordered": false,
+         "remark": "A required, repeatable literal with defaults.",
+         "remarkUrl": null,
+         "repeatable": false,
+         "required": true,
+         "subjectTemplateKey": "resourceTemplate:testing:uber1",
+         "type": "literal",
+         "uri": "http://id.loc.gov/ontologies/bibframe/uber/template1/property20",
+         "valueSubjectTemplateKeys": []
         }
       ]
     },
@@ -696,7 +722,7 @@
         "resourceKey": "abc0",
         "values": [
           {
-            "key": "abc31",
+            "key": "abc34",
             "resourceKey": "abc0",
             "literal": null,
             "lang": null,
@@ -739,7 +765,7 @@
               "resourceKey": "abc0",
               "properties": [
                 {
-                  "key": "abc30",
+                  "key": "abc33",
                   "resourceKey": "abc0",
                   "values": [],
                   "show": true
@@ -785,6 +811,31 @@
         "resourceKey": "abc0",
         "values": null,
         "show": false
+      },
+      {
+        "key": "abc30",
+        "resourceKey": "abc0",
+        "show": true,
+        "values": [
+          {
+            "key": "abc31",
+            "resourceKey": "abc0",
+            "literal": "Default required literal1",
+            "lang": null,
+            "uri": null,
+            "label": null,
+            "valueSubject": null
+          },
+          {
+            "key": "abc32",
+            "resourceKey": "abc0",
+            "literal": "Default required literal2",
+            "lang": null,
+            "uri": null,
+            "label": null,
+            "valueSubject": null
+          }
+        ]
       }
     ]
   }

--- a/__tests__/__action_fixtures__/newResourceFromDataset-ADD_SUBJECT.json
+++ b/__tests__/__action_fixtures__/newResourceFromDataset-ADD_SUBJECT.json
@@ -36,7 +36,8 @@
         "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/hasInstance",
         "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/instanceOf",
         "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/hasItem",
-        "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/itemOf"
+        "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/itemOf",
+        "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property20"
       ],
       "propertyTemplates": [
         {
@@ -546,7 +547,32 @@
           ],
           "type": "uri",
           "component": "InputLookupSinopia"
-        }
+        },
+        {
+           "authorities": [],
+           "component": "InputLiteral",
+           "defaults": [
+             {
+               "lang": null,
+               "literal": "Default required literal1"
+             },
+             {
+               "lang": null,
+               "literal": "Default required literal2"
+             }
+           ],
+           "key": "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property20",
+           "label": "Uber template1, property20",
+           "ordered": false,
+           "remark": "A required, repeatable literal with defaults.",
+           "remarkUrl": null,
+           "repeatable": false,
+           "required": true,
+           "subjectTemplateKey": "resourceTemplate:testing:uber1",
+           "type": "literal",
+           "uri": "http://id.loc.gov/ontologies/bibframe/uber/template1/property20",
+           "valueSubjectTemplateKeys": []
+         }
       ]
     },
     "resourceKey": "abc0",
@@ -556,14 +582,14 @@
         "resourceKey": "abc0",
         "values": [
           {
-            "key": "abc43",
+            "key": "abc44",
             "resourceKey": "abc0",
             "literal": null,
             "lang": null,
             "uri": null,
             "label": null,
             "valueSubject": {
-              "key": "abc32",
+              "key": "abc33",
               "uri": null,
               "subjectTemplate": {
                 "key": "resourceTemplate:testing:uber3",
@@ -616,11 +642,11 @@
               "resourceKey": "abc0",
               "properties": [
                 {
-                  "key": "abc35",
+                  "key": "abc36",
                   "resourceKey": "abc0",
                   "values": [
                     {
-                      "key": "abc39",
+                      "key": "abc40",
                       "resourceKey": "abc0",
                       "literal": "Uber template3, property1",
                       "lang": "eng",
@@ -632,11 +658,11 @@
                   "show": false
                 },
                 {
-                  "key": "abc36",
+                  "key": "abc37",
                   "resourceKey": "abc0",
                   "values": [
                     {
-                      "key": "abc40",
+                      "key": "abc41",
                       "resourceKey": "abc0",
                       "literal": "Uber template3, property2",
                       "lang": "eng",
@@ -651,14 +677,14 @@
             }
           },
           {
-            "key": "abc44",
+            "key": "abc45",
             "resourceKey": "abc0",
             "literal": null,
             "lang": null,
             "uri": null,
             "label": null,
             "valueSubject": {
-              "key": "abc33",
+              "key": "abc34",
               "uri": null,
               "subjectTemplate": {
                 "key": "resourceTemplate:testing:uber2",
@@ -694,11 +720,11 @@
               "resourceKey": "abc0",
               "properties": [
                 {
-                  "key": "abc37",
+                  "key": "abc38",
                   "resourceKey": "abc0",
                   "values": [
                     {
-                      "key": "abc41",
+                      "key": "abc42",
                       "resourceKey": "abc0",
                       "literal": "Uber template2, property1",
                       "lang": "eng",
@@ -713,23 +739,23 @@
             }
           },
           {
-            "key": "abc45",
+            "key": "abc46",
             "resourceKey": "abc0",
             "literal": null,
             "lang": null,
             "uri": null,
             "label": null,
             "valueSubject": {
-              "key": "abc34",
+              "key": "abc35",
               "uri": null,
               "resourceKey": "abc0",
               "properties": [
                 {
-                  "key": "abc38",
+                  "key": "abc39",
                   "resourceKey": "abc0",
                   "values": [
                     {
-                      "key": "abc42",
+                      "key": "abc43",
                       "resourceKey": "abc0",
                       "literal": "Uber template2, property1b",
                       "lang": "eng",
@@ -751,7 +777,7 @@
         "resourceKey": "abc0",
         "values": [
           {
-            "key": "abc28",
+            "key": "abc29",
             "resourceKey": "abc0",
             "literal": "Uber template1, property2",
             "lang": "eng",
@@ -773,7 +799,7 @@
         "resourceKey": "abc0",
         "values": [
           {
-            "key": "abc29",
+            "key": "abc30",
             "resourceKey": "abc0",
             "literal": "Uber template1, property4",
             "lang": "eng",
@@ -789,7 +815,7 @@
         "resourceKey": "abc0",
         "values": [
           {
-            "key": "abc30",
+            "key": "abc31",
             "resourceKey": "abc0",
             "literal": null,
             "lang": null,
@@ -805,7 +831,7 @@
         "resourceKey": "abc0",
         "values": [
           {
-            "key": "abc31",
+            "key": "abc32",
             "resourceKey": "abc0",
             "literal": null,
             "lang": null,
@@ -887,7 +913,7 @@
         "resourceKey": "abc0",
         "values": [
           {
-            "key": "abc27",
+            "key": "abc28",
             "resourceKey": "abc0",
             "literal": null,
             "lang": null,
@@ -930,7 +956,7 @@
               "resourceKey": "abc0",
               "properties": [
                 {
-                  "key": "abc26",
+                  "key": "abc27",
                   "resourceKey": "abc0",
                   "values": [],
                   "show": true
@@ -976,6 +1002,12 @@
         "resourceKey": "abc0",
         "values": null,
         "show": false
+      },
+      {
+        "key": "abc26",
+        "resourceKey": "abc0",
+        "show": true,
+        "values": []
       }
     ]
   }

--- a/__tests__/__template_fixtures__/uber_template1.json
+++ b/__tests__/__template_fixtures__/uber_template1.json
@@ -1031,6 +1031,61 @@
     ]
   },
   {
+    "@id": "_:b70",
+    "@type": [
+      "http://sinopia.io/vocabulary/PropertyTemplate"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Uber template1, property20"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasRemark": [
+      {
+        "@value": "A required, repeatable literal with defaults."
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyUri": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/uber/template1/property20"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyAttribute": [
+      {
+        "@id": "http://sinopia.io/vocabulary/propertyAttribute/repeatable"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyAttribute": [
+      {
+        "@id": "http://sinopia.io/vocabulary/propertyAttribute/required"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyType": [
+      {
+        "@id": "http://sinopia.io/vocabulary/propertyType/literal"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasLiteralAttributes": [
+      {
+        "@id": "_:b71"
+      }
+    ]
+  },
+  {
+    "@id": "_:b71",
+    "@type": [
+      "http://sinopia.io/vocabulary/LiteralPropertyTemplate"
+    ],
+    "http://sinopia.io/vocabulary/hasDefault": [
+      {
+        "@value": "Default required literal1"
+      },
+      {
+        "@value": "Default required literal2"
+      }
+    ]
+  },
+  {
     "@id": "_:b8",
     "@type": [
       "http://sinopia.io/vocabulary/PropertyTemplate"
@@ -1189,6 +1244,9 @@
           },
           {
             "@id": "_:b68"
+          },
+          {
+            "@id": "_:b70"
           }
         ]
       }

--- a/__tests__/feature/editing/addRemove.test.js
+++ b/__tests__/feature/editing/addRemove.test.js
@@ -20,7 +20,7 @@ describe('adding and removing properties', () => {
     await screen.findByText('Uber template1', { selector: 'h3' })
 
     // Add a panel property
-    expect(screen.getAllByText(/Uber template1, property2/)).toHaveLength(2)
+    expect(screen.getAllByText(/Uber template1, property2$/)).toHaveLength(2) // do not want to match property20!
     fireEvent.click(screen.getByTestId('Add Uber template1, property2'))
 
     // Input box displayed

--- a/__tests__/feature/loadNewResource.test.js
+++ b/__tests__/feature/loadNewResource.test.js
@@ -37,6 +37,8 @@ describe('loading new resource', () => {
     screen.getByText('Default literal2')
     screen.getByText('Default URI1')
     screen.getByText('http://sinopia.io/defaultURI2')
+    screen.getByText('Default required literal1')
+    screen.getByText('Default required literal2')
 
     // Required properties are expanded.
     screen.getByPlaceholderText('Uber template1, property4')

--- a/__tests__/feature/previewRdf.test.js
+++ b/__tests__/feature/previewRdf.test.js
@@ -8,7 +8,8 @@ global.$ = jest.fn().mockReturnValue({ popover: jest.fn() })
 
 jest.spyOn(Config, 'useResourceTemplateFixtures', 'get').mockReturnValue(true)
 
-const rdf = `<> <http://id.loc.gov/ontologies/bibframe/uber/template1/property7> "Default literal1", "Default literal2";
+const rdf = `<> <http://id.loc.gov/ontologies/bibframe/uber/template1/property20> "Default required literal1", "Default required literal2";
+    <http://id.loc.gov/ontologies/bibframe/uber/template1/property7> "Default literal1", "Default literal2";
     <http://id.loc.gov/ontologies/bibframe/uber/template1/property8> <http://sinopia.io/defaultURI1>, <http://sinopia.io/defaultURI2>;
     <http://sinopia.io/vocabulary/hasResourceTemplate> "resourceTemplate:testing:uber1";
     a <http://id.loc.gov/ontologies/bibframe/Uber1>.

--- a/cypress/fixtures/uber_template1.txt
+++ b/cypress/fixtures/uber_template1.txt
@@ -1076,6 +1076,61 @@
     ]
   },
   {
+    "@id": "_:b70",
+    "@type": [
+      "http://sinopia.io/vocabulary/PropertyTemplate"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Uber template1, property20"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasRemark": [
+      {
+        "@value": "A required, repeatable literal with defaults."
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyUri": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/uber/template1/property20"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyAttribute": [
+      {
+        "@id": "http://sinopia.io/vocabulary/propertyAttribute/repeatable"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyAttribute": [
+      {
+        "@id": "http://sinopia.io/vocabulary/propertyAttribute/required"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyType": [
+      {
+        "@id": "http://sinopia.io/vocabulary/propertyType/literal"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasLiteralAttributes": [
+      {
+        "@id": "_:b71"
+      }
+    ]
+  },
+  {
+    "@id": "_:b71",
+    "@type": [
+      "http://sinopia.io/vocabulary/LiteralPropertyTemplate"
+    ],
+    "http://sinopia.io/vocabulary/hasDefault": [
+      {
+        "@value": "Default required literal1"
+      },
+      {
+        "@value": "Default required literal2"
+      }
+    ]
+  },
+  {
     "@id": "http://localhost:3000/resource/resourceTemplate:testing:uber1",
     "http://sinopia.io/vocabulary/hasResourceTemplate": [
       {

--- a/src/actionCreators/resourceHelpers.js
+++ b/src/actionCreators/resourceHelpers.js
@@ -195,8 +195,8 @@ const newProperty = (subject, propertyTemplate, noDefaults, errorKey) => (dispat
     property.show = true
   }
 
-  // If required, then expand the property.
-  if (propertyTemplate.required) {
+  // If required and we do not already have some default values, then expand the property.
+  if (propertyTemplate.required && !property.values) {
     property.show = true
     return dispatch(valuesForExpandedProperty(property, noDefaults, errorKey))
       .then((values) => {


### PR DESCRIPTION
## Why was this change made?

Fixes #2371

## How was this change tested?

Added a new property template literal field that has required and default values and confirmed they show up on the page and in the preview RDF.  Had to modify existing tests to account for this new field.

## Which documentation and/or configurations were updated?

None
