### PR TITLE
Consolidate search utility functions

### DIFF
--- a/src/components/editor/property/InputLookupQA.jsx
+++ b/src/components/editor/property/InputLookupQA.jsx
@@ -2,40 +2,15 @@
 
 import React from 'react'
 import PropTypes from 'prop-types'
-import shortid from 'shortid'
 import { getSearchResults } from 'utilities/QuestioningAuthority'
+import { getQAOptions } from 'utilities/Search'
+
 import InputLookupModal from './InputLookupModal'
 
-const InputLookupQA = (props) => {
-  const getOptions = (results) => {
-    const options = []
-    results.forEach((result) => {
-      const authLabel = result.authLabel
-      const authURI = result.authURI
-      options.push({
-        authURI,
-        authLabel,
-        label: authLabel,
-      })
-      if (result.isError) {
-        options.push({
-          isError: true,
-          label: result.errorObject.message,
-          id: shortid.generate(),
-        })
-        return
-      }
-      result.body.results.forEach((option) => {
-        options.push(option)
-      })
-    })
-    return options
-  }
+const InputLookupQA = (props) => (
+  <InputLookupModal getLookupResults={getSearchResults} getOptions={getQAOptions} property={props.property} />
+)
 
-  return (
-    <InputLookupModal getLookupResults={getSearchResults} getOptions={getOptions} property={props.property} />
-  )
-}
 
 InputLookupQA.propTypes = {
   property: PropTypes.object.isRequired,

--- a/src/components/editor/property/InputLookupSinopia.jsx
+++ b/src/components/editor/property/InputLookupSinopia.jsx
@@ -1,45 +1,20 @@
 // Copyright 2019 Stanford University see LICENSE for license
 
 import React from 'react'
-import shortid from 'shortid'
 import PropTypes from 'prop-types'
 import { getLookupResults } from 'sinopiaSearch'
+import { getSinopiaOptions } from 'utilities/Search'
+
 import ResourceList from './ResourceList'
 import InputLookupModal from './InputLookupModal'
 
-const InputLookupSinopia = (props) => {
-  const getOptions = (results) => {
-    const options = []
-    results.forEach((result) => {
-      const authLabel = result.authLabel
-      const authURI = result.authURI
-      options.push({
-        authURI,
-        authLabel,
-        label: authLabel,
-      })
-      if (result.error) {
-        options.push({
-          isError: true,
-          label: result.error,
-          id: shortid.generate(),
-        })
-        return
-      }
-      result.results.forEach((option) => {
-        options.push(option)
-      })
-    })
-    return options
-  }
+const InputLookupSinopia = (props) => (
+  <React.Fragment>
+    <InputLookupModal getLookupResults={getLookupResults} getOptions={getSinopiaOptions} property={props.property} />
+    <ResourceList property={props.property} />
+  </React.Fragment>
+)
 
-  return (
-    <React.Fragment>
-      <InputLookupModal getLookupResults={getLookupResults} getOptions={getOptions} property={props.property} />
-      <ResourceList property={props.property} />
-    </React.Fragment>
-  )
-}
 
 InputLookupSinopia.propTypes = {
   property: PropTypes.object.isRequired,

--- a/src/utilities/Search.js
+++ b/src/utilities/Search.js
@@ -1,0 +1,31 @@
+// Copyright 2020 Stanford University see LICENSE for license
+
+import shortid from 'shortid'
+
+export const getQAOptions = (results) => getOptions(results, (result) => result.body.results)
+export const getSinopiaOptions = (results) => getOptions(results, (result) => result.results)
+
+const getOptions = (results, getResults) => {
+  const options = []
+  results.forEach((result) => {
+    const authLabel = result.authLabel
+    const authURI = result.authURI
+    options.push({
+      authURI,
+      authLabel,
+      label: authLabel,
+    })
+    if (result.isError) {
+      options.push({
+        isError: true,
+        label: result.errorObject.message,
+        id: shortid.generate(),
+      })
+      return
+    }
+    getResults(result).forEach((option) => {
+      options.push(option)
+    })
+  })
+  return options
+}


### PR DESCRIPTION
And remove them from the components

## Why was this change made?

These utility functions share similar logic and are business logic, so they don't belong in the view layer.

## How was this change tested?



## Which documentation and/or configurations were updated?



