### PR TITLE
prevent backspace for sending back button to browser when editing with diacritics

### DIFF
--- a/__tests__/feature/editing/editingLiteral.test.js
+++ b/__tests__/feature/editing/editingLiteral.test.js
@@ -108,6 +108,10 @@ describe('editing a literal property', () => {
     fireEvent.click(await screen.findByText('ọ'))
     expect(input).toHaveValue('Foọ')
 
+    // press backspace while the focus is on the diacritic panel and make sure we are still on the edit page
+    fireEvent.keyDown(await screen.findByText('ọ'), { key: 'Backspace', code: 8, charCode: 8 })
+    expect(screen.queryAllByText('Latin Extended')).toHaveLength(1)
+
     // Close it
     fireEvent.click(diacriticBtn)
     expect(screen.queryAllByText('Latin Extended')).toHaveLength(0)

--- a/src/components/editor/diacritics/DiacriticsSelection.jsx
+++ b/src/components/editor/diacritics/DiacriticsSelection.jsx
@@ -32,7 +32,11 @@ const DiacriticsSelection = (props) => {
 
   if (!props.showDiacritics) return null
 
-  return (<div id={props.id} tabIndex="0" >
+  const keyPressHandler = (event) => {
+    if (event.which === 8) event.preventDefault() // backspace should not be passed to the browser as it can cause the page to go back
+  }
+
+  return (<div id={props.id} onKeyDown={keyPressHandler} role="presentation" tabIndex="0" >
     <div className="row">
       <section className="col-1 offset-11">
         <button className="btn btn-lg" onClick={closeHandler}>&times;</button>


### PR DESCRIPTION
## Why was this change made?

Fixes #2103 

~~Also added the ability to hit the escape key and have it close the panel too (which follows other UI patterns).~~

## How was this change tested?

Added a new test, but it still passes even without my change, so I don't think the test is working correctly.


## Which documentation and/or configurations were updated?



