### PR TITLE
Change background color for resources in editor

### DIFF
--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -14,7 +14,9 @@ $theme-colors: (
   "danger": #b1020f
 );
 $enable-validation-icons: false;
-
+$prop-heading-bg: #B26F16;
+$prop-heading-color: white;
+$prop-panel-bg: #F7F4F1;
 
 $lookup-value-bg: #E8E2DC;
 
@@ -138,8 +140,8 @@ $primary-disabled: lighten( map-get($theme-colors,"secondary"), 20% );
 }
 
 .prop-heading {
-  background-color: #8C8A83 !important;
-  color: white !important;
+  background-color: $prop-heading-bg !important;
+  color: $prop-heading-color !important;
 }
 
 .prop-heading > span {
@@ -148,10 +150,7 @@ $primary-disabled: lighten( map-get($theme-colors,"secondary"), 20% );
 }
 
 .panel-property {
-  border-color: #8C8A83;
-  border-style: solid;
-  border-width: 1px;
-  background-color: #F8F6EF;
+  background-color: $prop-panel-bg;
   break-inside: avoid;
 }
 


### PR DESCRIPTION
## Why was this change made?

Part of #2439 - Changes the background color of the card header and panel, and removed the border:

BEFORE:

![Screen Shot 2020-09-14 at 3 09 36 PM](https://user-images.githubusercontent.com/2294288/93143264-6e0e8d80-f69c-11ea-9e57-f153c472340e.png)

AFTER:

<img width="636" alt="Screen Shot 2020-09-15 at 8 44 08 AM" src="https://user-images.githubusercontent.com/2294288/93233267-b925b080-f72f-11ea-95c9-31ff60598fc7.png">


## How was this change tested?

N/A

## Which documentation and/or configurations were updated?

N/A
