### PR TITLE
Move more out of selectorReducer

### DIFF
--- a/__tests__/actionCreators/exports.test.js
+++ b/__tests__/actionCreators/exports.test.js
@@ -18,7 +18,7 @@ describe('export', () => {
     beforeEach(() => global.fetch = jest.fn().mockImplementation(() => mockFetchPromise))
 
     it('dispatches actions', async () => {
-      const store = mockStore({ selectorReducer: { entities: { exports: [] } } })
+      const store = mockStore({ entities: { exports: [] } })
       await store.dispatch(fetchExports('testerrorkey'))
       expect(store.getActions()).toEqual([
         { type: 'CLEAR_ERRORS', payload: 'testerrorkey' },
@@ -39,7 +39,7 @@ describe('export', () => {
     beforeEach(() => global.fetch = jest.fn().mockImplementation(() => mockFetchPromise))
 
     it('dispatches actions', async () => {
-      const store = mockStore({ selectorReducer: { entities: { exports: [] } } })
+      const store = mockStore({ entities: { exports: [] } })
       await store.dispatch(fetchExports('testerrorkey'))
       expect(store.getActions()).toEqual([
         { type: 'CLEAR_ERRORS', payload: 'testerrorkey' },

--- a/__tests__/actionCreators/languages.test.js
+++ b/__tests__/actionCreators/languages.test.js
@@ -21,8 +21,6 @@ describe('fetchLanguages', () => {
   it('dispatches actions', async () => {
     await store.dispatch(fetchLanguages())
     const actions = store.getActions()
-    expect(actions.length).toEqual(2)
-    expect(actions[0]).toEqual({ type: 'FETCHING_LANGUAGES' })
-    expect(actions[1]).toEqual({ type: 'LANGUAGES_RECEIVED', payload: mockSuccessResponse })
+    expect(actions).toEqual([{ type: 'LANGUAGES_RECEIVED', payload: mockSuccessResponse }])
   })
 })

--- a/__tests__/components/App.test.js
+++ b/__tests__/components/App.test.js
@@ -20,7 +20,7 @@ describe('<App />', () => {
     const store = createStore()
     renderApp(store)
 
-    await wait(() => store.getState().selectorReducer.entities.languages.options.size > 0)
+    await wait(() => store.getState().entities.languages.size > 0)
   })
 
   it('sets app version', async () => {

--- a/__tests__/reducers/exports.test.js
+++ b/__tests__/reducers/exports.test.js
@@ -21,11 +21,9 @@ describe('exportsReceived', () => {
     }
 
     const oldState = createState().selectorReducer
-    const newState = reducer(oldState, action)
+    const newState = reducer(oldState.entities, action)
     expect(newState).toMatchObject({
-      entities: {
-        exports: exportFilenames,
-      },
+      exports: exportFilenames,
     })
   })
 })

--- a/__tests__/reducers/languages.test.js
+++ b/__tests__/reducers/languages.test.js
@@ -1,43 +1,17 @@
 // Copyright 2020 Stanford University see LICENSE for license
 
 import {
-  fetchingLanguages, languagesReceived, setLanguage,
+  languagesReceived, setLanguage,
 } from 'reducers/languages'
 
 import { createReducer } from 'reducers/index'
 import { createState } from 'stateUtils'
 
 const reducers = {
-  FETCHING_LANGUAGES: fetchingLanguages,
   LANGUAGE_SELECTED: setLanguage,
   LANGUAGES_RECEIVED: languagesReceived,
 }
 const reducer = createReducer(reducers)
-
-describe('fetchingLanguages()', () => {
-  it('sets loading in state', () => {
-    const oldState = {
-      entities: {
-        languages: {
-          loading: false,
-        },
-      },
-    }
-
-    const action = {
-      type: 'FETCHING_LANGUAGES',
-    }
-
-    const newState = reducer(oldState, action)
-    expect(newState).toStrictEqual({
-      entities: {
-        languages: {
-          loading: true,
-        },
-      },
-    })
-  })
-})
 
 describe('languagesReceived()', () => {
   it('creates a hash of options that it renders in the form field', () => {
@@ -57,9 +31,7 @@ describe('languagesReceived()', () => {
     ]
 
     const oldState = {
-      entities: {
-        resourceTemplates: {},
-      },
+      languages: [],
     }
 
     const action = {
@@ -69,13 +41,7 @@ describe('languagesReceived()', () => {
 
     const newState = reducer(oldState, action)
     expect(newState).toEqual({
-      entities: {
-        resourceTemplates: {},
-        languages: {
-          loading: false,
-          options: [{ id: 'sna', label: 'Shona' }],
-        },
-      },
+      languages: [{ id: 'sna', label: 'Shona' }],
     })
   })
 })

--- a/__tests__/reducers/lookups.test.js
+++ b/__tests__/reducers/lookups.test.js
@@ -18,11 +18,9 @@ describe('lookupOptionsRetrieved', () => {
   ]
 
   it('adds a new lookup', () => {
-    const newState = lookupOptionsRetrieved(createState().selectorReducer, { payload: { uri, lookup } })
+    const newState = lookupOptionsRetrieved(createState().entities, { payload: { uri, lookup } })
     expect(newState).toMatchObject({
-      entities: {
-        lookups: { [uri]: lookup },
-      },
+      lookups: { [uri]: lookup },
     })
   })
 })

--- a/__tests__/reducers/templates.test.js
+++ b/__tests__/reducers/templates.test.js
@@ -6,7 +6,7 @@ import Config from 'Config'
 
 describe('addTemplateHistory', () => {
   it('adds items uniquely', () => {
-    let state = addTemplateHistory(createState().selectorReducer, { payload: 'template1' })
+    let state = addTemplateHistory(createState().editor, { payload: 'template1' })
     state = addTemplateHistory(state, { payload: 'template2' })
     state = addTemplateHistory(state, { payload: 'template1' })
 
@@ -15,17 +15,17 @@ describe('addTemplateHistory', () => {
 
   it('limits to 7', () => {
     const state = createState()
-    state.selectorReducer.historicalTemplates = ['template1', 'template2', 'template3',
+    state.editor.historicalTemplates = ['template1', 'template2', 'template3',
       'template4', 'template5', 'template6', 'template7']
 
-    const newState = addTemplateHistory(state.selectorReducer, { payload: 'template8' })
+    const newState = addTemplateHistory(state.editor, { payload: 'template8' })
 
     expect(newState.historicalTemplates).toEqual(['template2', 'template3',
       'template4', 'template5', 'template6', 'template7', 'template8'])
   })
 
   it('does not add root resource template to history', () => {
-    let state = addTemplateHistory(createState().selectorReducer, { payload: 'template1' })
+    let state = addTemplateHistory(createState().editor, { payload: 'template1' })
     state = addTemplateHistory(state, { payload: Config.rootResourceTemplateId })
     state = addTemplateHistory(state, { payload: 'template2' })
 

--- a/__tests__/selectors/templates.test.js
+++ b/__tests__/selectors/templates.test.js
@@ -9,7 +9,7 @@ describe('selectHistoricalTemplates()', () => {
 
   it('returns templates', () => {
     const state = createState({ hasResourceWithLiteral: true })
-    state.selectorReducer.historicalTemplates = ['ld4p:RT:bf2:Title:AbbrTitle']
+    state.editor.historicalTemplates = ['ld4p:RT:bf2:Title:AbbrTitle']
 
     const templates = selectHistoricalTemplates(state)
     expect(templates).toHaveLength(1)

--- a/__tests__/testUtilities/stateUtils.js
+++ b/__tests__/testUtilities/stateUtils.js
@@ -23,7 +23,7 @@ export const createState = (options = {}) => {
 const buildExports = (state, options) => {
   if (options.noExports) return
 
-  state.selectorReducer.entities.exports = [
+  state.entities.exports = [
     'sinopia_export_all_2020-01-01T00:00:00.000Z.zip',
     'stanford_2020-01-01T00:00:00.000Z.zip',
   ]

--- a/__tests__/testUtilities/stateUtils.js
+++ b/__tests__/testUtilities/stateUtils.js
@@ -44,7 +44,7 @@ const buildAuthenticate = (state, options) => {
 const buildLanguages = (state, options) => {
   if (options.noLanguage) return
 
-  state.selectorReducer.entities.languages.options = [
+  state.entities.languages = [
     { id: 'tai', label: 'Tai languages' },
     { id: 'eng', label: 'English' },
   ]

--- a/src/actionCreators/languages.js
+++ b/src/actionCreators/languages.js
@@ -1,6 +1,6 @@
 // Copyright 2019 Stanford University see LICENSE for license
 
-import { fetchingLanguages, languagesReceived } from 'actions/languages'
+import { languagesReceived } from 'actions/languages'
 import { hasLanguages } from 'selectors/languages'
 
 export const fetchLanguages = () => (dispatch, getState) => {
@@ -8,7 +8,6 @@ export const fetchLanguages = () => (dispatch, getState) => {
     return // Languages already loaded
   }
 
-  dispatch(fetchingLanguages())
   return fetch('https://id.loc.gov/vocabulary/iso639-2.json')
     .then((resp) => resp.json())
     .then((json) => {

--- a/src/actions/languages.js
+++ b/src/actions/languages.js
@@ -7,7 +7,3 @@ export const languagesReceived = (json) => ({
   type: 'LANGUAGES_RECEIVED',
   payload: json,
 })
-
-export const fetchingLanguages = () => ({
-  type: 'FETCHING_LANGUAGES',
-})

--- a/src/components/editor/property/InputLang.jsx
+++ b/src/components/editor/property/InputLang.jsx
@@ -9,6 +9,7 @@ import { languageSelected } from 'actions/languages'
 import { hideModal } from 'actions/modals'
 import { bindActionCreators } from 'redux'
 import ModalWrapper from 'components/ModalWrapper'
+import { selectLanguages, hasLanguages } from 'selectors/languages'
 
 /**
  * Provides the RFC 5646 language tag for a literal element.
@@ -117,13 +118,12 @@ InputLang.propTypes = {
 }
 
 const mapStateToProps = (state, ownProps) => {
-  const languages = state.selectorReducer.entities.languages
   const show = selectModalType(state) === `LanguageModal-${ownProps.value.key}`
   return {
     lang: ownProps.value.lang,
     textValue: ownProps.value.literal,
-    options: languages?.options || [],
-    loading: languages?.loading || false,
+    options: selectLanguages(state),
+    loading: hasLanguages(state),
     show,
   }
 }

--- a/src/reducers/exports.js
+++ b/src/reducers/exports.js
@@ -1,9 +1,8 @@
 // Copyright 2019 Stanford University see LICENSE for license
 
-export const exportsReceived = (state, action) => {
-  const newState = { ...state }
-  newState.entities.exports = [...action.payload]
-  return newState
-}
+export const exportsReceived = (state, action) => ({
+  ...state,
+  exports: action.payload,
+})
 
 export const noop = () => {}

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -55,7 +55,6 @@ export const setCurrentComponent = (state, action) => ({
 })
 
 const handlers = {
-  ADD_TEMPLATE_HISTORY: addTemplateHistory,
   CLEAR_RESOURCE: clearResource,
   EXPORTS_RECEIVED: exportsReceived,
   FETCHING_LANGUAGES: fetchingLanguages,
@@ -90,6 +89,7 @@ const appHandlers = {
 const editorHandlers = {
   ADD_ERROR: addError,
   ADD_MODAL_MESSAGE: addModalMessage,
+  ADD_TEMPLATE_HISTORY: addTemplateHistory,
   CLEAR_ERRORS: clearErrors,
   CLEAR_MODAL_MESSAGES: clearModalMessages,
   CLEAR_RESOURCE: clearResourceFromEditor,

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -56,12 +56,10 @@ export const setCurrentComponent = (state, action) => ({
 
 const handlers = {
   CLEAR_RESOURCE: clearResource,
-  EXPORTS_RECEIVED: exportsReceived,
   HIDE_PROPERTY: hideProperty,
   HIDE_VALIDATION_ERRORS: hideValidationErrors,
   LANGUAGE_SELECTED: setLanguage,
   LOAD_RESOURCE_FINISHED: loadResourceFinished,
-  LOOKUP_OPTIONS_RETRIEVED: lookupOptionsRetrieved,
   SAVE_RESOURCE_FINISHED: saveResourceFinished,
   SET_BASE_URL: setBaseURL,
   SET_RESOURCE_GROUP: setResourceGroup,
@@ -106,7 +104,9 @@ const editorHandlers = {
 }
 
 const entityHandlers = {
+  EXPORTS_RECEIVED: exportsReceived,
   LANGUAGES_RECEIVED: languagesReceived,
+  LOOKUP_OPTIONS_RETRIEVED: lookupOptionsRetrieved,
 }
 
 const searchHandlers = {

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -18,7 +18,7 @@ import {
   clearResourceFromEditor, saveResourceFinishedEditor,
 } from './resources'
 import {
-  setLanguage, fetchingLanguages, languagesReceived,
+  setLanguage, languagesReceived,
 } from './languages'
 import {
   hideValidationErrors, addError, clearErrors,
@@ -57,11 +57,9 @@ export const setCurrentComponent = (state, action) => ({
 const handlers = {
   CLEAR_RESOURCE: clearResource,
   EXPORTS_RECEIVED: exportsReceived,
-  FETCHING_LANGUAGES: fetchingLanguages,
   HIDE_PROPERTY: hideProperty,
   HIDE_VALIDATION_ERRORS: hideValidationErrors,
   LANGUAGE_SELECTED: setLanguage,
-  LANGUAGES_RECEIVED: languagesReceived,
   LOAD_RESOURCE_FINISHED: loadResourceFinished,
   LOOKUP_OPTIONS_RETRIEVED: lookupOptionsRetrieved,
   SAVE_RESOURCE_FINISHED: saveResourceFinished,
@@ -107,6 +105,10 @@ const editorHandlers = {
   SHOW_VALIDATION_ERRORS: showValidationErrors,
 }
 
+const entityHandlers = {
+  LANGUAGES_RECEIVED: languagesReceived,
+}
+
 const searchHandlers = {
   CLEAR_SEARCH_RESULTS: clearSearchResults,
   SET_SEARCH_RESULTS: setSearchResults,
@@ -121,6 +123,7 @@ const appReducer = combineReducers({
   authenticate: createReducer(authHandlers),
   app: createReducer(appHandlers),
   editor: createReducer(editorHandlers),
+  entities: createReducer(entityHandlers),
   search: createReducer(searchHandlers),
   selectorReducer: createReducer(handlers),
 })

--- a/src/reducers/languages.js
+++ b/src/reducers/languages.js
@@ -8,20 +8,10 @@ export const setLanguage = (state, action) => {
   return newState
 }
 
-/**
- * This state change helps drive the isLoading value in the Typeahead (see the InputLang component)
- */
-export const fetchingLanguages = (state) => {
-  const newState = { ...state }
-  newState.entities.languages.loading = true
-  return newState
-}
-
-export const languagesReceived = (state, action) => {
-  const newState = { ...state }
-  newState.entities.languages = { loading: false, options: createOptions(action.payload) }
-  return newState
-}
+export const languagesReceived = (state, action) => ({
+  ...state,
+  languages: createOptions(action.payload),
+})
 
 const createOptions = (json) => json.reduce((result, item) => {
   // Object.getOwnPropertyDescriptor is necessary to handle the @

--- a/src/reducers/lookups.js
+++ b/src/reducers/lookups.js
@@ -6,14 +6,12 @@
  * @param {Object} action to be performed
  * @return {Object} the next redux state
  */
-export const lookupOptionsRetrieved = (state, action) => {
-  return {
-    ...state,
-    lookups: {
-      ...state.lookups,
-      [action.payload.uri]: action.payload.lookup
-    }
-  }
-}
+export const lookupOptionsRetrieved = (state, action) => ({
+  ...state,
+  lookups: {
+    ...state.lookups,
+    [action.payload.uri]: action.payload.lookup,
+  },
+})
 
 export const noop = () => {}

--- a/src/reducers/lookups.js
+++ b/src/reducers/lookups.js
@@ -7,11 +7,13 @@
  * @return {Object} the next redux state
  */
 export const lookupOptionsRetrieved = (state, action) => {
-  const newState = { ...state }
-
-  newState.entities.lookups[action.payload.uri] = action.payload.lookup
-
-  return newState
+  return {
+    ...state,
+    lookups: {
+      ...state.lookups,
+      [action.payload.uri]: action.payload.lookup
+    }
+  }
 }
 
 export const noop = () => {}

--- a/src/reducers/templates.js
+++ b/src/reducers/templates.js
@@ -4,16 +4,14 @@ import Config from 'Config'
 
 // Keeps a unique list of templates limited to 7
 export const addTemplateHistory = (state, action) => {
-  const newState = { ...state }
-  const template = action.payload
+  const templateId = action.payload
+  if (state.historicalTemplates.indexOf(templateId) !== -1
+      || templateId === Config.rootResourceTemplateId) return state
 
-  if (newState.historicalTemplates.indexOf(template) !== -1
-      || template === Config.rootResourceTemplateId) {
-    return newState
+  return {
+    ...state,
+    historicalTemplates: [...state.historicalTemplates, templateId].slice(-7),
   }
-
-  newState.historicalTemplates = [...state.historicalTemplates, template].slice(-7)
-  return newState
 }
 
 export const addTemplates = (state, action) => {

--- a/src/selectors/exports.js
+++ b/src/selectors/exports.js
@@ -1,5 +1,5 @@
 // Copyright 2019 Stanford University see LICENSE for license
 
-export const selectExports = (state) => state.selectorReducer.entities.exports
+export const selectExports = (state) => state.entities.exports
 
-export const hasExports = (state) => state.selectorReducer.entities.exports.length > 0
+export const hasExports = (state) => state.entities.exports.length > 0

--- a/src/selectors/languages.js
+++ b/src/selectors/languages.js
@@ -7,10 +7,12 @@
  * @return [string] the label of the language or an empty string
  */
 export const selectLanguageLabel = (state, languageId) => {
-  const lang = state.selectorReducer.entities.languages.options.find((lang) => lang.id === languageId)
+  const lang = state.entities.languages.find((lang) => lang.id === languageId)
   return lang ? lang.label : ''
 }
 
 export const hasLanguages = (state) => {
-  state.selectorReducer.entities.languages.options.length > 0
+  state.entities.languages.length > 0
 }
+
+export const selectLanguages = (state) => state.entities.languages

--- a/src/selectors/lookups.js
+++ b/src/selectors/lookups.js
@@ -6,6 +6,6 @@
  * @param [string] URI of the lookup
  * @return [Object] the lookup if found
  */
-export const selectLookup = (state, uri) => state.selectorReducer.entities.lookups[uri]
+export const selectLookup = (state, uri) => state.entities.lookups[uri]
 
 export const noop = () => {}

--- a/src/selectors/templates.js
+++ b/src/selectors/templates.js
@@ -33,5 +33,5 @@ export const selectSubjectAndPropertyTemplates = (state, key) => {
   return newSubjectTemplate
 }
 
-export const selectHistoricalTemplates = (state) => state.selectorReducer.historicalTemplates
+export const selectHistoricalTemplates = (state) => state.editor.historicalTemplates
   .map((resourceTemplateId) => selectSubjectTemplate(state, resourceTemplateId))

--- a/src/store.js
+++ b/src/store.js
@@ -26,6 +26,7 @@ export const initialState = {
       cursorOffset: null,
     },
     errors: {}, // {<error key>: [errors...]} or {<error key>: {<resourceKey>: [errors...]}}
+    historicalTemplates: [],
     lastSave: {}, // {<resourceKey>: date}
     modal: {
       name: undefined, // Name of modal to show. Should only be one at a time.
@@ -66,7 +67,6 @@ export const initialState = {
       properties: {},
       values: {},
     },
-    historicalTemplates: [],
   },
 }
 

--- a/src/store.js
+++ b/src/store.js
@@ -39,6 +39,7 @@ export const initialState = {
   entities: {
     languages: [],
     lookups: {},
+    exports: [],
   },
   search: {
     // Search model:
@@ -62,7 +63,6 @@ export const initialState = {
   },
   selectorReducer: {
     entities: { // The stuff we've retrieved from the server
-      exports: [],
       subjectTemplates: {},
       propertyTemplates: {},
       subjects: {},

--- a/src/store.js
+++ b/src/store.js
@@ -36,6 +36,9 @@ export const initialState = {
     resourceValidation: {}, // Show validation {<resourceKey>: boolean}
     unusedRDF: {}, // {<resourceKey>: rdf}
   },
+  entities: {
+    languages: [],
+  },
   search: {
     // Search model:
     // {
@@ -58,7 +61,6 @@ export const initialState = {
   },
   selectorReducer: {
     entities: { // The stuff we've retrieved from the server
-      languages: { loading: false, options: [] },
       lookups: {},
       exports: [],
       subjectTemplates: {},

--- a/src/store.js
+++ b/src/store.js
@@ -38,6 +38,7 @@ export const initialState = {
   },
   entities: {
     languages: [],
+    lookups: {},
   },
   search: {
     // Search model:
@@ -61,7 +62,6 @@ export const initialState = {
   },
   selectorReducer: {
     entities: { // The stuff we've retrieved from the server
-      lookups: {},
       exports: [],
       subjectTemplates: {},
       propertyTemplates: {},


### PR DESCRIPTION
## Why was this change made?
This is one of several PRs for making our reducers stop mutating state in accordance with Redux best practice. To assist with that, state is being made more shallow by eliminating `selectorReducer`.

## How was this change tested?
Unit/feature.


## Which documentation and/or configurations were updated?
NA


