### PR TITLE
ensure expanded field has default values if they exist

### DIFF
--- a/__tests__/actionCreators/resources.test.js
+++ b/__tests__/actionCreators/resources.test.js
@@ -450,6 +450,6 @@ describe('contractProperty', () => {
   it('removes a property values from state', async () => {
     await store.dispatch(contractProperty('JQEtq-vmq8'))
     const actions = store.getActions()
-    expect(actions).toHaveAction('REMOVE_PROPERTY')
+    expect(actions).toHaveAction('ADD_PROPERTY')
   })
 })

--- a/__tests__/feature/editing/addRemove.test.js
+++ b/__tests__/feature/editing/addRemove.test.js
@@ -117,4 +117,43 @@ describe('adding and removing properties', () => {
     // Delete button removed
     expect(screen.queryAllByTestId('Remove Uber template2, property1')).toHaveLength(0)
   }, 15000)
+
+  it('removes and adds a required property with defaults, leaving the defaults but deleting the user entered literal', async () => {
+    renderApp(null, history)
+
+    const literalText = 'bogus in property 7'
+
+    await screen.findByText('Uber template1', { selector: 'h3' })
+
+    // Verify defaults for propert7 are shown
+    expect(screen.queryAllByText('Default literal1')).toHaveLength(1)
+    expect(screen.queryAllByText('Default literal2')).toHaveLength(1)
+
+    // Enter a new literal value
+    const input = screen.getByPlaceholderText('Uber template1, property7')
+    fireEvent.change(input, { target: { value: literalText } })
+    fireEvent.keyPress(input, { key: 'Enter', code: 13, charCode: 13 })
+
+    // Bogus literal is there
+    await waitFor(() => expect(screen.getByText(literalText)).toHaveClass('rbt-token'))
+
+    // Now remove property7.
+    fireEvent.click(screen.getByTestId('Remove Uber template1, property7'))
+
+    // Verify defaults and bogus literal for propert7 are gone
+    expect(screen.queryAllByText('Default literal1')).toHaveLength(0)
+    expect(screen.queryAllByText('Default literal2')).toHaveLength(0)
+    expect(screen.queryAllByText(literalText)).toHaveLength(0)
+
+    // Remove button removed.
+    expect(screen.queryAllByTestId('Remove Uber template1, property7')).toHaveLength(0)
+
+    // Now add back property7.
+    fireEvent.click(screen.getByTestId('Add Uber template1, property7'))
+
+    // Verify defaults for propert7 are back again but user entered literal is gone
+    expect(screen.queryAllByText('Default literal1')).toHaveLength(1)
+    expect(screen.queryAllByText('Default literal2')).toHaveLength(1)
+    expect(screen.queryAllByText(literalText)).toHaveLength(0)
+  }, 15000)
 })

--- a/__tests__/reducers/resources.test.js
+++ b/__tests__/reducers/resources.test.js
@@ -2,7 +2,7 @@
 
 import {
   addProperty, addSubject, addValue, clearResource,
-  hideProperty, removeProperty, removeSubject,
+  hideProperty, removeSubject,
   removeValue, saveResourceFinished, setBaseURL, setCurrentResource,
   setUnusedRDF, showProperty, loadResourceFinished, setResourceGroup,
   setValueOrder,
@@ -18,7 +18,6 @@ const reducers = {
   CLEAR_RESOURCE: clearResource,
   HIDE_PROPERTY: hideProperty,
   LOAD_RESOURCE_FINISHED: loadResourceFinished,
-  REMOVE_PROPERTY: removeProperty,
   REMOVE_SUBJECT: removeSubject,
   REMOVE_VALUE: removeValue,
   SAVE_RESOURCE_FINISHED: saveResourceFinished,
@@ -515,22 +514,6 @@ describe('hideProperty()', () => {
 
     const newState = reducer(oldState, action)
     expect(newState.entities.properties['kqKVn-1TbC'].show).toBeFalsy()
-  })
-})
-
-describe('removeProperty()', () => {
-  it('removes a property from a subject', () => {
-    const oldState = createState({ hasResourceWithLiteral: true })
-    const action = {
-      type: 'REMOVE_PROPERTY',
-      payload: 'JQEtq-vmq8',
-    }
-
-    const newState = reducer(oldState.selectorReducer, action)
-    expect(newState.entities.properties['JQEtq-vmq8']).toBe(undefined)
-    expect(newState.entities.subjects.t9zVwg2zO.propertyKeys).not.toContain('JQEtq-vmq8')
-    expect(newState.entities.values.CxGx7WMh2).toBe(undefined)
-    expect(newState.entities.subjects.t9zVwg2zO.changed).toBe(true)
   })
 })
 

--- a/src/actionCreators/resourceHelpers.js
+++ b/src/actionCreators/resourceHelpers.js
@@ -186,13 +186,8 @@ const newProperty = (subject, propertyTemplate, noDefaults, errorKey) => (dispat
     show: false,
   }
   if (!noDefaults && !_.isEmpty(property.propertyTemplate.defaults)) {
-    property.values = property.propertyTemplate.defaults.map((defaultValue) => {
-      if (property.propertyTemplate.type === 'uri') {
-        return newUriValue(property, defaultValue.uri, defaultValue.label)
-      }
-      return newLiteralValue(property, defaultValue.literal, defaultValue.lang)
-    })
-    property.show = true
+    property.values = defaultValuesFor(property)
+    if (!_.isEmpty(property.values)) property.show = true
   }
 
   // If required and we do not already have some default values, then expand the property.
@@ -206,6 +201,15 @@ const newProperty = (subject, propertyTemplate, noDefaults, errorKey) => (dispat
   }
 
   return property
+}
+
+export function defaultValuesFor(property) {
+  return property.propertyTemplate.defaults.map((defaultValue) => {
+    if (property.propertyTemplate.type === 'uri') {
+      return newUriValue(property, defaultValue.uri, defaultValue.label)
+    }
+    return newLiteralValue(property, defaultValue.literal, defaultValue.lang)
+  })
 }
 
 const valuesForExpandedProperty = (property, noDefaults, errorKey) => (dispatch) => {

--- a/src/actionCreators/resources.js
+++ b/src/actionCreators/resources.js
@@ -4,6 +4,7 @@ import { findRootResourceTemplateId } from 'utilities/Utilities'
 import {
   addResourceFromDataset, addEmptyResource, newSubject,
   newSubjectCopy, newPropertiesFromTemplates, chooseURI,
+  defaultValuesFor,
 } from './resourceHelpers'
 import { fetchResource, putResource, postResource } from 'sinopiaApi'
 import {
@@ -13,10 +14,11 @@ import {
   addProperty as addPropertyAction,
   addValue as addValueAction, addSubject as addSubjectAction,
   showProperty, setBaseURL, setCurrentResource, saveResourceFinished,
-  setUnusedRDF, loadResourceFinished, setResourceGroup, removeProperty,
+  setUnusedRDF, loadResourceFinished, setResourceGroup,
 } from 'actions/resources'
 import { newValueSubject } from 'utilities/valueFactory'
 import { selectUser } from 'selectors/authenticate'
+import _ from 'lodash'
 
 /**
  * A thunk that loads an existing resource from Sinopia API and adds to state.
@@ -173,7 +175,8 @@ export const expandProperty = (propertyKey, errorKey) => (dispatch, getState) =>
           return dispatch(addValueAction(newValue))
         })))
   } else {
-    property.values = []
+    property.values = defaultValuesFor(property)
+    if (!_.isEmpty(property.values)) property.show = true
     promises = [dispatch(addPropertyAction(property))]
   }
   return Promise.all(promises)
@@ -187,7 +190,6 @@ export const expandProperty = (propertyKey, errorKey) => (dispatch, getState) =>
 export const contractProperty = (propertyKey) => (dispatch, getState) => {
   const property = selectProperty(getState(), propertyKey)
   property.values = null
-  dispatch(removeProperty(propertyKey))
   dispatch(addPropertyAction(property))
 }
 

--- a/src/actionCreators/resources.js
+++ b/src/actionCreators/resources.js
@@ -184,7 +184,7 @@ export const expandProperty = (propertyKey, errorKey) => (dispatch, getState) =>
 }
 
 /**
- * A thunk that removes a property from state (the opposite of expandProperty).
+ * A thunk that clears the values from a property from state (the opposite of expandProperty).
  * Note that this is NOT showing/hiding a property.
  */
 export const contractProperty = (propertyKey) => (dispatch, getState) => {

--- a/src/actions/resources.js
+++ b/src/actions/resources.js
@@ -71,11 +71,6 @@ export const removeSubject = (subjectKey) => ({
   payload: subjectKey,
 })
 
-export const removeProperty = (propertyKey) => ({
-  type: 'REMOVE_PROPERTY',
-  payload: propertyKey,
-})
-
 export const setValueOrder = (valueKey, index) => ({
   type: 'SET_VALUE_ORDER',
   payload: {

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -11,7 +11,7 @@ import {
   setBaseURL, hideProperty, showProperty,
   setUnusedRDF, setCurrentResource,
   addSubject, addProperty, addValue, removeValue,
-  removeProperty, removeSubject, clearResource,
+  removeSubject, clearResource,
   saveResourceFinished, loadResourceFinished,
   setResourceGroup, setValueOrder,
 } from './resources'
@@ -101,7 +101,6 @@ const handlers = {
   ADD_VALUE: addValue,
   REMOVE_VALUE: removeValue,
   REMOVE_SUBJECT: removeSubject,
-  REMOVE_PROPERTY: removeProperty,
 }
 
 const authHandlers = {

--- a/src/reducers/resources.js
+++ b/src/reducers/resources.js
@@ -307,23 +307,6 @@ const removeBibframeRefs = (newState, value, newProperty) => {
   }
 }
 
-export const removeProperty = (state, action) => {
-  const newState = { ...state }
-
-  const property = newState.entities.properties[action.payload]
-
-  // Remove from subject
-  const subject = newState.entities.subjects[property.subjectKey]
-  newState.entities.subjects[property.subjectKey].propertyKeys = subject.propertyKeys.filter((propertyKey) => propertyKey !== action.payload)
-
-  // Recursively remove property
-  clearPropertyFromNewState(newState, property.key)
-
-  newState.entities.subjects[property.resourceKey].changed = true
-
-  return newState
-}
-
 export const removeSubject = (state, action) => {
   const newState = { ...state }
 


### PR DESCRIPTION
## Why was this change made?

Fixes #2371 and #2461 

Get rid of `removeProperty` that does appear to be used anymore.

## How was this change tested?

TODO:
- [x] update ~~`expandContract.test.js`~~ `addRemove.test.js` to verify default values exist after removing and then adding a required field with defaults

## Which documentation and/or configurations were updated?

None
