### PR TITLE
Add test coverage for property tooltip behavior

### DIFF
--- a/__tests__/feature/editing/propInfo.test.js
+++ b/__tests__/feature/editing/propInfo.test.js
@@ -1,5 +1,5 @@
 import { renderApp, createHistory } from 'testUtils'
-import { fireEvent, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import Config from 'Config'
 
 // Mock jquery
@@ -29,18 +29,6 @@ describe('getting property related info from a resource', () => {
   it('has tooltip text info based on the content of a nested property remark', async () => {
     const history = createHistory(['/editor/resourceTemplate:testing:uber1'])
     renderApp(null, history)
-
-    // Verifies that tooltip pops up when clicked and hides when something else is clicked
-    const tooltipText = 'Multiple nested, repeatable resource templates.'
-    expect(screen.queryByText(tooltipText)).not.toBeInTheDocument()
-    fireEvent.click(await screen.findByTitle('Uber template1, property1'))
-    // NOTE: This is the line that should be doing the real testing... but I
-    //       can't get it to work after much googling and many different
-    //       incantations.
-    //
-    // expect(await screen.findByText(tooltipText)).toBeInTheDocument()
-    fireEvent.click(screen.getByPlaceholderText('Uber template1, property4'))
-    expect(screen.queryByText(tooltipText)).not.toBeInTheDocument()
 
     // Finds the parent property
     const infoIcon1 = await screen.findByTitle('Uber template1, property18')

--- a/cypress/integration/leftNav.spec.js
+++ b/cypress/integration/leftNav.spec.js
@@ -105,6 +105,18 @@ describe('Left-nav test', () => {
     cy.get('li.li-checked .left-nav-header').should('contain', 'Uber template1, property7')
   })
 
+  it('Pops up tooltips for properties with remarks', () => {
+    // Verifies that tooltip pops up when clicked and hides when something else is clicked
+    const tooltipText = 'Multiple nested, repeatable resource templates.'
+    cy.get('body').should('not.contain', tooltipText)
+    cy.get('a[data-testid="Uber template1, property1"]').click()
+    // Tooltip appears when clicked
+    cy.get('body').should('contain', tooltipText)
+    // And disappears when anything else is clicked
+    cy.get('button[aria-label="Go to Uber template1, property1"]').click()
+    cy.get('body').should('not.contain', tooltipText)
+  })
+
   it('Marks properties with values with a check', () => {
     cy.get('li.li-checked .left-nav-header').should('not.contain', 'Uber template1, property18')
     cy.get('li.li-checked .left-nav-header').should('not.contain', 'Uber template4')


### PR DESCRIPTION
Connects to #2539

## Why was this change made?

To add test coverage.

## How was this change tested?

By running `npm run cypress-open` locally.

## Which documentation and/or configurations were updated?

None

