### PR TITLE
Remove ids that are not unique in the document

### DIFF
--- a/src/components/editor/property/InputValue.jsx
+++ b/src/components/editor/property/InputValue.jsx
@@ -19,7 +19,7 @@ const InputValue = (props) => {
     props.removeValue(props.valueKey)
   }
 
-  return (<div id="userInput" style={{ marginTop: '.25em' }}>
+  return (<div className="input-value">
     <div
       className="rbt-token rbt-token-removeable">
       {label}
@@ -32,7 +32,6 @@ const InputValue = (props) => {
       </button>
     </div>
     <button
-      id="editItem"
       onClick={handleEditClick}
       style={ { marginRight: '.25em' } }
       aria-label={`Edit ${label}`}

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -251,6 +251,10 @@ div.rbt-input-multi {
   height: auto;
 }
 
+.input-value {
+  marginTop: .25em;
+}
+
 .rdf-modal-content {
   padding: 20px 25px 20px 20px;
 }


### PR DESCRIPTION
Move styles to stylesheet

## Why was this change made?
Having multiple instances of an id is not permitted.  Stylesheets is the best place for static styles.


## How was this change tested?



## Which documentation and/or configurations were updated?



