### PR TITLE
Refactors selectors to minimize changes to selected state.

### DIFF
--- a/__tests__/__action_fixtures__/newResourceCopy-ADD_SUBJECT.json
+++ b/__tests__/__action_fixtures__/newResourceCopy-ADD_SUBJECT.json
@@ -56,7 +56,6 @@
             "values": [
               {
                 "key": "abc2",
-                "index": 1,
                 "rootSubjectKey": "t9zVwg2zO",
                 "literal": "foo",
                 "lang": "eng",

--- a/__tests__/reducers/languages.test.js
+++ b/__tests__/reducers/languages.test.js
@@ -41,7 +41,8 @@ describe('languagesReceived()', () => {
 
     const newState = reducer(oldState, action)
     expect(newState).toEqual({
-      languages: [{ id: 'sna', label: 'Shona' }],
+      languageLookup: [{ id: 'sna', label: 'Shona' }],
+      languages: { sna: 'Shona' },
     })
   })
 })

--- a/__tests__/reducers/resources.test.js
+++ b/__tests__/reducers/resources.test.js
@@ -537,7 +537,7 @@ describe('clearResourceFromEditor()', () => {
 
     const newState = editorReducer(oldState.editor, action)
     expect(newState.errors['resourceedit-t9zVwg2zO']).toBe(undefined)
-    expect(newState.currentResource).toBe(undefined)
+    expect(newState.currentResource).toBe(null)
     expect(newState.resources).toStrictEqual([])
   })
 })

--- a/__tests__/selectors/errors.test.js
+++ b/__tests__/selectors/errors.test.js
@@ -1,6 +1,6 @@
 import { createState } from 'stateUtils'
 import {
-  displayResourceValidations, selectErrors, selectValidationErrors, selectCurrentResourceValidationErrors,
+  displayResourceValidations, selectErrors, selectValidationErrors,
 } from 'selectors/errors'
 
 describe('displayResourceValidations()', () => {
@@ -62,31 +62,6 @@ describe('selectValidationErrors()', () => {
   it('returns errors for a property with a nested resource given a subject key', () => {
     const state = createState({ hasResourceWithNestedResource: true, hasError: true })
     const errors = selectValidationErrors(state, 'ljAblGiBW')
-    expect(errors[0].message).toEqual('Required')
-    expect(errors[0].propertyKey).toEqual('7caLbfwwle')
-    expect(errors[0].labelPath).toEqual(['Uber template1', 'Uber template2', 'Uber template2, property1'])
-  })
-})
-
-describe('selectCurrentResourceValidationErrors()', () => {
-  it('returns nothing if there is no subject', () => {
-    const state = createState()
-    const errors = selectCurrentResourceValidationErrors(state)
-    expect(errors.length).toBe(0)
-  })
-
-  it('returns errors for a given property in state', () => {
-    const state = createState({ hasResourceWithLiteral: true, hasError: true })
-    const errors = selectCurrentResourceValidationErrors(state)
-    expect(errors.length).toBe(1)
-    expect(errors[0].message).toEqual('Required')
-    expect(errors[0].propertyKey).toEqual('JQEtq-vmq8')
-    expect(errors[0].labelPath).toEqual(['Abbreviated Title', 'Abbreviated Title'])
-  })
-
-  it('returns errors for a property in state with a nested resource', () => {
-    const state = createState({ hasResourceWithNestedResource: true, hasError: true })
-    const errors = selectCurrentResourceValidationErrors(state)
     expect(errors[0].message).toEqual('Required')
     expect(errors[0].propertyKey).toEqual('7caLbfwwle')
     expect(errors[0].labelPath).toEqual(['Uber template1', 'Uber template2', 'Uber template2, property1'])

--- a/__tests__/selectors/resources.test.js
+++ b/__tests__/selectors/resources.test.js
@@ -1,7 +1,7 @@
 import { createState } from 'stateUtils'
 import {
   selectSubject, selectProperty, selectValue,
-  selectCurrentResource, selectFullSubject, resourceHasChangesSinceLastSave,
+  selectFullSubject, resourceHasChangesSinceLastSave,
 } from 'selectors/resources'
 
 describe('selectSubject()', () => {
@@ -38,19 +38,6 @@ describe('selectValue()', () => {
     const state = createState({ hasResourceWithNestedResource: true })
     const value = selectValue(state, 'VDOeQCnFA8')
     expect(value).toBeValue('VDOeQCnFA8')
-    expect(value.index).toBe(1)
-  })
-})
-
-describe('selectCurrentResource()', () => {
-  it('returns null when no current resource', () => {
-    const state = createState()
-    expect(selectCurrentResource(state)).toBeNull()
-  })
-
-  it('returns subject for current resource', () => {
-    const state = createState({ hasResourceWithNestedResource: true })
-    expect(selectCurrentResource(state)).toBeSubject('ljAblGiBW')
   })
 })
 

--- a/__tests__/testUtilities/stateUtils.js
+++ b/__tests__/testUtilities/stateUtils.js
@@ -45,10 +45,14 @@ const buildAuthenticate = (state, options) => {
 const buildLanguages = (state, options) => {
   if (options.noLanguage) return
 
-  state.entities.languages = [
+  state.entities.languageLookup = [
     { id: 'tai', label: 'Tai languages' },
     { id: 'eng', label: 'English' },
   ]
+  state.entities.languages = {
+    tai: 'Tai languages',
+    eng: 'English',
+  }
 }
 
 const buildResourceWithError = (state, options) => {

--- a/src/components/editor/Editor.jsx
+++ b/src/components/editor/Editor.jsx
@@ -2,6 +2,7 @@
 
 import React from 'react'
 import PropTypes from 'prop-types'
+import { useSelector } from 'react-redux'
 import ResourceComponent from './ResourceComponent'
 import Header from '../Header'
 import RDFModal from './RDFModal'
@@ -10,23 +11,34 @@ import GroupChoiceModal from './GroupChoiceModal'
 import EditorActions from './EditorActions'
 import ErrorMessages from './ErrorMessages'
 import ResourcesNav from './ResourcesNav'
+import { displayResourceValidations, hasValidationErrors } from 'selectors/errors'
+import { selectCurrentResourceKey } from 'selectors/resources'
+
 
 // Error key for errors that occur while editing a resource.
 export const resourceEditErrorKey = (resourceKey) => `resourceedit-${resourceKey}`
 
-const Editor = (props) => (
-  <div id="editor">
-    <Header triggerEditorMenu={ props.triggerHandleOffsetMenu }/>
-    <EditorActions />
-    <DiacriticsSelection />
-    <RDFModal />
-    <ErrorMessages />
-    <GroupChoiceModal />
-    <ResourcesNav />
-    <ResourceComponent />
-    <EditorActions />
-  </div>
-)
+const Editor = (props) => {
+  const resourceKey = useSelector((state) => selectCurrentResourceKey(state))
+  const displayErrors = useSelector((state) => displayResourceValidations(state, resourceKey))
+  const hasErrors = useSelector((state) => hasValidationErrors(state, resourceKey))
+
+  if (!resourceKey) return null
+
+  return (
+    <div id="editor">
+      <Header triggerEditorMenu={ props.triggerHandleOffsetMenu }/>
+      <EditorActions />
+      <DiacriticsSelection />
+      <RDFModal />
+      {displayErrors && hasErrors && <ErrorMessages /> }
+      <GroupChoiceModal />
+      <ResourcesNav />
+      <ResourceComponent />
+      <EditorActions />
+    </div>
+  )
+}
 
 Editor.propTypes = {
   triggerHandleOffsetMenu: PropTypes.func,

--- a/src/components/editor/ErrorMessages.jsx
+++ b/src/components/editor/ErrorMessages.jsx
@@ -3,11 +3,12 @@
 import React from 'react'
 import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
-import { displayResourceValidations, selectCurrentResourceValidationErrors } from 'selectors/errors'
+import { selectValidationErrors } from 'selectors/errors'
+import { selectCurrentResourceKey } from 'selectors/resources'
 import Alert from '../Alert'
 
 const ErrorMessages = (props) => {
-  if (!props.displayValidations || props.errors.length === 0) {
+  if (props.errors.length === 0) {
     return null
   }
 
@@ -23,9 +24,11 @@ ErrorMessages.propTypes = {
   displayValidations: PropTypes.bool,
 }
 
-const mapStateToProps = (state) => ({
-  errors: selectCurrentResourceValidationErrors(state),
-  displayValidations: displayResourceValidations(state),
-})
+const mapStateToProps = (state) => {
+  const resourceKey = selectCurrentResourceKey(state)
+  return {
+    errors: selectValidationErrors(state, resourceKey),
+  }
+}
 
 export default connect(mapStateToProps, {})(ErrorMessages)

--- a/src/components/editor/ResourceComponent.jsx
+++ b/src/components/editor/ResourceComponent.jsx
@@ -12,9 +12,10 @@ import { newResourceErrorKey } from './property/ResourceList'
 import { resourceEditErrorKey } from './Editor'
 import { addError } from 'actions/errors'
 import { datasetFromN3 } from 'utilities/Utilities'
-import { selectCurrentResource } from 'selectors/resources'
+import { selectNormSubject, selectCurrentResourceKey } from 'selectors/resources'
 import { selectErrors } from 'selectors/errors'
 import { selectUnusedRDF } from 'selectors/modals'
+import { selectSubjectTemplate } from 'selectors/templates'
 import _ from 'lodash'
 
 /**
@@ -22,8 +23,9 @@ import _ from 'lodash'
  */
 const ResourceComponent = () => {
   const dispatch = useDispatch()
-  const resource = useSelector((state) => selectCurrentResource(state))
-  const resourceKey = resource.key
+  const resourceKey = useSelector((state) => selectCurrentResourceKey(state))
+  const resource = useSelector((state) => selectNormSubject(state, resourceKey))
+  const subjectTemplate = useSelector((state) => selectSubjectTemplate(state, resource.subjectTemplateKey))
   const errors = useSelector((state) => selectErrors(state, resourceEditErrorKey(resourceKey)))
   const unusedRDF = useSelector((state) => selectUnusedRDF(state, resourceKey))
 
@@ -49,7 +51,7 @@ const ResourceComponent = () => {
         <Alerts errorKey={resourceEditErrorKey(resourceKey)} />
         <Alerts errorKey={newResourceErrorKey} />
         <section>
-          <h3>{resource.subjectTemplate.label}</h3>
+          <h3>{subjectTemplate.label}</h3>
           <CopyToNewMessage />
           <ResourceURIMessage />
           <SaveAlert />

--- a/src/components/editor/ResourceURIMessage.jsx
+++ b/src/components/editor/ResourceURIMessage.jsx
@@ -2,11 +2,13 @@
 
 import React, { useState, useEffect } from 'react'
 import { useSelector } from 'react-redux'
-import { selectCurrentResource } from 'selectors/resources'
+import { selectCurrentResourceKey, selectNormSubject } from 'selectors/resources'
 
 // Renders the resource URI message for saved resource
 const ResourceURIMessage = () => {
-  const uri = useSelector((state) => selectCurrentResource(state).uri)
+  const resourceKey = useSelector((state) => selectCurrentResourceKey(state))
+  const resource = useSelector((state) => selectNormSubject(state, resourceKey))
+  const uri = resource.uri
 
   const [copyText, setCopyText] = useState('Copy URI')
   const [timerId, setTimerId] = useState(false)

--- a/src/components/editor/ResourcesNav.jsx
+++ b/src/components/editor/ResourcesNav.jsx
@@ -3,7 +3,8 @@
 import React from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import CloseButton from './actions/CloseButton'
-import { selectCurrentResourceKey, selectSubject, selectResourceKeys } from 'selectors/resources'
+import { selectCurrentResourceKey, selectResourceKeys } from 'selectors/resources'
+import { selectSubjectTemplateFor } from 'selectors/templates'
 import { setCurrentResource } from 'actions/resources'
 
 const ResourcesNav = () => {
@@ -16,8 +17,8 @@ const ResourcesNav = () => {
   const navLabels = useSelector((state) => {
     const labels = {}
     resourceKeys.forEach((resourceKey) => {
-      const subject = selectSubject(state, resourceKey)
-      const resourceLabel = subject.subjectTemplate.label
+      const subjectTemplate = selectSubjectTemplateFor(state, resourceKey)
+      const resourceLabel = subjectTemplate.label
       labels[resourceKey] = resourceLabel.length > 40 ? `${resourceLabel.slice(0, 40)}...` : resourceLabel
     })
     return labels

--- a/src/components/editor/actions/CopyToNewButton.jsx
+++ b/src/components/editor/actions/CopyToNewButton.jsx
@@ -6,12 +6,13 @@ import PropTypes from 'prop-types'
 import { showCopyNewMessage } from 'actions/messages'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCopy } from '@fortawesome/free-solid-svg-icons'
-import { selectCurrentResource } from 'selectors/resources'
+import { selectCurrentResourceKey, selectNormSubject } from 'selectors/resources'
 import { newResourceCopy } from 'actionCreators/resources'
 
 const CopyToNewButton = (props) => {
   const dispatch = useDispatch()
-  const resource = useSelector((state) => selectCurrentResource(state))
+  const resourceKey = useSelector((state) => selectCurrentResourceKey(state))
+  const resource = useSelector((state) => selectNormSubject(state, resourceKey))
 
   const handleClick = () => {
     dispatch(newResourceCopy(resource.key))

--- a/src/components/editor/actions/SaveAndPublishButton.jsx
+++ b/src/components/editor/actions/SaveAndPublishButton.jsx
@@ -5,10 +5,11 @@ import { useSelector, useDispatch } from 'react-redux'
 import PropTypes from 'prop-types'
 import { saveResource as saveResourceAction } from 'actionCreators/resources'
 import {
-  resourceHasChangesSinceLastSave, selectCurrentResource,
+  resourceHasChangesSinceLastSave, selectNormSubject,
+  selectCurrentResourceKey,
 } from 'selectors/resources'
 import {
-  displayResourceValidations, selectCurrentResourceValidationErrors,
+  displayResourceValidations, hasValidationErrors as hasValidationErrorsSelector,
 } from 'selectors/errors'
 import {
   showModal as showModalAction,
@@ -22,17 +23,18 @@ import { resourceEditErrorKey } from '../Editor'
 const SaveAndPublishButton = (props) => {
   const dispatch = useDispatch()
 
-  const resource = useSelector((state) => selectCurrentResource(state))
+  const resourceKey = useSelector((state) => selectCurrentResourceKey(state))
+  const resource = useSelector((state) => selectNormSubject(state, resourceKey))
   const isSaved = !!resource.uri
-  const saveResource = () => dispatch(saveResourceAction(resource.key, resourceEditErrorKey(resource.key)))
+  const saveResource = () => dispatch(saveResourceAction(resourceKey, resourceEditErrorKey(resourceKey)))
 
   const showGroupChooser = () => dispatch(showModalAction('GroupChoiceModal'))
-  const showValidationErrors = () => dispatch(showValidationErrorsAction(resource.key))
-  const hideValidationErrors = () => dispatch(hideValidationErrorsAction(resource.key))
+  const showValidationErrors = () => dispatch(showValidationErrorsAction(resourceKey))
+  const hideValidationErrors = () => dispatch(hideValidationErrorsAction(resourceKey))
 
   const resourceHasChanged = useSelector((state) => resourceHasChangesSinceLastSave(state))
-  const hasValidationErrors = useSelector((state) => selectCurrentResourceValidationErrors(state).length > 0)
-  const validationErrorsAreShowing = useSelector((state) => displayResourceValidations(state))
+  const hasValidationErrors = useSelector((state) => hasValidationErrorsSelector(state, resourceKey))
+  const validationErrorsAreShowing = useSelector((state) => displayResourceValidations(state, resourceKey))
   const [isDisabled, setIsDisabled] = useState(true)
 
   useEffect(() => {

--- a/src/components/editor/property/InputLiteral.jsx
+++ b/src/components/editor/property/InputLiteral.jsx
@@ -23,8 +23,8 @@ const InputLiteral = (props) => {
   const [lang, setLang] = useState(defaultLanguageId)
   const id = `inputliteral-${props.property.key}`
 
-  const disabled = !props.property.propertyTemplate.repeatable
-      && props.property.values.length > 0
+  const disabled = !props.propertyTemplate.repeatable
+      && props.property.valueKeys.length > 0
 
   const addItem = () => {
     let currentcontent = props.content.trim()
@@ -70,8 +70,7 @@ const InputLiteral = (props) => {
   const addedList = props.property.valueKeys.map((valueKey) => (<InputValue key={valueKey}
                                                                             handleEdit={handleEdit}
                                                                             valueKey={valueKey} />))
-
-  const required = props.property.propertyTemplate.required
+  const required = props.propertyTemplate.required
 
   let error
   let controlClasses = 'form-control'
@@ -122,7 +121,7 @@ const InputLiteral = (props) => {
         <TextareaAutosize
               required={required}
               className={controlClasses}
-              placeholder={props.property.propertyTemplate.label}
+              placeholder={props.propertyTemplate.label}
               onChange={(event) => props.setLiteralContent(props.property.key, event.target.value)}
               onKeyPress={handleKeypress}
               onFocus={handleFocus}
@@ -149,6 +148,7 @@ InputLiteral.propTypes = {
   showDiacritics: PropTypes.func,
   displayValidations: PropTypes.bool,
   property: PropTypes.object.isRequired,
+  propertyTemplate: PropTypes.object.isRequired,
   addValue: PropTypes.func,
   content: PropTypes.string,
   setLiteralContent: PropTypes.func,
@@ -156,9 +156,9 @@ InputLiteral.propTypes = {
 }
 
 const mapStateToProps = (state, ownProps) => ({
-  displayValidations: displayResourceValidations(state),
+  displayValidations: displayResourceValidations(state, ownProps.property?.rootSubjectKey),
   shouldShowDiacritic: displayDiacritics(state),
-  content: selectLiteralInputContent(state, ownProps.property.key) || '',
+  content: selectLiteralInputContent(state, ownProps.property?.key) || '',
 })
 
 const mapDispatchToProps = (dispatch) => bindActionCreators({

--- a/src/components/editor/property/InputLookup.jsx
+++ b/src/components/editor/property/InputLookup.jsx
@@ -7,22 +7,22 @@ import { connect, useSelector, useDispatch } from 'react-redux'
 import { bindActionCreators } from 'redux'
 import { displayResourceValidations } from 'selectors/errors'
 import _ from 'lodash'
-import { itemsForProperty } from './renderTypeaheadFunctions'
+import { itemsForValues } from './renderTypeaheadFunctions'
 import { removeValue } from 'actions/resources'
 import { showModal } from 'actions/modals'
 import ModalWrapper from 'components/ModalWrapper'
 import LookupWithMultipleAuthorities from './LookupWithMultipleAuthorities'
-
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faGlobe, faSearch, faTrashAlt } from '@fortawesome/free-solid-svg-icons'
+import { selectNormValues } from 'selectors/resources'
 
 const InputLookup = (props) => {
   const dispatch = useDispatch()
-  const displayValidations = useSelector((state) => displayResourceValidations(state))
+  const displayValidations = useSelector((state) => displayResourceValidations(state, props.property.rootSubjectKey))
   const errors = props.property.errors
-  const selected = itemsForProperty(props.property)
+  const selected = itemsForValues(props.lookupValues)
 
-  const isRepeatable = props.property.propertyTemplate.repeatable
+  const isRepeatable = props.propertyTemplate.repeatable
 
   const isDisabled = selected?.length > 0 && !isRepeatable
 
@@ -57,7 +57,9 @@ const InputLookup = (props) => {
   let modal
   if (props.show) {
     modal = (
-      <LookupWithMultipleAuthorities modalId={modalId} property={props.property}
+      <LookupWithMultipleAuthorities modalId={modalId}
+                                     property={props.property}
+                                     propertyTemplate={props.propertyTemplate}
                                      getLookupResults={props.getLookupResults}
                                      getOptions={props.getOptions}
                                      show={props.show} />
@@ -70,7 +72,7 @@ const InputLookup = (props) => {
         id="lookup"
         data-testid="lookup"
         onClick={ handleClick }
-        aria-label={`Lookup value for ${props.property.propertyTemplate.label}`}
+        aria-label={`Lookup value for ${props.propertyTemplate.label}`}
         disabled={isDisabled}
         className={controlClasses}>
         <FontAwesomeIcon className="search-icon" icon={faSearch} />
@@ -84,6 +86,7 @@ const InputLookup = (props) => {
 
 InputLookup.propTypes = {
   property: PropTypes.object.isRequired,
+  propertyTemplate: PropTypes.object.isRequired,
   getLookupResults: PropTypes.func.isRequired,
   getOptions: PropTypes.func.isRequired,
   show: PropTypes.bool,
@@ -91,13 +94,10 @@ InputLookup.propTypes = {
   removeValue: PropTypes.func,
 }
 
-const mapStateToProps = (state, ownProps) => {
-  const show = selectModalType(state) === `InputLookupModal-${ownProps.property.key}`
-  return {
-    lookupValues: ownProps.property.values,
-    show,
-  }
-}
+const mapStateToProps = (state, ownProps) => ({
+  lookupValues: selectNormValues(state, ownProps.property?.valueKeys),
+  show: selectModalType(state) === `InputLookupModal-${ownProps.property.key}`,
+})
 
 const mapDispatchToProps = (dispatch) => bindActionCreators({ removeValue }, dispatch)
 

--- a/src/components/editor/property/InputLookupQA.jsx
+++ b/src/components/editor/property/InputLookupQA.jsx
@@ -7,12 +7,17 @@ import { getQAOptions } from 'utilities/Search'
 import InputLookup from './InputLookup'
 
 const InputLookupQA = (props) => (
-  <InputLookup getLookupResults={getSearchResults} getOptions={getQAOptions} property={props.property} />
+  <InputLookup
+    getLookupResults={getSearchResults}
+    getOptions={getQAOptions}
+    property={props.property}
+    propertyTemplate={props.propertyTemplate} />
 )
 
 
 InputLookupQA.propTypes = {
   property: PropTypes.object.isRequired,
+  propertyTemplate: PropTypes.object.isRequired,
 }
 
 export default InputLookupQA

--- a/src/components/editor/property/InputLookupSinopia.jsx
+++ b/src/components/editor/property/InputLookupSinopia.jsx
@@ -10,7 +10,11 @@ import InputLookup from './InputLookup'
 
 const InputLookupSinopia = (props) => (
   <React.Fragment>
-    <InputLookup getLookupResults={getLookupResults} getOptions={getSinopiaOptions} property={props.property} />
+    <InputLookup
+      getLookupResults={getLookupResults}
+      getOptions={getSinopiaOptions}
+      property={props.property}
+      propertyTemplate={props.propertyTemplate} />
     <ResourceList property={props.property} />
   </React.Fragment>
 )
@@ -18,6 +22,7 @@ const InputLookupSinopia = (props) => (
 
 InputLookupSinopia.propTypes = {
   property: PropTypes.object.isRequired,
+  propertyTemplate: PropTypes.object.isRequired,
 }
 
 export default InputLookupSinopia

--- a/src/components/editor/property/InputURI.jsx
+++ b/src/components/editor/property/InputURI.jsx
@@ -18,8 +18,8 @@ const InputURI = (props) => {
   const [content, setContent] = useState('')
   const [uriError, setURIError] = useState(false)
 
-  const disabled = !props.property.propertyTemplate.repeatable
-      && props.property.values.length > 0
+  const disabled = !props.propertyTemplate.repeatable
+      && props.property.valueKeys.length > 0
 
   const addItem = () => {
     const currentcontent = content.trim()
@@ -49,7 +49,7 @@ const InputURI = (props) => {
     inputLiteralRef.current.focus()
   }
 
-  const required = props.property.propertyTemplate.required
+  const required = props.propertyTemplate.required
 
   const mergeErrors = () => {
     let errors = []
@@ -81,7 +81,7 @@ const InputURI = (props) => {
       <input id={id}
              required={required}
              className={controlClasses}
-             placeholder={props.property.propertyTemplate.label}
+             placeholder={props.propertyTemplate.label}
              onChange={(event) => setContent(event.target.value)}
              onKeyPress={handleKeypress}
              value={content}
@@ -97,12 +97,13 @@ const InputURI = (props) => {
 
 InputURI.propTypes = {
   property: PropTypes.object.isRequired,
+  propertyTemplate: PropTypes.object.isRequired,
   displayValidations: PropTypes.bool,
   addValue: PropTypes.func,
 }
 
-const mapStateToProps = (state) => ({
-  displayValidations: displayResourceValidations(state),
+const mapStateToProps = (state, ownProps) => ({
+  displayValidations: displayResourceValidations(state, ownProps.property?.rootSubjectKey),
 })
 
 const mapDispatchToProps = (dispatch) => bindActionCreators({ addValue }, dispatch)

--- a/src/components/editor/property/InputValue.jsx
+++ b/src/components/editor/property/InputValue.jsx
@@ -6,17 +6,18 @@ import { bindActionCreators } from 'redux'
 import PropTypes from 'prop-types'
 import { removeValue } from 'actions/resources'
 import LanguageButton from './LanguageButton'
-import { selectValue } from 'selectors/resources'
+import { selectNormValue, selectNormProperty } from 'selectors/resources'
+import { selectPropertyTemplate } from 'selectors/templates'
 
 const InputValue = (props) => {
   if (!props.value) return null
 
-  const isLiteral = props.value.property.propertyTemplate.type === 'literal'
+  const isLiteral = props.propertyTemplate.type === 'literal'
   const label = props.value.literal || props.value.label || props.value.uri
 
   const handleEditClick = () => {
-    props.handleEdit(label, props.value.lang)
     props.removeValue(props.valueKey)
+    props.handleEdit(label, props.value.lang)
   }
 
   return (<div className="input-value">
@@ -48,11 +49,17 @@ InputValue.propTypes = {
   removeValue: PropTypes.func.isRequired,
   valueKey: PropTypes.string.isRequired,
   value: PropTypes.object,
+  propertyTemplate: PropTypes.object,
 }
 
-const mapStateToProps = (state, ownProps) => ({
-  value: selectValue(state, ownProps.valueKey),
-})
+const mapStateToProps = (state, ownProps) => {
+  const value = selectNormValue(state, ownProps.valueKey)
+  const property = selectNormProperty(state, value?.propertyKey)
+  return {
+    value,
+    propertyTemplate: selectPropertyTemplate(state, property?.propertyTemplateKey),
+  }
+}
 
 const mapDispatchToProps = (dispatch) => bindActionCreators({ removeValue }, dispatch)
 

--- a/src/components/editor/property/LookupWithMultipleAuthorities.jsx
+++ b/src/components/editor/property/LookupWithMultipleAuthorities.jsx
@@ -34,9 +34,9 @@ const LookupWithMultipleAuthorities = (props) => {
 
   const allAuthorities = useMemo(() => {
     const authorities = {}
-    props.property.propertyTemplate.authorities.forEach((authority) => authorities[authority.uri] = authority)
+    props.propertyTemplate.authorities.forEach((authority) => authorities[authority.uri] = authority)
     return Object.values(authorities)
-  }, [props.property.propertyTemplate.authorities])
+  }, [props.propertyTemplate.authorities])
 
 
   // For use inside the effect without having to add props to dependency array.
@@ -164,7 +164,7 @@ const LookupWithMultipleAuthorities = (props) => {
         <div className="modal-content">
           <div className="modal-header">
             <div className="form-group">
-              <label htmlFor="search">{props.property.propertyTemplate.label}</label>
+              <label htmlFor="search">{props.propertyTemplate.label}</label>
               <input id="search" type="search" className="form-control"
                      onKeyUp={(e) => setQuery(e.target.value)}></input>
             </div>
@@ -188,6 +188,7 @@ const LookupWithMultipleAuthorities = (props) => {
 LookupWithMultipleAuthorities.propTypes = {
   modalId: PropTypes.string,
   property: PropTypes.object.isRequired,
+  propertyTemplate: PropTypes.object.isRequired,
   getLookupResults: PropTypes.func.isRequired,
   getOptions: PropTypes.func.isRequired,
   show: PropTypes.bool,

--- a/src/components/editor/property/NestedProperty.jsx
+++ b/src/components/editor/property/NestedProperty.jsx
@@ -4,23 +4,23 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import NestedPropertyHeader from './NestedPropertyHeader'
 import PropertyComponent from './PropertyComponent'
-import { selectProperty } from 'selectors/resources'
+import { selectNormProperty } from 'selectors/resources'
 import { connect } from 'react-redux'
 import useNavigableComponent from 'hooks/useNavigableComponent'
+import { selectPropertyTemplate } from 'selectors/templates'
 
 const NestedProperty = (props) => {
   const [navEl, navClickHandler] = useNavigableComponent(props.property.rootSubjectKey, props.property.rootPropertyKey, props.property.key)
-
   // onClick is to support left navigation, so ignoring jsx-ally seems reasonable.
   /* eslint-disable jsx-a11y/click-events-have-key-events */
   /* eslint-disable jsx-a11y/no-static-element-interactions */
   return (
-    <div ref={navEl} onClick={navClickHandler} className="rtOutline" data-label={props.property.propertyTemplate.label}>
-      <NestedPropertyHeader property={ props.property } />
-      { props.property.values !== null && props.property.show
+    <div ref={navEl} onClick={navClickHandler} className="rtOutline" data-label={props.propertyTemplate.label}>
+      <NestedPropertyHeader property={ props.property } propertyTemplate={ props.propertyTemplate } />
+      { props.property.valueKeys && props.property.show
           && (
             <div className="rOutline-property">
-              <PropertyComponent property={ props.property } />
+              <PropertyComponent property={ props.property } propertyTemplate={ props.propertyTemplate } />
             </div>
           )
       }
@@ -31,10 +31,15 @@ const NestedProperty = (props) => {
 NestedProperty.propTypes = {
   propertyKey: PropTypes.string.isRequired,
   property: PropTypes.object,
+  propertyTemplate: PropTypes.object,
 }
 
-const mapStateToProps = (state, ourProps) => ({
-  property: selectProperty(state, ourProps.propertyKey),
-})
+const mapStateToProps = (state, ourProps) => {
+  const property = selectNormProperty(state, ourProps.propertyKey)
+  return {
+    property,
+    propertyTemplate: selectPropertyTemplate(state, property?.propertyTemplateKey),
+  }
+}
 
 export default connect(mapStateToProps)(NestedProperty)

--- a/src/components/editor/property/NestedPropertyHeader.jsx
+++ b/src/components/editor/property/NestedPropertyHeader.jsx
@@ -10,17 +10,16 @@ import PropertyLabelInfo from './PropertyLabelInfo'
 import { displayResourceValidations } from 'selectors/errors'
 import { showProperty, hideProperty } from 'actions/resources'
 import { resourceEditErrorKey } from '../Editor'
-import { selectCurrentResourceKey } from 'selectors/resources'
 import _ from 'lodash'
 import { expandProperty, contractProperty } from 'actionCreators/resources'
 import { bindActionCreators } from 'redux'
 
 const NestedPropertyHeader = (props) => {
   const toggleIcon = props.property.show === true ? faAngleDown : faAngleRight
-  const toggleAria = props.property.show === true ? `Hide ${props.property.propertyTemplate.label}` : `Show ${props.property.propertyTemplate.label}`
+  const toggleAria = props.property.show === true ? `Hide ${props.propertyTemplate.label}` : `Show ${props.propertyTemplate.label}`
   const trashIcon = faTrashAlt
 
-  const isAdd = props.property.values === null
+  const isAdd = !props.property.valueKeys
 
   let error
   let groupClasses = 'rOutline-header'
@@ -44,12 +43,12 @@ const NestedPropertyHeader = (props) => {
         <button type="button"
                 className="btn btn-default btn-add btn-add-property"
                 onClick={() => props.expandProperty(props.property.key, resourceEditErrorKey(props.resourceKey))}
-                aria-label={`Add ${props.property.propertyTemplate.label}`}
-                data-testid={`Add ${props.property.propertyTemplate.label}`}
+                aria-label={`Add ${props.propertyTemplate.label}`}
+                data-testid={`Add ${props.propertyTemplate.label}`}
                 data-id={props.property.key}>
-          + Add <strong><PropertyLabel propertyTemplate={props.property.propertyTemplate} /></strong>
+          + Add <strong><PropertyLabel propertyTemplate={props.propertyTemplate} /></strong>
         </button>
-        <PropertyLabelInfo propertyTemplate={ props.property.propertyTemplate } />
+        <PropertyLabelInfo propertyTemplate={ props.propertyTemplate } />
         { error && <span className="invalid-feedback">{error}</span>}
       </div>
     )
@@ -66,13 +65,13 @@ const NestedPropertyHeader = (props) => {
               onClick={() => toggleProperty()}>
         <FontAwesomeIcon className="toggle-icon" icon={toggleIcon} />
       </button>
-      <strong><PropertyLabel propertyTemplate={props.property.propertyTemplate} /></strong>
-      <PropertyLabelInfo propertyTemplate={ props.property.propertyTemplate } />
+      <strong><PropertyLabel propertyTemplate={props.propertyTemplate} /></strong>
+      <PropertyLabelInfo propertyTemplate={ props.propertyTemplate } />
       <button type="button"
               className="btn btn-sm btn-remove pull-right"
               onClick={() => props.contractProperty(props.property.key)}
-              aria-label={`Remove ${props.property.propertyTemplate.label}`}
-              data-testid={`Remove ${props.property.propertyTemplate.label}`}
+              aria-label={`Remove ${props.propertyTemplate.label}`}
+              data-testid={`Remove ${props.propertyTemplate.label}`}
               data-id={props.property.key}>
         <FontAwesomeIcon className="trash-icon" icon={trashIcon} />
       </button>
@@ -84,6 +83,7 @@ NestedPropertyHeader.propTypes = {
   collapsed: PropTypes.any,
   handleCollapsed: PropTypes.func,
   property: PropTypes.object.isRequired,
+  propertyTemplate: PropTypes.object.isRequired,
   handleAddButton: PropTypes.func,
   handleRemoveButton: PropTypes.func,
   displayValidations: PropTypes.bool,
@@ -95,10 +95,10 @@ NestedPropertyHeader.propTypes = {
   resourceKey: PropTypes.string,
 }
 
-const mapStateToProps = (state) => ({
+const mapStateToProps = (state, ownProps) => ({
   collapsed: false,
-  displayValidations: displayResourceValidations(state),
-  resourceKey: selectCurrentResourceKey(state),
+  displayValidations: displayResourceValidations(state, ownProps.property?.rootSubjectKey),
+  resourceKey: ownProps.property?.rootSubjectKey,
 })
 
 const mapDispatchToProps = (dispatch) => bindActionCreators({

--- a/src/components/editor/property/NestedResource.jsx
+++ b/src/components/editor/property/NestedResource.jsx
@@ -4,13 +4,14 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import NestedProperty from './NestedProperty'
 import NestedResourceActionButtons from './NestedResourceActionButtons'
-import { selectValue } from 'selectors/resources'
+import { selectNormValue, selectNormSubject } from 'selectors/resources'
+import { selectSubjectTemplate } from 'selectors/templates'
 import { connect } from 'react-redux'
 import useNavigableComponent from 'hooks/useNavigableComponent'
 
 // AKA a value subject.
 const NestedResource = (props) => {
-  const [navEl, navClickHandler] = useNavigableComponent(props.value.rootSubjectKey, props.value.rootPropertyKey, props.value.valueSubject.key)
+  const [navEl, navClickHandler] = useNavigableComponent(props.value.rootSubjectKey, props.value.rootPropertyKey, props.value.valueSubjectKey)
 
   // onClick is to support left navigation, so ignoring jsx-ally seems reasonable.
   /* eslint-disable jsx-a11y/click-events-have-key-events */
@@ -19,7 +20,7 @@ const NestedResource = (props) => {
     <div className='nested-resource' ref={navEl} onClick={navClickHandler}>
       <div className="row" key={props.valueKey}>
         <section className="col-md-6">
-          <h5>{ props.value.valueSubject.subjectTemplate.label }</h5>
+          <h5>{ props.subjectTemplate.label }</h5>
         </section>
         <section className="col-md-6">
           <NestedResourceActionButtons value={props.value} />
@@ -27,7 +28,7 @@ const NestedResource = (props) => {
       </div>
       <div>
         {
-          props.value.valueSubject.propertyKeys.map((propertyKey) => (
+          props.valueSubject.propertyKeys.map((propertyKey) => (
             <NestedProperty key={propertyKey} propertyKey={propertyKey} />
           ))
         }
@@ -39,10 +40,19 @@ const NestedResource = (props) => {
 NestedResource.propTypes = {
   valueKey: PropTypes.string.isRequired,
   value: PropTypes.object,
+  valueSubject: PropTypes.object,
+  subjectTemplate: PropTypes.object,
 }
 
-const mapStateToProps = (state, ourProps) => ({
-  value: selectValue(state, ourProps.valueKey),
-})
+const mapStateToProps = (state, ourProps) => {
+  // props.value.valueSubject.subjectTemplate
+  const value = selectNormValue(state, ourProps.valueKey)
+  const valueSubject = selectNormSubject(state, value?.valueSubjectKey)
+  return {
+    value,
+    valueSubject,
+    subjectTemplate: selectSubjectTemplate(state, valueSubject?.subjectTemplateKey),
+  }
+}
 
 export default connect(mapStateToProps)(NestedResource)

--- a/src/components/editor/property/PanelProperty.jsx
+++ b/src/components/editor/property/PanelProperty.jsx
@@ -11,13 +11,14 @@ import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
 import { resourceEditErrorKey } from '../Editor'
 import { expandProperty, contractProperty } from 'actionCreators/resources'
-import { selectProperty, selectCurrentResourceKey } from 'selectors/resources'
+import { selectNormProperty, selectCurrentResourceKey } from 'selectors/resources'
+import { selectPropertyTemplate } from 'selectors/templates'
 import useNavigableComponent from 'hooks/useNavigableComponent'
 
 const PanelProperty = (props) => {
   // Null values indicates that can be added.
-  const isAdd = props.property.values === null
-  const isRequired = props.property.propertyTemplate.required
+  const isAdd = !props.property.valueKeys
+  const isRequired = props.propertyTemplate.required
   const nbsp = '\u00A0'
   const trashIcon = faTrashAlt
   const [navEl, navClickHandler] = useNavigableComponent(props.resourceKey, props.propertyKey, props.propertyKey)
@@ -27,18 +28,18 @@ const PanelProperty = (props) => {
   /* eslint-disable jsx-a11y/no-static-element-interactions */
   return (
     <div ref={navEl} onClick={navClickHandler}>
-      <div className="card" data-label={ props.property.propertyTemplate.label } style={{ marginBottom: '1em' }}>
+      <div className="card" data-label={ props.propertyTemplate.label } style={{ marginBottom: '1em' }}>
         <div className="card-header prop-heading">
           <h5 className="card-title">
-            <PropertyLabel propertyTemplate={ props.property.propertyTemplate } />
-            <PropertyLabelInfo propertyTemplate={ props.property.propertyTemplate } />{nbsp}
+            <PropertyLabel propertyTemplate={ props.propertyTemplate } />
+            <PropertyLabelInfo propertyTemplate={ props.propertyTemplate } />{nbsp}
             { isAdd && (
               <button
                   type="button"
                   className="btn btn-sm btn-add btn-add-instance pull-right"
                   onClick={() => props.expandProperty(props.property.key, resourceEditErrorKey(props.resourceKey))}
-                  aria-label={`Add ${props.property.propertyTemplate.label}`}
-                  data-testid={`Add ${props.property.propertyTemplate.label}`}
+                  aria-label={`Add ${props.propertyTemplate.label}`}
+                  data-testid={`Add ${props.propertyTemplate.label}`}
                   data-id={props.property.key}>
                 + Add
               </button>
@@ -46,8 +47,8 @@ const PanelProperty = (props) => {
             { !isAdd && !isRequired && (
               <button type="button"
                       className="btn btn-sm btn-remove pull-right"
-                      aria-label={`Remove ${props.property.propertyTemplate.label}`}
-                      data-testid={`Remove ${props.property.propertyTemplate.label}`}
+                      aria-label={`Remove ${props.propertyTemplate.label}`}
+                      data-testid={`Remove ${props.propertyTemplate.label}`}
                       onClick={() => props.contractProperty(props.property.key)} data-id={props.id}>
                 <FontAwesomeIcon className="fa-inverse trash-icon" icon={trashIcon} />
               </button>
@@ -56,7 +57,7 @@ const PanelProperty = (props) => {
         </div>
         { !isAdd && (
           <div className="card-body panel-property">
-            <PropertyComponent property={ props.property } />
+            <PropertyComponent property={ props.property } propertyTemplate={ props.propertyTemplate } />
           </div>
         )}
       </div>
@@ -68,16 +69,21 @@ PanelProperty.propTypes = {
   float: PropTypes.number,
   id: PropTypes.string,
   property: PropTypes.object,
+  propertyTemplate: PropTypes.object,
   propertyKey: PropTypes.string.isRequired,
   expandProperty: PropTypes.func,
   contractProperty: PropTypes.func,
   resourceKey: PropTypes.string.isRequired,
 }
 
-const mapStateToProps = (state, ourProps) => ({
-  property: selectProperty(state, ourProps.propertyKey),
-  resourceKey: selectCurrentResourceKey(state),
-})
+const mapStateToProps = (state, ourProps) => {
+  const property = selectNormProperty(state, ourProps.propertyKey)
+  return {
+    property,
+    propertyTemplate: selectPropertyTemplate(state, property?.propertyTemplateKey),
+    resourceKey: selectCurrentResourceKey(state),
+  }
+}
 
 const mapDispatchToProps = (dispatch) => bindActionCreators({ expandProperty, contractProperty }, dispatch)
 

--- a/src/components/editor/property/PanelPropertyNav.jsx
+++ b/src/components/editor/property/PanelPropertyNav.jsx
@@ -3,30 +3,34 @@ import PropTypes from 'prop-types'
 import { setCurrentComponent } from 'actions/index'
 import { useDispatch, useSelector } from 'react-redux'
 import { displayResourceValidations } from 'selectors/errors'
-import { selectProperty } from 'selectors/resources'
+import { selectNormProperty } from 'selectors/resources'
+import { selectPropertyTemplate } from 'selectors/templates'
 import _ from 'lodash'
 
 const PanelPropertyNav = (props) => {
   const dispatch = useDispatch()
-  const property = useSelector((state) => selectProperty(state, props.propertyKey))
+  const property = useSelector((state) => selectNormProperty(state, props.propertyKey))
+  const propertyTemplate = useSelector((state) => selectPropertyTemplate(state, property?.propertyTemplateKey))
 
   const hasValue = !_.isEmpty(property.descUriOrLiteralValueKeys)
   const liClassNames = hasValue ? 'li-checked' : ''
 
   const hasError = !_.isEmpty(property.descWithErrorPropertyKeys)
-  const displayValidations = useSelector((state) => displayResourceValidations(state))
+  const displayValidations = useSelector((state) => displayResourceValidations(state, property?.rootSubjectKey))
   const headingClassNames = ['left-nav-header']
   if (displayValidations && hasError) headingClassNames.push('text-danger')
+
+  if (!property) return null
 
   return (<li className={liClassNames}>
     <button
               type="button"
               className="btn btn-link"
-              aria-label={`Go to ${property.propertyTemplate.label}`}
-              data-testid={`Go to ${property.propertyTemplate.label}`}
+              aria-label={`Go to ${propertyTemplate.label}`}
+              data-testid={`Go to ${propertyTemplate.label}`}
               onClick={() => dispatch(setCurrentComponent(property.rootSubjectKey, property.rootPropertyKey, property.key))}>
       <h5 className={headingClassNames.join(' ')}>
-        {property.propertyTemplate.label}
+        {propertyTemplate.label}
       </h5>
     </button>
   </li>)

--- a/src/components/editor/property/PanelResource.jsx
+++ b/src/components/editor/property/PanelResource.jsx
@@ -12,8 +12,8 @@ const PanelResource = (props) => (
     <div className="col-sm-9">
       <form>
         {
-          props.resource.properties.map((property, index) => (
-            <PanelProperty resourceKey={props.resource.key} propertyKey={property.key} key={property.key} float={index} id={property.key} />
+          props.resource.propertyKeys.map((propertyKey, index) => (
+            <PanelProperty resourceKey={props.resource.key} propertyKey={propertyKey} key={propertyKey} float={index} id={propertyKey} />
           ))
         }
       </form>

--- a/src/components/editor/property/PanelResourceNav.jsx
+++ b/src/components/editor/property/PanelResourceNav.jsx
@@ -8,13 +8,13 @@ import { selectCurrentPropertyKey } from 'selectors/index'
 import { useSelector } from 'react-redux'
 
 const PanelResourceNav = (props) => {
-  const currentPropertyKey = useSelector((state) => selectCurrentPropertyKey(state, props.resource.key))
+  const currentPropertyKey = useSelector((state) => selectCurrentPropertyKey(state, props.resource?.key))
 
-  const navItems = props.resource.properties.map((property) => {
-    if (property.key === currentPropertyKey) {
-      return (<ActivePanelPropertyNav key={property.key} propertyKey={property.key} />)
+  const navItems = props.resource.propertyKeys.map((propertyKey) => {
+    if (propertyKey === currentPropertyKey) {
+      return (<ActivePanelPropertyNav key={propertyKey} propertyKey={propertyKey} />)
     }
-    return (<PanelPropertyNav key={property.key} propertyKey={property.key} />)
+    return (<PanelPropertyNav key={propertyKey} propertyKey={propertyKey} />)
   })
   return (
     <div className="col-sm-3">

--- a/src/components/editor/property/PropertyComponent.jsx
+++ b/src/components/editor/property/PropertyComponent.jsx
@@ -13,30 +13,30 @@ import Alert from '../../Alert'
 // Decides how to render this property.
 const PropertyComponent = (props) => {
   // Might be tempted to use lazy / suspense here, but it forces a remounting of components.
-  switch (props.property.propertyTemplate.component) {
+  switch (props.propertyTemplate.component) {
     case 'NestedResource':
-      return props.property.values.map((value) => (
-        <NestedResource key={value.key} valueKey={value.key} />
+      return props.property.valueKeys.map((valueKey) => (
+        <NestedResource key={valueKey} valueKey={valueKey} />
       ))
     case 'InputLiteral':
       return (
-        <InputLiteral property={props.property} />
+        <InputLiteral property={props.property} propertyTemplate={props.propertyTemplate} />
       )
     case 'InputURI':
       return (
-        <InputURI property={props.property} />
+        <InputURI property={props.property} propertyTemplate={props.propertyTemplate} />
       )
     case 'InputLookupQA':
       return (
-        <InputLookupQA property={props.property} />
+        <InputLookupQA property={props.property} propertyTemplate={props.propertyTemplate} />
       )
     case 'InputLookupSinopia':
       return (
-        <InputLookupSinopia property={props.property} />
+        <InputLookupSinopia property={props.property} propertyTemplate={props.propertyTemplate} />
       )
     case 'InputListLOC':
       return (
-        <InputListLOC property={props.property} />
+        <InputListLOC property={props.property} propertyTemplate={props.propertyTemplate} />
       )
     default:
       return (
@@ -47,6 +47,7 @@ const PropertyComponent = (props) => {
 
 PropertyComponent.propTypes = {
   property: PropTypes.object.isRequired,
+  propertyTemplate: PropTypes.object.isRequired,
 }
 
 export default PropertyComponent

--- a/src/components/editor/property/ResourceList.jsx
+++ b/src/components/editor/property/ResourceList.jsx
@@ -1,11 +1,13 @@
 // Copyright 2019 Stanford University see LICENSE for license
 
 import React, { useEffect, useRef, useState } from 'react'
-import { useDispatch } from 'react-redux'
+import { useDispatch, useSelector } from 'react-redux'
 import PropTypes from 'prop-types'
 import { getTemplateSearchResults } from 'sinopiaSearch'
 import shortid from 'shortid'
 import { newResource } from 'actionCreators/resources'
+import { selectPropertyTemplate, selectSubjectTemplate } from 'selectors/templates'
+import { selectNormSubject } from 'selectors/resources'
 
 export const newResourceErrorKey = 'newresource'
 
@@ -13,6 +15,10 @@ const ResourceList = (props) => {
   const dispatch = useDispatch()
   const [newResourceList, setNewResourceList] = useState([])
   const topRef = useRef(null)
+
+  const propertyTemplate = useSelector((state) => selectPropertyTemplate(state, props.property?.propertyTemplateKey))
+  const subject = useSelector((state) => selectNormSubject(state, props.property?.subjectKey))
+  const subjectTemplate = useSelector((state) => selectSubjectTemplate(state, subject?.subjectTemplateKey))
 
   useEffect(() => {
     const handleChange = (resourceTemplateId) => {
@@ -22,11 +28,11 @@ const ResourceList = (props) => {
     }
     const getNewResourceList = async () => {
       const listItems = []
-      const authorities = props.property.propertyTemplate.authorities
+      const authorities = propertyTemplate.authorities
       await Promise.all(authorities.map((authority) => getTemplateSearchResults(authority.type).then((response) => {
         if (response.error !== undefined) return ''
         response.results?.forEach((hit) => {
-          if (hit.resourceURI === props.property.subject.subjectTemplate.class) {
+          if (hit.resourceURI === subjectTemplate.class) {
             listItems.push(
               <button className="dropdown-item" href="#" data-resource-id={hit.id} key={shortid.generate()} onClick={() => { handleChange(hit.id) }}>
                 {hit.resourceLabel} ({hit.id})
@@ -38,7 +44,7 @@ const ResourceList = (props) => {
       setNewResourceList(listItems)
     }
     getNewResourceList()
-  }, [dispatch, props.property.propertyTemplate.authorities, props.property.subject.subjectTemplate.class])
+  }, [dispatch, propertyTemplate.authorities, subjectTemplate.class])
 
   const dropdown = (items) => <div className="dropdown">
     <button className="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown"

--- a/src/components/editor/property/SubjectSubNav.jsx
+++ b/src/components/editor/property/SubjectSubNav.jsx
@@ -3,44 +3,46 @@ import PropTypes from 'prop-types'
 import { setCurrentComponent } from 'actions/index'
 import { useDispatch, useSelector } from 'react-redux'
 import { displayResourceValidations } from 'selectors/errors'
-import { selectSubject } from 'selectors/resources'
+import { selectNormSubject } from 'selectors/resources'
+import { selectSubjectTemplate } from 'selectors/templates'
 import PropertySubNav from './PropertySubNav'
 import _ from 'lodash'
 
 const SubjectSubNav = (props) => {
   const dispatch = useDispatch()
-
-  const subject = useSelector((state) => selectSubject(state, props.subjectKey))
+  const subject = useSelector((state) => selectNormSubject(state, props.subjectKey))
+  const subjectTemplate = useSelector((state) => selectSubjectTemplate(state, subject?.subjectTemplateKey))
 
   const hasValue = !_.isEmpty(subject.descUriOrLiteralValueKeys)
   const liClassNames = hasValue ? 'li-checked' : ''
 
   const hasError = !_.isEmpty(subject.descWithErrorPropertyKeys)
-  const displayValidations = useSelector((state) => displayResourceValidations(state))
+  const displayValidations = useSelector((state) => displayResourceValidations(state, subject?.rootSubjectKey))
   const headingClassNames = ['left-nav-header']
   if (displayValidations && hasError) headingClassNames.push('text-danger')
 
-  const subNavForSubject = (subNavSubj) => {
-    if (_.isEmpty(subNavSubj.properties)) return []
+  const subNavForSubject = () => {
+    if (_.isEmpty(subject.propertyKeys)) return []
     const subNavItems = []
 
-    subNavSubj.properties.forEach((subNavProp) => {
-      subNavItems.push(<PropertySubNav key={subNavProp.key} propertyKey={subNavProp.key} />)
+    subject.propertyKeys.forEach((propertyKey) => {
+      subNavItems.push(<PropertySubNav key={propertyKey} propertyKey={propertyKey} />)
     })
     return (<ul>{subNavItems}</ul>)
   }
-  const subNavItems = subNavForSubject(subject)
+
+  if (!subject) return null
 
   return (<li className={liClassNames}>
     <button
               type="button"
               className="btn btn-link"
-              aria-label={`Go to ${subject.subjectTemplate.label}`}
-              data-testid={`Go to ${subject.subjectTemplate.label}`}
+              aria-label={`Go to ${subjectTemplate.label}`}
+              data-testid={`Go to ${subjectTemplate.label}`}
               onClick={() => dispatch(setCurrentComponent(subject.rootSubjectKey, subject.rootPropertyKey, subject.key))}>
-      <span className={headingClassNames.join(' ')}>{subject.subjectTemplate.label}</span>
+      <span className={headingClassNames.join(' ')}>{subjectTemplate.label}</span>
     </button>
-    {subNavItems}
+    { subNavForSubject() }
   </li>)
 }
 

--- a/src/components/editor/property/renderTypeaheadFunctions.js
+++ b/src/components/editor/property/renderTypeaheadFunctions.js
@@ -94,7 +94,7 @@ export const renderTokenFunc = (option, tokenProps, idx) => {
   )
 }
 
-export const itemsForProperty = (property) => property.values.map((value) => ({
+export const itemsForValues = (values) => values.map((value) => ({
   id: value.key,
   content: value.literal,
   uri: value.uri,

--- a/src/components/search/SinopiaSearchResults.jsx
+++ b/src/components/search/SinopiaSearchResults.jsx
@@ -13,7 +13,7 @@ import GroupFilter from './GroupFilter'
 import SearchResultRows from './SearchResultRows'
 import SinopiaSort from './SinopiaSort'
 import _ from 'lodash'
-import { selectCurrentResource } from 'selectors/resources'
+import { selectCurrentResourceKey } from 'selectors/resources'
 import { selectSearchResults } from 'selectors/search'
 
 // Errors from retrieving a resource from this page.
@@ -38,7 +38,7 @@ const SinopiaSearchResults = (props) => {
 
   useEffect(() => {
     // Forces a wait until the resource has been set in state
-    if (navigateEditor && props.currentResource && _.isEmpty(props.errors)) {
+    if (navigateEditor && props.currentResourceKey && _.isEmpty(props.errors)) {
       props.history.push('/editor')
     }
     else if (!_.isEmpty(props.errors))
@@ -96,14 +96,14 @@ SinopiaSearchResults.propTypes = {
   searchResults: PropTypes.array,
   loadResource: PropTypes.func,
   history: PropTypes.object,
-  currentResource: PropTypes.object,
+  currentResourceKey: PropTypes.string,
   errors: PropTypes.array,
   fetchSinopiaSearchResults: PropTypes.func,
 }
 
 const mapStateToProps = (state) => ({
   searchResults: selectSearchResults(state, 'resource'),
-  currentResource: selectCurrentResource(state),
+  currentResourceKey: selectCurrentResourceKey(state),
   errors: selectErrors(state, searchRetrieveErrorKey),
 })
 

--- a/src/components/templates/NewResourceTemplateButton.jsx
+++ b/src/components/templates/NewResourceTemplateButton.jsx
@@ -9,7 +9,7 @@ import { Link } from 'react-router-dom'
 import { newResourceErrorKey } from './SinopiaResourceTemplates'
 import { newResource } from 'actionCreators/resources'
 import { selectErrors } from 'selectors/errors'
-import { selectCurrentResource } from 'selectors/resources'
+import { selectCurrentResourceKey } from 'selectors/resources'
 import _ from 'lodash'
 import Config from 'Config'
 
@@ -17,16 +17,16 @@ const NewResourceTemplateButton = (props) => {
   const dispatch = useDispatch()
 
   const errors = useSelector((state) => selectErrors(state, newResourceErrorKey))
-  const resource = useSelector((state) => selectCurrentResource(state))
+  const resourceKey = useSelector((state) => selectCurrentResourceKey(state))
 
   const [navigateEditor, setNavigateEditor] = useState(false)
 
   useEffect(() => {
     // Forces a wait until the root resource has been set in state
-    if (navigateEditor && resource && _.isEmpty(errors)) {
+    if (navigateEditor && resourceKey && _.isEmpty(errors)) {
       props.history.push('/editor')
     }
-  }, [navigateEditor, resource, props.history, errors])
+  }, [navigateEditor, resourceKey, props.history, errors])
 
 
   const handleClick = (event) => {

--- a/src/components/templates/SinopiaResourceTemplates.jsx
+++ b/src/components/templates/SinopiaResourceTemplates.jsx
@@ -7,7 +7,7 @@ import { useSelector, useDispatch } from 'react-redux'
 import PropTypes from 'prop-types'
 import { newResource, loadResource } from 'actionCreators/resources'
 import { selectErrors } from 'selectors/errors'
-import { selectCurrentResource } from 'selectors/resources'
+import { selectCurrentResourceKey, selectNormSubject } from 'selectors/resources'
 import _ from 'lodash'
 import Alerts from '../Alerts'
 import ResourceTemplateSearchResult from './ResourceTemplateSearchResult'
@@ -37,15 +37,15 @@ const SinopiaResourceTemplates = (props) => {
   })), [historicallyUsedTemplates])
 
   const errors = useSelector((state) => selectErrors(state, newResourceErrorKey))
-  const resource = useSelector((state) => selectCurrentResource(state))
+  const resourceKey = useSelector((state) => selectCurrentResourceKey(state))
+  const resource = useSelector((state) => selectNormSubject(state, resourceKey))
 
   const [navigateEditor, setNavigateEditor] = useState(false)
 
   useEffect(() => {
     // Forces a wait until the root resource has been set in state
     if (navigateEditor && resource && _.isEmpty(errors)) {
-      const resourceTemplateId = resource.subjectTemplate.id
-      props.history.push(`/editor/${resourceTemplateId}`)
+      props.history.push(`/editor/${resource.subjectTemplateKey}`)
     }
   }, [navigateEditor, resource, props.history, errors])
 

--- a/src/hooks/useResource.js
+++ b/src/hooks/useResource.js
@@ -3,7 +3,7 @@ import { useState, useEffect } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { newResourceFromDataset } from 'actionCreators/resources'
 import { clearErrors } from 'actions/errors'
-import { selectCurrentResource } from 'selectors/resources'
+import { selectCurrentResourceKey } from 'selectors/resources'
 
 /**
  * Hook for transforming a resource to state and changing the page to the editor (i.e., /editor path).
@@ -16,7 +16,7 @@ import { selectCurrentResource } from 'selectors/resources'
  */
 const useResource = (dataset, baseURI, resourceTemplateId, errorKey, history) => {
   const dispatch = useDispatch()
-  const hasResource = useSelector((state) => !!selectCurrentResource(state))
+  const hasResource = useSelector((state) => !!selectCurrentResourceKey(state))
 
   // Indicates that would like to change to editor once resource is in state
   const [navigateEditor, setNavigateEditor] = useState(false)

--- a/src/reducers/languages.js
+++ b/src/reducers/languages.js
@@ -11,10 +11,14 @@ export const setLanguage = (state, action) => ({
   },
 })
 
-export const languagesReceived = (state, action) => ({
-  ...state,
-  languages: createOptions(action.payload),
-})
+export const languagesReceived = (state, action) => {
+  const options = createOptions(action.payload)
+  return {
+    ...state,
+    languageLookup: options,
+    languages: createMap(options),
+  }
+}
 
 const createOptions = (json) => json.reduce((result, item) => {
   // Object.getOwnPropertyDescriptor is necessary to handle the @
@@ -40,3 +44,9 @@ const createOptions = (json) => json.reduce((result, item) => {
   result.push({ id, label })
   return result
 }, [])
+
+const createMap = (options) => {
+  const langMap = {}
+  options.forEach((item) => langMap[item.id] = item.label)
+  return langMap
+}

--- a/src/selectors/errors.js
+++ b/src/selectors/errors.js
@@ -1,4 +1,4 @@
-import { selectCurrentResourceKey, selectProperty, selectSubject } from './resources'
+import { selectProperty, selectSubject } from './resources'
 import _ from 'lodash'
 
 /**
@@ -7,7 +7,12 @@ import _ from 'lodash'
   * @param {string} resourceKey of the resource to check; if omitted, current resource key is used
   * @return {boolean} true if resource validations should be displayed
   */
-export const displayResourceValidations = (state, resourceKey) => state.editor.resourceValidation[resourceKey || selectCurrentResourceKey(state)] || false
+export const displayResourceValidations = (state, resourceKey) => state.editor.resourceValidation[resourceKey] || false
+
+export const hasValidationErrors = (state, resourceKey) => {
+  const subject = selectSubject(state, resourceKey)
+  return !_.isEmpty(subject.descWithErrorPropertyKeys)
+}
 
 /**
  * @returns {function} a function that returns the errors for an error key
@@ -15,11 +20,6 @@ export const displayResourceValidations = (state, resourceKey) => state.editor.r
 export const selectErrors = (state, errorKey) => state.editor.errors[errorKey] || []
 
 export const selectValidationErrors = (state, resourceKey) => findValidationErrors(state, resourceKey, [])
-
-export const selectCurrentResourceValidationErrors = (state) => {
-  const resourceKey = selectCurrentResourceKey(state)
-  return findValidationErrors(state, resourceKey, [])
-}
 
 // Searches the subject for errors. Also, sets label path for each error.
 const findValidationErrors = (state, subjectKey, labelPath) => {

--- a/src/selectors/languages.js
+++ b/src/selectors/languages.js
@@ -6,13 +6,10 @@
  * @param [string] languageId the identifier of the language, (e.g. 'eng')
  * @return [string] the label of the language or an empty string
  */
-export const selectLanguageLabel = (state, languageId) => {
-  const lang = state.entities.languages.find((lang) => lang.id === languageId)
-  return lang ? lang.label : ''
-}
+export const selectLanguageLabel = (state, languageId) => state.entities.languages[languageId] || ''
 
 export const hasLanguages = (state) => {
   state.entities.languages.length > 0
 }
 
-export const selectLanguages = (state) => state.entities.languages
+export const selectLanguages = (state) => state.entities.languageLookup

--- a/src/selectors/resources.js
+++ b/src/selectors/resources.js
@@ -2,6 +2,10 @@
 import _ from 'lodash'
 import { selectSubjectTemplate, selectPropertyTemplate } from 'selectors/templates'
 
+// Always use selectNormSubject/Property/Value in components.
+// selectSubject/Property/Value can be used in actionCreators.
+// Only use selectFullSubject/Property/Value where absolutely necessary, since expensive to create.
+
 export const selectSubject = (state, key) => {
   const subject = selectNormSubject(state, key)
   if (_.isEmpty(subject)) return null
@@ -42,7 +46,6 @@ export const selectValue = (state, key) => {
   const newProperty = { ...property }
   newProperty.propertyTemplate = selectPropertyTemplate(state, newProperty.propertyTemplateKey)
   newValue.property = newProperty
-  newValue.index = newProperty.valueKeys.indexOf(value.key) + 1
   newValue.valueSubject = selectSubject(state, newValue.valueSubjectKey)
   return newValue
 }
@@ -52,8 +55,6 @@ export const selectNormSubject = (state, key) => state.entities.subjects[key]
 export const selectNormProperty = (state, key) => state.entities.properties[key]
 
 export const selectNormValue = (state, key) => state.entities.values[key]
-
-export const selectCurrentResource = (state) => selectSubject(state, selectCurrentResourceKey(state))
 
 export const selectCurrentResourceKey = (state) => state.editor.currentResource
 
@@ -103,3 +104,8 @@ export const resourceHasChangesSinceLastSave = (state, resourceKey) => {
 export const selectResourceKeys = (state) => state.editor.resources
 
 export const selectLastSave = (state, resourceKey) => state.editor.lastSave[resourceKey]
+
+export const selectNormValues = (state, valueKeys) => {
+  if (!valueKeys) return null
+  return valueKeys.map((valueKey) => selectNormValue(state, valueKey))
+}

--- a/src/selectors/templates.js
+++ b/src/selectors/templates.js
@@ -1,3 +1,5 @@
+import { selectNormSubject } from 'selectors/resources'
+
 /**
  * Selects a subject template by key.
  * @param [Object] state
@@ -33,3 +35,8 @@ export const selectSubjectAndPropertyTemplates = (state, key) => {
 
 export const selectHistoricalTemplates = (state) => state.editor.historicalTemplates
   .map((resourceTemplateId) => selectSubjectTemplate(state, resourceTemplateId))
+
+export const selectSubjectTemplateFor = (state, subjectKey) => {
+  const subject = selectNormSubject(state, subjectKey)
+  return selectSubjectTemplate(state, subject.subjectTemplateKey)
+}

--- a/src/store.js
+++ b/src/store.js
@@ -37,7 +37,8 @@ export const initialState = {
     unusedRDF: {}, // {<resourceKey>: rdf}
   },
   entities: {
-    languages: [],
+    languageLookup: [],
+    languages: {},
     lookups: {},
     exports: [],
     properties: {},


### PR DESCRIPTION
closes #2528

## Why was this change made?
To improve Sinopia performance by having selectors return objects from state without modifying or copying them. This  should cause React to refresh components less often.

## How was this change tested?
Unit/feature.


## Which documentation and/or configurations were updated?
NA


