### PR TITLE
Do not add root resource template ID to history

### DIFF
--- a/__tests__/reducers/templates.test.js
+++ b/__tests__/reducers/templates.test.js
@@ -2,6 +2,7 @@
 
 import { addTemplateHistory, addTemplates } from 'reducers/templates'
 import { createState } from 'stateUtils'
+import Config from 'Config'
 
 describe('addTemplateHistory', () => {
   it('adds items uniquely', () => {
@@ -21,6 +22,14 @@ describe('addTemplateHistory', () => {
 
     expect(newState.historicalTemplates).toEqual(['template2', 'template3',
       'template4', 'template5', 'template6', 'template7', 'template8'])
+  })
+
+  it('does not add root resource template to history', () => {
+    let state = addTemplateHistory(createState().selectorReducer, { payload: 'template1' })
+    state = addTemplateHistory(state, { payload: Config.rootResourceTemplateId })
+    state = addTemplateHistory(state, { payload: 'template2' })
+
+    expect(state.historicalTemplates).toEqual(['template1', 'template2'])
   })
 })
 

--- a/src/Config.js
+++ b/src/Config.js
@@ -1,6 +1,10 @@
 // Copyright 2019 Stanford University see LICENSE for license
 
 class Config {
+  static get rootResourceTemplateId() {
+    return process.env.ROOT_RESOURCE_TEMPLATE_ID || 'sinopia:template:resource'
+  }
+
   static get sinopiaApiBase() {
     return process.env.SINOPIA_API_BASE_URL || 'http://localhost:3000'
   }

--- a/src/components/templates/NewResourceTemplateButton.jsx
+++ b/src/components/templates/NewResourceTemplateButton.jsx
@@ -11,6 +11,7 @@ import { newResource } from 'actionCreators/resources'
 import { selectErrors } from 'selectors/errors'
 import { selectCurrentResource } from 'selectors/resources'
 import _ from 'lodash'
+import Config from 'Config'
 
 const NewResourceTemplateButton = (props) => {
   const dispatch = useDispatch()
@@ -30,7 +31,7 @@ const NewResourceTemplateButton = (props) => {
 
   const handleClick = (event) => {
     event.preventDefault()
-    dispatch(newResource('sinopia:template:resource', newResourceErrorKey)).then((result) => {
+    dispatch(newResource(Config.rootResourceTemplateId, newResourceErrorKey)).then((result) => {
       setNavigateEditor(result)
     })
   }

--- a/src/reducers/templates.js
+++ b/src/reducers/templates.js
@@ -1,11 +1,18 @@
 // Copyright 2019 Stanford University see LICENSE for license
 
+import Config from 'Config'
+
 // Keeps a unique list of templates limited to 7
 export const addTemplateHistory = (state, action) => {
   const newState = { ...state }
-  if (newState.historicalTemplates.indexOf(action.payload) !== -1) return newState
+  const template = action.payload
 
-  newState.historicalTemplates = [...state.historicalTemplates, action.payload].slice(-7)
+  if (newState.historicalTemplates.indexOf(template) !== -1
+      || template === Config.rootResourceTemplateId) {
+    return newState
+  }
+
+  newState.historicalTemplates = [...state.historicalTemplates, template].slice(-7)
   return newState
 }
 

--- a/src/sinopiaApi.js
+++ b/src/sinopiaApi.js
@@ -1,7 +1,7 @@
 // Copyright 2019 Stanford University see LICENSE for license
 
 import { datasetFromJsonld, jsonldFromDataset } from 'utilities/Utilities'
-import Config from './Config'
+import Config from 'Config'
 /* eslint-disable node/no-unpublished-import */
 import { hasFixtureResource, getFixtureResource } from '../__tests__/testUtilities/fixtureLoaderHelper'
 import GraphBuilder from 'GraphBuilder'
@@ -115,7 +115,7 @@ const saveBodyForResource = (resource, user, group) => {
     }))
 }
 
-const isTemplate = (resource) => resource.subjectTemplate.id === 'sinopia:template:resource'
+const isTemplate = (resource) => resource.subjectTemplate.id === Config.rootResourceTemplateId
 
 const templateIdFor = (resource) => {
   const resourceIdProperty = resource.properties.find((property) => property.propertyTemplate.uri === 'http://sinopia.io/vocabulary/hasResourceId')

--- a/src/sinopiaSearch.js
+++ b/src/sinopiaSearch.js
@@ -1,5 +1,5 @@
 // Copyright 2019 Stanford University see LICENSE for license
-import Config from './Config'
+import Config from 'Config'
 /* eslint-disable node/no-unpublished-import */
 import {
   getFixtureTemplateSearchResults, hasFixtureResource, resourceSearchResults,


### PR DESCRIPTION
Fixes #2510

## Why was this change made?

To prevent showing the root resource template in the editor history.

Includes:
* Add root resource template ID to configuration
* Import config consistently across the app
* Do not add root resource template ID to history

## How was this change tested?

CI. 

**NOTE**: I can't get the containers to spin up without using up all available swap space on my laptop, so I am limited in my testing until new RAM shows up. Can someone pull down this branch and test it for me?

## Which documentation and/or configurations were updated?

Added a config for root resource template ID.

