### PR TITLE
Use proper resultsPerPage variable for templates

### DIFF
--- a/src/reducers/search.js
+++ b/src/reducers/search.js
@@ -47,7 +47,7 @@ export const setTemplateSearchResults = (state, action) => {
   newState.templateSearch.results = action.payload.searchResults
   newState.templateSearch.totalResults = action.payload.totalResults
   newState.templateSearch.options = { ...action.payload.options }
-  if (newState.templateSearch.options.resultsPerPage === undefined) newState.templateSearch.options.resultsPerPage = Config.searchResultsPerPage
+  if (newState.templateSearch.options.resultsPerPage === undefined) newState.templateSearch.options.resultsPerPage = Config.templateSearchResultsPerPage
 
   newState.templateSearch.error = action.payload.error
 


### PR DESCRIPTION
## Why was this change made?

Fixes #2050 by setting the proper templateSearchResultsPerPage variable to be used instead of searchResultsPerPage.

## How was this change tested?

Manually

## Which documentation and/or configurations were updated?

N/A


