### PR TITLE
Fix RDF loading

### DIFF
--- a/__tests__/sinopiaApi.test.js
+++ b/__tests__/sinopiaApi.test.js
@@ -129,7 +129,7 @@ describe('postResource', () => {
           type: 'uri',
         },
         values: [{
-          uri: 'resourceTemplate:bf2:Note',
+          literal: 'resourceTemplate:bf2:Note',
           property: { propertyTemplate: { type: 'uri' } },
         }],
       })

--- a/src/sinopiaApi.js
+++ b/src/sinopiaApi.js
@@ -119,7 +119,7 @@ const isTemplate = (resource) => resource.subjectTemplate.id === Config.rootReso
 
 const templateIdFor = (resource) => {
   const resourceIdProperty = resource.properties.find((property) => property.propertyTemplate.uri === 'http://sinopia.io/vocabulary/hasResourceId')
-  return resourceIdProperty.values[0].uri
+  return resourceIdProperty.values[0].literal || resourceIdProperty.values[0].uri
 }
 
 const getJwt = () => Auth.currentSession()


### PR DESCRIPTION
Fixes #2519


## Why was this change made?

The URN of the new resource template lives in the .literal property of the property template, not in the .uri property, due to a recent change in sinopia_api.


## How was this change tested?

Locally and in CI

## Which documentation and/or configurations were updated?

None

