### PR TITLE
Make property tooltips hide when elsewhere is clicked

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -212,7 +212,8 @@ module.exports = {
       // Might be able to fix this with BS4.
       "files": [
         "src/components/Header.jsx",
-        "src/components/home/Header.jsx"
+        "src/components/home/Header.jsx",
+        "src/components/editor/property/PropertyLabelInfoTooltip.jsx"
       ],
       "rules": {
         "jsx-a11y/anchor-is-valid": "off"

--- a/src/components/editor/property/PropertyLabelInfoTooltip.jsx
+++ b/src/components/editor/property/PropertyLabelInfoTooltip.jsx
@@ -14,15 +14,20 @@ const PropertyLabelInfoTooltip = (props) => {
   }, [key])
 
   return (
-    <span data-toggle="popover"
-          data-placement="right"
-          data-container="body"
-          title={props.propertyTemplate.label}
-          data-content={props.propertyTemplate.remark}
-          key={key}
-          id={key}>
+    <a href="#"
+       className="tooltip-heading"
+       tabIndex="0"
+       data-toggle="popover"
+       data-trigger="focus"
+       data-placement="right"
+       data-container="body"
+       data-testid={props.propertyTemplate.label}
+       title={props.propertyTemplate.label}
+       data-content={props.propertyTemplate.remark}
+       key={key}
+       id={key}>
       <FontAwesomeIcon className="info-icon" icon={faInfoCircle} />
-    </span>
+    </a>
   )
 }
 

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -22,6 +22,7 @@ $link-color: $orient;
 $theme-colors: (
   "danger": $bright-red
 );
+$tooltip-color: white;
 
 $enable-validation-icons: false;
 $prop-heading-bg: $reno-sand;
@@ -90,6 +91,11 @@ $primary-disabled: lighten( map-get($theme-colors,"secondary"), 20% );
 .btn-add, .btn-remove {
   background-image: none;
   border-style: dashed;
+}
+
+a.tooltip-heading {
+  color: $tooltip-color;
+  outline: none;
 }
 
 .panel-heading > .btn-add, .panel-heading > .btn-remove {


### PR DESCRIPTION
Fixes #2539

## Why was this change made?

To make tooltips behave per user expectations.

## How was this change tested?

CI and local browser.

**NOTE**: I fought with RTL/Jest for 1-2 hours and could not get the commented-out test line to pass. That line is the most important line to testing that the clicks work properly. Advice or code are most welcome.

## Which documentation and/or configurations were updated?

None

