### PR TITLE
Add view resource modal to search results rows

### DIFF
--- a/__tests__/actionCreators/resources.test.js
+++ b/__tests__/actionCreators/resources.test.js
@@ -214,6 +214,7 @@ describe('loadResource', () => {
       expect(actions).toHaveAction('ADD_TEMPLATES')
       expect(actions).toHaveAction('SET_UNUSED_RDF')
       expect(actions).toHaveAction('SET_CURRENT_RESOURCE')
+      expect(actions).toHaveAction('SET_CURRENT_RESOURCE_IS_READ_ONLY', undefined)
       expect(actions).toHaveAction('LOAD_RESOURCE_FINISHED')
     })
   })
@@ -232,7 +233,26 @@ describe('loadResource', () => {
       expect(actions).toHaveAction('ADD_SUBJECT')
       expect(actions).toHaveAction('SET_UNUSED_RDF')
       expect(actions).toHaveAction('SET_CURRENT_RESOURCE')
+      expect(actions).toHaveAction('SET_CURRENT_RESOURCE_IS_READ_ONLY', undefined)
       expect(actions).not.toHaveAction('LOAD_RESOURCE_FINISHED')
+    })
+  })
+
+  describe('loading a read-only resource', () => {
+    const store = mockStore(createState())
+
+    it('dispatches actions', async () => {
+      const uri = 'http://localhost:3000/resource/c7db5404-7d7d-40ac-b38e-c821d2c3ae3f'
+      const result = await store.dispatch(loadResource(uri, 'testerrorkey', false, true))
+      expect(result).toBe(true)
+
+      const actions = store.getActions()
+      expect(actions).toHaveAction('CLEAR_ERRORS')
+      expect(actions).toHaveAction('ADD_TEMPLATES')
+      expect(actions).toHaveAction('SET_UNUSED_RDF')
+      expect(actions).toHaveAction('SET_CURRENT_RESOURCE')
+      expect(actions).toHaveAction('SET_CURRENT_RESOURCE_IS_READ_ONLY', true)
+      expect(actions).toHaveAction('LOAD_RESOURCE_FINISHED')
     })
   })
 

--- a/__tests__/feature/searchAndViewResource.test.js
+++ b/__tests__/feature/searchAndViewResource.test.js
@@ -1,0 +1,75 @@
+import { fireEvent, screen } from '@testing-library/react'
+import { renderApp } from 'testUtils'
+import * as sinopiaSearch from 'sinopiaSearch'
+import { resourceSearchResults } from 'fixtureLoaderHelper'
+import Config from 'Config'
+
+// This forces Sinopia server to use fixtures
+jest.spyOn(Config, 'useResourceTemplateFixtures', 'get').mockReturnValue(true)
+jest.mock('sinopiaSearch')
+// Mock jquery
+global.$ = jest.fn().mockReturnValue({ popover: jest.fn() })
+
+describe('searching and viewing a resource', () => {
+  sinopiaSearch.getTemplateSearchResults.mockResolvedValue({
+    totalHits: 0,
+    results: [],
+    error: undefined,
+  })
+
+  it('renders a modal without edit controls', async () => {
+    // Setup search component to return known resource
+    const uri = 'http://localhost:3000/resource/c7db5404-7d7d-40ac-b38e-c821d2c3ae3f'
+    sinopiaSearch.getSearchResultsWithFacets.mockResolvedValue(resourceSearchResults(uri))
+
+    renderApp()
+
+    fireEvent.click(screen.getByText('Linked Data Editor', { selector: 'a' }))
+    fireEvent.click(screen.getByText('Search', { selector: 'a' }))
+
+    fireEvent.change(screen.getByLabelText('Query'), { target: { value: uri } })
+    fireEvent.click(screen.getByTestId('Submit search'))
+
+    await screen.findByText(uri)
+    expect(screen.getByText('http://id.loc.gov/ontologies/bibframe/Fixture')).toBeInTheDocument()
+
+    // Modal hasn't rendered yet
+    expect(screen.queryByRole('dialog', { name: 'View Resource' })).not.toBeInTheDocument()
+    expect(screen.getByTestId('view-resource-modal').classList).not.toContain('show')
+
+    // Click the view icon next to the search result row
+    expect(screen.getByTestId(`View ${uri}`)).toBeInTheDocument()
+    fireEvent.click(screen.getByTestId(`View ${uri}`))
+
+    // Modal has now rendered
+    expect((await screen.findByTestId('view-resource-modal')).classList).toContain('show')
+    expect((await screen.findAllByText('Uber template1, property1', { selector: 'span' }))).toHaveLength(1)
+
+    // Edit controls are disabled in view modal
+    screen.getAllByTestId('Remove Uber template3, property1').forEach((removeButton) => {
+      expect(removeButton).toBeDisabled()
+    })
+    screen.getAllByText('ä').forEach((languageButton) => {
+      expect(languageButton).toBeDisabled()
+    })
+    expect(screen.getByPlaceholderText('Uber template3, property1')).toBeDisabled()
+    expect(screen.getByTestId('Edit Uber template3, property1')).toBeDisabled()
+    expect(screen.getByTestId('Change language for Uber template3, property1')).toBeDisabled()
+    expect(screen.getByTestId('Remove analog')).toBeDisabled()
+    screen.getAllByTestId('lookup').forEach((lookupValueControl) => {
+      expect(lookupValueControl).toBeDisabled()
+    })
+    screen.getAllByText('+').forEach((lookupControl) => {
+      expect(lookupControl).toBeDisabled()
+    })
+
+    // Modal has edit and copy buttons
+    expect(screen.getByTestId('edit-resource')).toBeInTheDocument()
+    expect(screen.getByTestId('copy-resource')).toBeInTheDocument()
+
+    // Edit button opens the editor with existing resource
+    fireEvent.click(screen.getByLabelText('Edit', { selector: 'button', exact: true }))
+    expect(screen.getByText('Uber template1', { selector: 'h3' })).toBeInTheDocument()
+    expect(screen.getByText('Copy URI', { selector: 'button' })).toBeInTheDocument()
+  })
+})

--- a/__tests__/reducers/resources.test.js
+++ b/__tests__/reducers/resources.test.js
@@ -1,11 +1,11 @@
 // Copyright 2020 Stanford University see LICENSE for license
 
 import {
-  addProperty, addSubject, addValue, clearResource,
-  hideProperty, removeSubject,
+  addProperty, addSubject, addValue, clearResource, hideProperty, removeSubject,
   removeValue, saveResourceFinished, setBaseURL, setCurrentResource,
-  setUnusedRDF, showProperty, loadResourceFinished, setResourceGroup,
-  setValueOrder, clearResourceFromEditor, saveResourceFinishedEditor,
+  setCurrentResourceIsReadOnly, setUnusedRDF, showProperty,
+  loadResourceFinished, setResourceGroup, setValueOrder,
+  clearResourceFromEditor, saveResourceFinishedEditor,
 } from 'reducers/resources'
 
 import { createState } from 'stateUtils'
@@ -33,6 +33,7 @@ const editorReducers = {
   CLEAR_RESOURCE: clearResourceFromEditor,
   SAVE_RESOURCE_FINISHED: saveResourceFinishedEditor,
   SET_CURRENT_RESOURCE: setCurrentResource,
+  SET_CURRENT_RESOURCE_IS_READ_ONLY: setCurrentResourceIsReadOnly,
   SET_UNUSED_RDF: setUnusedRDF,
 }
 
@@ -538,6 +539,7 @@ describe('clearResourceFromEditor()', () => {
     const newState = editorReducer(oldState.editor, action)
     expect(newState.errors['resourceedit-t9zVwg2zO']).toBe(undefined)
     expect(newState.currentResource).toBe(null)
+    expect(newState.currentResourceIsReadOnly).toBe(undefined)
     expect(newState.resources).toStrictEqual([])
   })
 })
@@ -708,6 +710,36 @@ describe('setCurrentResource()', () => {
     const newState = editorReducer(oldState.editor, action)
     expect(newState.currentResource).toBe('t9zVwg2zO')
     expect(newState.resources).toStrictEqual(['t9zVwg2zO'])
+  })
+})
+
+describe('setCurrentResourceIsReadOnly()', () => {
+  it('sets current resource to read-only', () => {
+    const oldState = createState({ hasResourceWithLiteral: true })
+    oldState.editor.currentResourceIsReadOnly = undefined
+    expect(oldState.editor.currentResourceIsReadOnly).toBeUndefined()
+
+    const action = {
+      type: 'SET_CURRENT_RESOURCE_IS_READ_ONLY',
+      payload: true,
+    }
+
+    const newState = editorReducer(oldState.editor, action)
+    expect(newState.currentResourceIsReadOnly).toBe(true)
+  })
+
+  it('sets current resource to not read-only', () => {
+    const oldState = createState({ hasResourceWithLiteral: true })
+    oldState.editor.currentResourceIsReadOnly = true
+    expect(oldState.editor.currentResourceIsReadOnly).toBe(true)
+
+    const action = {
+      type: 'SET_CURRENT_RESOURCE_IS_READ_ONLY',
+      payload: undefined,
+    }
+
+    const newState = editorReducer(oldState.editor, action)
+    expect(newState.currentResourceIsReadOnly).toBeUndefined()
   })
 })
 

--- a/__tests__/selectors/resources.test.js
+++ b/__tests__/selectors/resources.test.js
@@ -1,7 +1,8 @@
 import { createState } from 'stateUtils'
 import {
   selectSubject, selectProperty, selectValue,
-  selectFullSubject, resourceHasChangesSinceLastSave,
+  selectCurrentResourceIsReadOnly, selectFullSubject,
+  resourceHasChangesSinceLastSave,
 } from 'selectors/resources'
 
 describe('selectSubject()', () => {
@@ -40,6 +41,19 @@ describe('selectValue()', () => {
     expect(value).toBeValue('VDOeQCnFA8')
   })
 })
+
+describe('selectCurrentResourceIsReadOnly()', () => {
+  it('returns undefined when current resource is not read-only', () => {
+    const state = createState()
+    expect(selectCurrentResourceIsReadOnly(state)).toBeUndefined()
+  })
+
+  it('returns true when current resource is read-only', () => {
+    const state = createState({ hasResourceWithLiteral: true, readOnlyResource: true })
+    expect(selectCurrentResourceIsReadOnly(state)).toBe(true)
+  })
+})
+
 
 describe('selectFullSubject()', () => {
   it('returns null when no match', () => {

--- a/__tests__/testUtilities/stateUtils.js
+++ b/__tests__/testUtilities/stateUtils.js
@@ -169,6 +169,8 @@ const buildTemplateWithLiteral = (state, options) => {
 const buildResourceWithLiteral = (state, options) => {
   if (!options.hasResourceWithLiteral) return
 
+  if (options.readOnlyResource) state.editor.currentResourceIsReadOnly = true
+
   state.editor.currentResource = 't9zVwg2zO'
   state.editor.resources = ['t9zVwg2zO']
   state.entities.subjectTemplates = {

--- a/src/actionCreators/resources.js
+++ b/src/actionCreators/resources.js
@@ -14,7 +14,7 @@ import {
   addProperty as addPropertyAction,
   addValue as addValueAction, addSubject as addSubjectAction,
   showProperty, setBaseURL, setCurrentResource, saveResourceFinished,
-  setUnusedRDF, loadResourceFinished, setResourceGroup,
+  setUnusedRDF, loadResourceFinished, setResourceGroup, setCurrentResourceIsReadOnly,
 } from 'actions/resources'
 import { newValueSubject } from 'utilities/valueFactory'
 import { selectUser } from 'selectors/authenticate'
@@ -24,7 +24,7 @@ import _ from 'lodash'
  * A thunk that loads an existing resource from Sinopia API and adds to state.
  * @return {boolean} true if successful
  */
-export const loadResource = (uri, errorKey, asNewResource) => (dispatch) => {
+export const loadResource = (uri, errorKey, asNewResource, readOnly) => (dispatch) => {
   dispatch(clearErrors(errorKey))
   return fetchResource(uri)
     .then(([dataset, response]) => {
@@ -35,6 +35,7 @@ export const loadResource = (uri, errorKey, asNewResource) => (dispatch) => {
           const unusedDataset = dataset.difference(usedDataset)
           dispatch(setUnusedRDF(resource.key, unusedDataset.size > 0 ? unusedDataset.toCanonical() : null))
           dispatch(setCurrentResource(resource.key))
+          dispatch(setCurrentResourceIsReadOnly(readOnly))
           if (!asNewResource) dispatch(loadResourceFinished(resource.key))
           return true
         })

--- a/src/actions/resources.js
+++ b/src/actions/resources.js
@@ -26,6 +26,11 @@ export const setCurrentResource = (resourceKey) => ({
   payload: resourceKey,
 })
 
+export const setCurrentResourceIsReadOnly = (readOnly) => ({
+  type: 'SET_CURRENT_RESOURCE_IS_READ_ONLY',
+  payload: readOnly,
+})
+
 export const setResourceGroup = (resourceKey, group) => ({
   type: 'SET_RESOURCE_GROUP',
   payload: { resourceKey, group },

--- a/src/components/ViewResourceModal.jsx
+++ b/src/components/ViewResourceModal.jsx
@@ -1,0 +1,84 @@
+// Copyright 2019 Stanford University see LICENSE for license
+
+import React from 'react'
+import PropTypes from 'prop-types'
+import { useDispatch, useSelector } from 'react-redux'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faCopy, faEdit } from '@fortawesome/free-solid-svg-icons'
+import ModalWrapper, { useDisplayStyle, useModalCss } from 'components/ModalWrapper'
+import { hideModal } from 'actions/modals'
+import { selectModalType } from 'selectors/modals'
+import { selectCurrentResourceKey, selectNormSubject } from 'selectors/resources'
+import ResourceComponent from './editor/ResourceComponent'
+
+const ViewResourceModal = (props) => {
+  const dispatch = useDispatch()
+
+  const show = useSelector((state) => selectModalType(state) === 'ViewResourceModal')
+
+  // Ensure there is a current resource before attempting to render a resource component
+  const currentResourceKey = useSelector((state) => selectCurrentResourceKey(state))
+  const currentResource = useSelector((state) => selectNormSubject(state, currentResourceKey))
+
+  const close = (event) => {
+    event.preventDefault()
+    dispatch(hideModal())
+  }
+
+  const editAndClose = (event) => {
+    close(event)
+    props.handleEdit(currentResource.uri)
+  }
+
+  const copyAndClose = (event) => {
+    close(event)
+    props.handleCopy(currentResource.uri)
+  }
+
+  const modal = (
+    <div className={ useModalCss(show) }
+         tabIndex="-1"
+         role="dialog"
+         id="view-resource-modal"
+         data-testid="view-resource-modal"
+         aria-labelledby="view-resource-modal-title"
+         style={{ display: useDisplayStyle(show) }}>
+      <div className="modal-dialog modal-dialog-scrollable view-resource-modal-dialog modal-lg" role="document">
+        <div className="modal-content">
+          <div className="modal-header">
+            <h4 className="modal-title" id="view-resource-modal-title">View Resource</h4>
+            <div className="view-resource-buttons">
+              <button type="button" className="close modal-close" onClick={ close } aria-label="Close">
+                <span aria-hidden="true">&times;</span>
+              </button>
+            </div>
+          </div>
+          <div className="modal-body view-resource-modal-content">
+            { currentResource && <ResourceComponent /> }
+          </div>
+          <div className="modal-footer">
+            <button className="btn btn-primary btn-view-resource" onClick={ editAndClose } aria-label="Edit" data-testid="edit-resource">
+              <FontAwesomeIcon icon={faEdit} />
+              &nbsp;
+              Edit
+            </button>
+            <button className="btn btn-primary btn-view-resource" onClick={ copyAndClose } aria-label="Copy" data-testid="copy-resource">
+              <FontAwesomeIcon icon={faCopy} />
+              &nbsp;
+              Copy
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+
+  return (<ModalWrapper modal={modal} />)
+}
+
+ViewResourceModal.propTypes = {
+  handleEdit: PropTypes.func.isRequired,
+  handleCopy: PropTypes.func.isRequired,
+}
+
+export default ViewResourceModal

--- a/src/components/editor/ResourceComponent.jsx
+++ b/src/components/editor/ResourceComponent.jsx
@@ -12,7 +12,7 @@ import { newResourceErrorKey } from './property/ResourceList'
 import { resourceEditErrorKey } from './Editor'
 import { addError } from 'actions/errors'
 import { datasetFromN3 } from 'utilities/Utilities'
-import { selectNormSubject, selectCurrentResourceKey } from 'selectors/resources'
+import { selectCurrentResourceKey, selectCurrentResourceIsReadOnly, selectNormSubject } from 'selectors/resources'
 import { selectErrors } from 'selectors/errors'
 import { selectUnusedRDF } from 'selectors/modals'
 import { selectSubjectTemplate } from 'selectors/templates'
@@ -28,6 +28,7 @@ const ResourceComponent = () => {
   const subjectTemplate = useSelector((state) => selectSubjectTemplate(state, resource.subjectTemplateKey))
   const errors = useSelector((state) => selectErrors(state, resourceEditErrorKey(resourceKey)))
   const unusedRDF = useSelector((state) => selectUnusedRDF(state, resourceKey))
+  const readOnly = useSelector((state) => selectCurrentResourceIsReadOnly(state))
 
   const [dataset, setDataset] = useState(null)
 
@@ -56,11 +57,12 @@ const ResourceComponent = () => {
           <ResourceURIMessage />
           <SaveAlert />
         </section>
-        {dataset
-         && <div className="alert alert-warning" role="alert">
-           <strong>Unable to load the entire resource.</strong> The unused triples are:
-           <RDFDisplay dataset={dataset} />
-         </div>
+        {
+          dataset && !readOnly
+          && <div className="alert alert-warning" role="alert">
+            <strong>Unable to load the entire resource.</strong> The unused triples are:
+            <RDFDisplay dataset={dataset} />
+          </div>
         }
         <PanelResource resource={resource} />
       </div>

--- a/src/components/editor/property/InputListLOC.jsx
+++ b/src/components/editor/property/InputListLOC.jsx
@@ -12,6 +12,7 @@ import { displayResourceValidations } from 'selectors/errors'
 import { renderMenuFunc, renderTokenFunc, itemsForValues } from './renderTypeaheadFunctions'
 import { fetchLookup } from 'actionCreators/lookups'
 import { selectLookup } from 'selectors/lookups'
+import { selectCurrentResourceIsReadOnly, selectNormValues } from 'selectors/resources'
 import _ from 'lodash'
 import { addProperty, removeValue } from 'actions/resources'
 import { newUriValue, newLiteralValue } from 'utilities/valueFactory'
@@ -20,8 +21,6 @@ import ModalWrapper from 'components/ModalWrapper'
 import { hideModal, showModal } from 'actions/modals'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faTrashAlt, faGlobe } from '@fortawesome/free-solid-svg-icons'
-import { selectNormValues } from 'selectors/resources'
-
 
 // propertyTemplate of type 'lookup' does live QA lookup via API
 //  based on URI in propertyTemplate.valueConstraint.useValuesFrom,
@@ -43,6 +42,8 @@ const InputListLOC = (props) => {
   }, [allAuthorities])
 
   const isRepeatable = props.propertyTemplate.repeatable
+
+  const readOnly = useSelector((state) => selectCurrentResourceIsReadOnly(state))
 
   useEffect(() => {
     props.propertyTemplate.authorities.forEach((authority) => {
@@ -134,7 +135,7 @@ const InputListLOC = (props) => {
   const displayValidations = useSelector((state) => displayResourceValidations(state, props.property.rootSubjectKey))
   const validationErrors = props.property.errors
 
-  const isDisabled = selected?.length > 0 && !isRepeatable
+  const isDisabled = readOnly || (selected?.length > 0 && !isRepeatable)
 
   let error
   let groupClasses = 'form-group'
@@ -170,6 +171,7 @@ const InputListLOC = (props) => {
         onClick={() => props.removeValue(lookupValue.key)}
         aria-label={`Remove ${lookupValue.label}`}
         data-testid={`Remove ${lookupValue.label}`}
+        disabled={isDisabled}
         className="close rbt-close rbt-token-remove-button">
         <span aria-hidden="true"><FontAwesomeIcon className="trash-icon" icon={faTrashAlt} /></span>
       </button>
@@ -227,6 +229,7 @@ const InputListLOC = (props) => {
         id="lookup"
         onClick={ handleClick }
         aria-label={'LookupLOC'}
+        disabled={isDisabled}
         className="btn btn-sm btn-secondary btn-literal">
         +
       </button>

--- a/src/components/editor/property/InputLiteral.jsx
+++ b/src/components/editor/property/InputLiteral.jsx
@@ -3,13 +3,14 @@
 import React, { useRef, useState } from 'react'
 import PropTypes from 'prop-types'
 import { bindActionCreators } from 'redux'
-import { connect } from 'react-redux'
+import { connect, useSelector } from 'react-redux'
 import TextareaAutosize from 'react-textarea-autosize'
 import {
   hideDiacritics, showDiacritics,
   setLiteralContent, updateCursorPosition,
 } from 'actions/inputs'
 import { displayResourceValidations } from 'selectors/errors'
+import { selectCurrentResourceIsReadOnly } from 'selectors/resources'
 import InputValue from './InputValue'
 import { defaultLanguageId } from 'utilities/Utilities'
 import _ from 'lodash'
@@ -17,14 +18,14 @@ import { addValue } from 'actions/resources'
 import { newLiteralValue } from 'utilities/valueFactory'
 import { selectLiteralInputContent, displayDiacritics } from 'selectors/inputs'
 
-
 const InputLiteral = (props) => {
   const inputLiteralRef = useRef(100 * Math.random())
   const [lang, setLang] = useState(defaultLanguageId)
   const id = `inputliteral-${props.property.key}`
+  const readOnly = useSelector((state) => selectCurrentResourceIsReadOnly(state))
 
-  const disabled = !props.propertyTemplate.repeatable
-      && props.property.valueKeys.length > 0
+  const disabled = readOnly || (!props.propertyTemplate.repeatable
+                                && props.property.valueKeys.length > 0)
 
   const addItem = () => {
     let currentcontent = props.content.trim()

--- a/src/components/editor/property/InputLookup.jsx
+++ b/src/components/editor/property/InputLookup.jsx
@@ -6,6 +6,7 @@ import { selectModalType } from 'selectors/modals'
 import { connect, useSelector, useDispatch } from 'react-redux'
 import { bindActionCreators } from 'redux'
 import { displayResourceValidations } from 'selectors/errors'
+import { selectNormValues, selectCurrentResourceIsReadOnly } from 'selectors/resources'
 import _ from 'lodash'
 import { itemsForValues } from './renderTypeaheadFunctions'
 import { removeValue } from 'actions/resources'
@@ -14,17 +15,17 @@ import ModalWrapper from 'components/ModalWrapper'
 import LookupWithMultipleAuthorities from './LookupWithMultipleAuthorities'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faGlobe, faSearch, faTrashAlt } from '@fortawesome/free-solid-svg-icons'
-import { selectNormValues } from 'selectors/resources'
 
 const InputLookup = (props) => {
   const dispatch = useDispatch()
   const displayValidations = useSelector((state) => displayResourceValidations(state, props.property.rootSubjectKey))
   const errors = props.property.errors
   const selected = itemsForValues(props.lookupValues)
+  const readOnly = useSelector((state) => selectCurrentResourceIsReadOnly(state))
 
   const isRepeatable = props.propertyTemplate.repeatable
 
-  const isDisabled = selected?.length > 0 && !isRepeatable
+  const isDisabled = readOnly || (selected?.length > 0 && !isRepeatable)
 
   let error
   let controlClasses = 'open-search-modal btn btn-sm btn-secondary btn-literal form-control'

--- a/src/components/editor/property/InputLookupQA.jsx
+++ b/src/components/editor/property/InputLookupQA.jsx
@@ -14,7 +14,6 @@ const InputLookupQA = (props) => (
     propertyTemplate={props.propertyTemplate} />
 )
 
-
 InputLookupQA.propTypes = {
   property: PropTypes.object.isRequired,
   propertyTemplate: PropTypes.object.isRequired,

--- a/src/components/editor/property/InputURI.jsx
+++ b/src/components/editor/property/InputURI.jsx
@@ -3,9 +3,10 @@
 import React, { useRef, useState } from 'react'
 import PropTypes from 'prop-types'
 import { bindActionCreators } from 'redux'
-import { connect } from 'react-redux'
+import { connect, useSelector } from 'react-redux'
 import shortid from 'shortid'
 import { displayResourceValidations } from 'selectors/errors'
+import { selectCurrentResourceIsReadOnly } from 'selectors/resources'
 import { addValue } from 'actions/resources'
 import { newUriValue } from 'utilities/valueFactory'
 import InputValue from './InputValue'
@@ -17,9 +18,10 @@ const InputURI = (props) => {
   const inputLiteralRef = useRef(Math.floor(100 * Math.random()))
   const [content, setContent] = useState('')
   const [uriError, setURIError] = useState(false)
+  const readOnly = useSelector((state) => selectCurrentResourceIsReadOnly(state))
 
-  const disabled = !props.propertyTemplate.repeatable
-      && props.property.valueKeys.length > 0
+  const disabled = readOnly || (!props.propertyTemplate.repeatable
+                                && props.property.valueKeys.length > 0)
 
   const addItem = () => {
     const currentcontent = content.trim()

--- a/src/components/editor/property/InputValue.jsx
+++ b/src/components/editor/property/InputValue.jsx
@@ -1,15 +1,17 @@
 // Copyright 2019 Stanford University see LICENSE for license
 
 import React from 'react'
-import { connect } from 'react-redux'
+import { connect, useSelector } from 'react-redux'
 import { bindActionCreators } from 'redux'
 import PropTypes from 'prop-types'
 import { removeValue } from 'actions/resources'
 import LanguageButton from './LanguageButton'
-import { selectNormValue, selectNormProperty } from 'selectors/resources'
+import { selectCurrentResourceIsReadOnly, selectNormValue, selectNormProperty } from 'selectors/resources'
 import { selectPropertyTemplate } from 'selectors/templates'
 
 const InputValue = (props) => {
+  const readOnly = useSelector((state) => selectCurrentResourceIsReadOnly(state))
+
   if (!props.value) return null
 
   const isLiteral = props.propertyTemplate.type === 'literal'
@@ -25,6 +27,7 @@ const InputValue = (props) => {
       className="rbt-token rbt-token-removeable">
       {label}
       <button
+        disabled={readOnly}
         onClick={() => props.removeValue(props.valueKey)}
         aria-label={`Remove ${label}`}
         data-testid={`Remove ${label}`}
@@ -33,6 +36,7 @@ const InputValue = (props) => {
       </button>
     </div>
     <button
+      disabled={readOnly}
       onClick={handleEditClick}
       style={ { marginRight: '.25em' } }
       aria-label={`Edit ${label}`}

--- a/src/components/editor/property/LanguageButton.jsx
+++ b/src/components/editor/property/LanguageButton.jsx
@@ -2,13 +2,15 @@
 
 import React from 'react'
 import PropTypes from 'prop-types'
-import { useDispatch, connect } from 'react-redux'
+import { useDispatch, useSelector, connect } from 'react-redux'
 import InputLang from './InputLang'
 import { showModal } from 'actions/modals'
 import { selectLanguageLabel } from 'selectors/languages'
+import { selectCurrentResourceIsReadOnly } from 'selectors/resources'
 
 const LanguageButton = (props) => {
   const dispatch = useDispatch()
+  const readOnly = useSelector((state) => selectCurrentResourceIsReadOnly(state))
 
   const handleClick = (event) => {
     event.preventDefault()
@@ -20,6 +22,7 @@ const LanguageButton = (props) => {
   return (
     <React.Fragment>
       <button
+        disabled={readOnly}
         id="language"
         onClick={ handleClick }
         aria-label={`Change language for ${props.value.literal}`}

--- a/src/components/editor/property/NestedPropertyHeader.jsx
+++ b/src/components/editor/property/NestedPropertyHeader.jsx
@@ -1,7 +1,7 @@
 // Copyright 2019 Stanford University see LICENSE for license
 
 import React from 'react'
-import { connect } from 'react-redux'
+import { connect, useSelector } from 'react-redux'
 import PropTypes from 'prop-types'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faAngleRight, faAngleDown, faTrashAlt } from '@fortawesome/free-solid-svg-icons'
@@ -10,6 +10,7 @@ import PropertyLabelInfo from './PropertyLabelInfo'
 import { displayResourceValidations } from 'selectors/errors'
 import { showProperty, hideProperty } from 'actions/resources'
 import { resourceEditErrorKey } from '../Editor'
+import { selectCurrentResourceIsReadOnly } from 'selectors/resources'
 import _ from 'lodash'
 import { expandProperty, contractProperty } from 'actionCreators/resources'
 import { bindActionCreators } from 'redux'
@@ -19,7 +20,9 @@ const NestedPropertyHeader = (props) => {
   const toggleAria = props.property.show === true ? `Hide ${props.propertyTemplate.label}` : `Show ${props.propertyTemplate.label}`
   const trashIcon = faTrashAlt
 
-  const isAdd = !props.property.valueKeys
+  const readOnly = useSelector((state) => selectCurrentResourceIsReadOnly(state))
+
+  const isAdd = !readOnly && !props.property.valueKeys
 
   let error
   let groupClasses = 'rOutline-header'
@@ -69,6 +72,7 @@ const NestedPropertyHeader = (props) => {
       <PropertyLabelInfo propertyTemplate={ props.propertyTemplate } />
       <button type="button"
               className="btn btn-sm btn-remove pull-right"
+              disabled={readOnly}
               onClick={() => props.contractProperty(props.property.key)}
               aria-label={`Remove ${props.propertyTemplate.label}`}
               data-testid={`Remove ${props.propertyTemplate.label}`}

--- a/src/components/editor/property/NestedResource.jsx
+++ b/src/components/editor/property/NestedResource.jsx
@@ -4,14 +4,16 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import NestedProperty from './NestedProperty'
 import NestedResourceActionButtons from './NestedResourceActionButtons'
-import { selectNormValue, selectNormSubject } from 'selectors/resources'
+import { selectNormValue, selectNormSubject, selectCurrentResourceIsReadOnly } from 'selectors/resources'
 import { selectSubjectTemplate } from 'selectors/templates'
-import { connect } from 'react-redux'
+import { connect, useSelector } from 'react-redux'
 import useNavigableComponent from 'hooks/useNavigableComponent'
 
 // AKA a value subject.
 const NestedResource = (props) => {
   const [navEl, navClickHandler] = useNavigableComponent(props.value.rootSubjectKey, props.value.rootPropertyKey, props.value.valueSubjectKey)
+
+  const readOnly = useSelector((state) => selectCurrentResourceIsReadOnly(state))
 
   // onClick is to support left navigation, so ignoring jsx-ally seems reasonable.
   /* eslint-disable jsx-a11y/click-events-have-key-events */
@@ -23,7 +25,7 @@ const NestedResource = (props) => {
           <h5>{ props.subjectTemplate.label }</h5>
         </section>
         <section className="col-md-6">
-          <NestedResourceActionButtons value={props.value} />
+          {!readOnly && <NestedResourceActionButtons value={props.value} />}
         </section>
       </div>
       <div>

--- a/src/components/editor/property/PanelProperty.jsx
+++ b/src/components/editor/property/PanelProperty.jsx
@@ -8,10 +8,10 @@ import PropertyComponent from './PropertyComponent'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faTrashAlt } from '@fortawesome/free-solid-svg-icons'
 import { bindActionCreators } from 'redux'
-import { connect } from 'react-redux'
+import { connect, useSelector } from 'react-redux'
 import { resourceEditErrorKey } from '../Editor'
 import { expandProperty, contractProperty } from 'actionCreators/resources'
-import { selectNormProperty, selectCurrentResourceKey } from 'selectors/resources'
+import { selectNormProperty, selectCurrentResourceKey, selectCurrentResourceIsReadOnly } from 'selectors/resources'
 import { selectPropertyTemplate } from 'selectors/templates'
 import useNavigableComponent from 'hooks/useNavigableComponent'
 
@@ -22,6 +22,7 @@ const PanelProperty = (props) => {
   const nbsp = '\u00A0'
   const trashIcon = faTrashAlt
   const [navEl, navClickHandler] = useNavigableComponent(props.resourceKey, props.propertyKey, props.propertyKey)
+  const readOnly = useSelector((state) => selectCurrentResourceIsReadOnly(state))
 
   // onClick is to support left navigation, so ignoring jsx-ally seems reasonable.
   /* eslint-disable jsx-a11y/click-events-have-key-events */
@@ -33,7 +34,7 @@ const PanelProperty = (props) => {
           <h5 className="card-title">
             <PropertyLabel propertyTemplate={ props.propertyTemplate } />
             <PropertyLabelInfo propertyTemplate={ props.propertyTemplate } />{nbsp}
-            { isAdd && (
+            { isAdd && !readOnly && (
               <button
                   type="button"
                   className="btn btn-sm btn-add btn-add-instance pull-right"
@@ -44,7 +45,7 @@ const PanelProperty = (props) => {
                 + Add
               </button>
             )}
-            { !isAdd && !isRequired && (
+            { !isAdd && !isRequired && !readOnly && (
               <button type="button"
                       className="btn btn-sm btn-remove pull-right"
                       aria-label={`Remove ${props.propertyTemplate.label}`}

--- a/src/components/editor/property/PanelResource.jsx
+++ b/src/components/editor/property/PanelResource.jsx
@@ -1,25 +1,36 @@
 // Copyright 2019 Stanford University see LICENSE for license
 
 import React from 'react'
+import { useSelector } from 'react-redux'
 import PropTypes from 'prop-types'
 import PanelProperty from './PanelProperty'
 import PanelResourceNav from './PanelResourceNav'
+import { selectCurrentResourceIsReadOnly } from 'selectors/resources'
 
 // Top-level resource
-const PanelResource = (props) => (
-  <div className="row" >
-    <PanelResourceNav resource={props.resource} />
-    <div className="col-sm-9">
-      <form>
-        {
-          props.resource.propertyKeys.map((propertyKey, index) => (
-            <PanelProperty resourceKey={props.resource.key} propertyKey={propertyKey} key={propertyKey} float={index} id={propertyKey} />
-          ))
-        }
-      </form>
+const PanelResource = (props) => {
+  const readOnly = useSelector((state) => selectCurrentResourceIsReadOnly(state))
+  const resourceDivClass = readOnly ? 'col-sm-12' : 'col-sm-9'
+
+  return (
+    <div className="row" >
+      { !readOnly && <PanelResourceNav resource={props.resource} /> }
+      <div className={resourceDivClass}>
+        <form>
+          {
+            props.resource.propertyKeys.map((propertyKey, index) => (
+              <PanelProperty resourceKey={props.resource.key}
+                             propertyKey={propertyKey}
+                             key={propertyKey}
+                             float={index}
+                             id={propertyKey} />
+            ))
+          }
+        </form>
+      </div>
     </div>
-  </div>
-)
+  )
+}
 
 PanelResource.propTypes = {
   resource: PropTypes.object.isRequired,

--- a/src/components/editor/property/ResourceList.jsx
+++ b/src/components/editor/property/ResourceList.jsx
@@ -7,7 +7,7 @@ import { getTemplateSearchResults } from 'sinopiaSearch'
 import shortid from 'shortid'
 import { newResource } from 'actionCreators/resources'
 import { selectPropertyTemplate, selectSubjectTemplate } from 'selectors/templates'
-import { selectNormSubject } from 'selectors/resources'
+import { selectCurrentResourceIsReadOnly, selectNormSubject } from 'selectors/resources'
 
 export const newResourceErrorKey = 'newresource'
 
@@ -15,6 +15,7 @@ const ResourceList = (props) => {
   const dispatch = useDispatch()
   const [newResourceList, setNewResourceList] = useState([])
   const topRef = useRef(null)
+  const readOnly = useSelector((state) => selectCurrentResourceIsReadOnly(state))
 
   const propertyTemplate = useSelector((state) => selectPropertyTemplate(state, props.property?.propertyTemplateKey))
   const subject = useSelector((state) => selectNormSubject(state, props.property?.subjectKey))
@@ -34,7 +35,12 @@ const ResourceList = (props) => {
         response.results?.forEach((hit) => {
           if (hit.resourceURI === subjectTemplate.class) {
             listItems.push(
-              <button className="dropdown-item" href="#" data-resource-id={hit.id} key={shortid.generate()} onClick={() => { handleChange(hit.id) }}>
+              <button disabled={readOnly}
+                      className="dropdown-item"
+                      href="#"
+                      data-resource-id={hit.id}
+                      key={shortid.generate()}
+                      onClick={() => { handleChange(hit.id) }}>
                 {hit.resourceLabel} ({hit.id})
               </button>,
             )
@@ -44,11 +50,11 @@ const ResourceList = (props) => {
       setNewResourceList(listItems)
     }
     getNewResourceList()
-  }, [dispatch, propertyTemplate.authorities, subjectTemplate.class])
+  }, [readOnly, dispatch, propertyTemplate.authorities, subjectTemplate.class])
 
   const dropdown = (items) => <div className="dropdown">
     <button className="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown"
-            aria-haspopup="true" aria-expanded="false">
+            aria-haspopup="true" aria-expanded="false" disabled={readOnly}>
       Create New
     </button>
     <div className="dropdown-menu" aria-labelledby="dropdownMenuButton">

--- a/src/components/search/SearchResultRows.jsx
+++ b/src/components/search/SearchResultRows.jsx
@@ -3,7 +3,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faCopy, faEdit } from '@fortawesome/free-solid-svg-icons'
+import { faCopy, faEdit, faEye } from '@fortawesome/free-solid-svg-icons'
 import { groupNameFromGroup } from 'utilities/Utilities'
 import LongDate from 'components/LongDate'
 
@@ -22,6 +22,13 @@ const SearchResultRows = (props) => props.searchResults.map((row) => (
     <td><LongDate datetime={ row.modified } /></td>
     <td>
       <div className="btn-group" role="group" aria-label="Result Actions">
+        <button className="btn btn-link"
+                title="View"
+                aria-label={`View ${row.label}`}
+                data-testid={`View ${row.label}`}
+                onClick={() => props.handleView(row.uri) }>
+          <FontAwesomeIcon icon={faEye} className="icon-lg" />
+        </button>
         <button className="btn btn-link"
                 title="Edit"
                 aria-label={`Edit ${row.label}`}
@@ -46,6 +53,7 @@ SearchResultRows.propTypes = {
   searchResults: PropTypes.array,
   handleEdit: PropTypes.func,
   handleCopy: PropTypes.func,
+  handleView: PropTypes.func,
 }
 
 export default SearchResultRows

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -10,7 +10,7 @@ import {
 } from './inputs'
 import {
   setBaseURL, hideProperty, showProperty,
-  setUnusedRDF, setCurrentResource,
+  setUnusedRDF, setCurrentResource, setCurrentResourceIsReadOnly,
   addSubject, addProperty, addValue, removeValue,
   removeSubject, clearResource,
   saveResourceFinished, loadResourceFinished,
@@ -76,6 +76,7 @@ const editorHandlers = {
   SAVE_RESOURCE_FINISHED: saveResourceFinishedEditor,
   SET_CURRENT_COMPONENT: setCurrentComponent,
   SET_CURRENT_RESOURCE: setCurrentResource,
+  SET_CURRENT_RESOURCE_IS_READ_ONLY: setCurrentResourceIsReadOnly,
   SET_CURSOR_POSITION: setCursorPosition,
   SET_LITERAL_CONTENT: setLiteralInputContent,
   SET_UNUSED_RDF: setUnusedRDF,

--- a/src/reducers/resources.js
+++ b/src/reducers/resources.js
@@ -55,6 +55,11 @@ export const setCurrentResource = (state, action) => {
   return newState
 }
 
+export const setCurrentResourceIsReadOnly = (state, action) => ({
+  ...state,
+  currentResourceIsReadOnly: action.payload,
+})
+
 export const addSubject = (state, action) => addSubjectToNewState(state, _.cloneDeep(action.payload))
 
 const addSubjectToNewState = (state, subject, valueSubjectOfKey) => {

--- a/src/selectors/resources.js
+++ b/src/selectors/resources.js
@@ -58,6 +58,8 @@ export const selectNormValue = (state, key) => state.entities.values[key]
 
 export const selectCurrentResourceKey = (state) => state.editor.currentResource
 
+export const selectCurrentResourceIsReadOnly = (state) => state.editor.currentResourceIsReadOnly
+
 export const selectFullSubject = (state, key) => {
   const subject = selectNormSubject(state, key)
   if (_.isEmpty(subject)) return null

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -397,6 +397,26 @@ a.list-group-item {
   padding-right: 2px;
 }
 
+.btn-view-resource {
+  padding-left: 20px;
+  padding-right: 20px;
+  margin-right: 20px;
+  background-color: $link-color;
+  border-color: $link-color;
+}
+
+.view-resource-buttons {
+  padding-right: 20px;
+}
+
+.view-resource-modal-content {
+  overflow-x: hidden;
+}
+
+.modal-close {
+  opacity: 1;
+}
+
 .lookup-value {
   background-color: $lookup-value-bg;
   font-weight: bold;


### PR DESCRIPTION
Fixes #2172

![Peek 2020-09-24 10-45](https://user-images.githubusercontent.com/131982/94180620-2255a400-fe53-11ea-854e-644cf5ce3948.gif)

**NOTE**: Since I made this screencast, I had to pull the change that blurred the background because we don't have a maintainable, testable approach for this in the editor.

## Why was this change made?

To allow catalogers to view resources among search results before editing or copying them.

## How was this change tested?

CI, and in the browser, locally.

## Which documentation and/or configurations were updated?

None