### PR TITLE
Fix template error

### DIFF
--- a/__tests__/feature/previewRdf.test.js
+++ b/__tests__/feature/previewRdf.test.js
@@ -8,12 +8,14 @@ global.$ = jest.fn().mockReturnValue({ popover: jest.fn() })
 
 jest.spyOn(Config, 'useResourceTemplateFixtures', 'get').mockReturnValue(true)
 
-const rdf = `<> <http://id.loc.gov/ontologies/bibframe/uber/template1/property20> "Default required literal1", "Default required literal2";
+const rdf = `<> <http://sinopia.io/vocabulary/hasResourceTemplate> "resourceTemplate:testing:uber1";
+    a <http://id.loc.gov/ontologies/bibframe/Uber1>;
     <http://id.loc.gov/ontologies/bibframe/uber/template1/property7> "Default literal1", "Default literal2";
-    <http://id.loc.gov/ontologies/bibframe/uber/template1/property8> <http://sinopia.io/defaultURI1>, <http://sinopia.io/defaultURI2>;
-    <http://sinopia.io/vocabulary/hasResourceTemplate> "resourceTemplate:testing:uber1";
-    a <http://id.loc.gov/ontologies/bibframe/Uber1>.
-<http://sinopia.io/defaultURI1> <http://www.w3.org/2000/01/rdf-schema#label> "Default URI1".`
+    <http://id.loc.gov/ontologies/bibframe/uber/template1/property8> <http://sinopia.io/defaultURI1>.
+<http://sinopia.io/defaultURI1> <http://www.w3.org/2000/01/rdf-schema#label> "Default URI1".
+<> <http://id.loc.gov/ontologies/bibframe/uber/template1/property8> <http://sinopia.io/defaultURI2>;
+    <http://id.loc.gov/ontologies/bibframe/uber/template1/property20> "Default required literal1", "Default required literal2".
+`
 
 describe('preview RDF after editing', () => {
   it('adds properties and then displays preview RDF model', async () => {

--- a/src/components/editor/RDFDisplay.jsx
+++ b/src/components/editor/RDFDisplay.jsx
@@ -2,34 +2,26 @@
 
 import React, { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
-import { datasetFromN3, n3FromDataset, jsonldFromDataset } from 'utilities/Utilities'
+import { n3FromDataset, jsonldFromDataset } from 'utilities/Utilities'
 import Alert from '../Alert'
 
 const RDFDisplay = (props) => {
   const [error, setError] = useState(false)
-  const [dataset, setDataset] = useState(false)
-  useEffect(() => {
-    setError(false)
-    datasetFromN3(props.rdf)
-      .then((dataset) => setDataset(dataset))
-      .catch((err) => setError(err.message || err))
-  }, [props.rdf])
-
   const [format, setFormat] = useState('table')
   const [formattedRDF, setFormattedRDF] = useState(false)
   useEffect(() => {
-    if (!dataset || format === 'table') return
+    if (!props.dataset || format === 'table') return
     setError(false)
     if (format === 'jsonld') {
-      jsonldFromDataset(dataset)
+      jsonldFromDataset(props.dataset)
         .then((result) => setFormattedRDF(JSON.stringify(result, null, 2)))
         .catch((err) => setError(err.message || err))
     } else {
-      n3FromDataset(dataset, format)
+      n3FromDataset(props.dataset, format)
         .then((result) => setFormattedRDF(result.replace(/<null>/g, '<>')))
         .catch((err) => setError(err.message || err))
     }
-  }, [dataset, format])
+  }, [props.dataset, format])
 
   if (error) {
     return (<Alert text={error} />)
@@ -38,13 +30,10 @@ const RDFDisplay = (props) => {
   if (format !== 'table' && !formattedRDF) {
     return null
   }
-  if (format === 'table' && !dataset) {
-    return null
-  }
 
   let body
   if (format === 'table') {
-    const rows = dataset.toArray().map((quad) => <tr key={[quad.subject.value, quad.predicate.value, quad.object.value].concat('-')}>
+    const rows = props.dataset.toArray().map((quad) => <tr key={[quad.subject.value, quad.predicate.value, quad.object.value].concat('-')}>
       <td>{quad.subject.value || '<>'}</td>
       <td>{quad.predicate.value}</td>
       <td>{quad.object.value}{quad.object.language && ` [${quad.object.language}]`}</td>
@@ -88,7 +77,7 @@ const RDFDisplay = (props) => {
 }
 
 RDFDisplay.propTypes = {
-  rdf: PropTypes.string,
+  dataset: PropTypes.object.isRequired,
   id: PropTypes.string,
 }
 

--- a/src/components/editor/RDFModal.jsx
+++ b/src/components/editor/RDFModal.jsx
@@ -42,7 +42,7 @@ const RDFModal = (props) => {
               </div>
             </div>
             { props.show
-              && <RDFDisplay rdf={props.rdf()} />
+              && <RDFDisplay dataset={props.dataset()} />
             }
           </div>
         </div>
@@ -55,11 +55,13 @@ const RDFModal = (props) => {
 RDFModal.propTypes = {
   show: PropTypes.bool,
   rdf: PropTypes.func,
+  dataset: PropTypes.func,
 }
 
 const mapStateToProps = (state) => ({
   show: selectModalType(state) === 'RDFModal',
-  rdf: () => new GraphBuilder(selectFullSubject(state, selectCurrentResourceKey(state))).graph.toCanonical(),
+  dataset: () => new GraphBuilder(selectFullSubject(state, selectCurrentResourceKey(state))).graph,
 })
+
 
 export default connect(mapStateToProps, null)(RDFModal)

--- a/src/selectors/modals.js
+++ b/src/selectors/modals.js
@@ -3,3 +3,5 @@
 export const selectModalType = (state) => state.selectorReducer.editor.modal.name
 
 export const selectModalMessages = (state) => state.selectorReducer.editor.modal.messages
+
+export const selectUnusedRDF = (state, resourceKey) => state.selectorReducer.editor.unusedRDF[resourceKey]


### PR DESCRIPTION
## Why was this change made?
Fixes #2424. RDFDisplay should receive a dataset instead of an RDF string to avoid overloading the browser memory when calling the `toCannonical` method on the rdf dataset. Adds a selector in `selectors/modals` to set the unusedRDF state.

## How was this change tested?
Updated tests for previewRDF and RDFDisplay components.

## Which documentation and/or configurations were updated?


