### PR TITLE
Fix RDF loading.

### DIFF
--- a/__tests__/__template_fixtures__/DiscogsLookup.json
+++ b/__tests__/__template_fixtures__/DiscogsLookup.json
@@ -58,7 +58,7 @@
     ],
     "http://sinopia.io/vocabulary/hasResourceId": [
       {
-        "@id": "test:resource:DiscogsLookup"
+        "@value": "test:resource:DiscogsLookup"
       }
     ],
     "http://sinopia.io/vocabulary/hasClass": [

--- a/__tests__/__template_fixtures__/Note.json
+++ b/__tests__/__template_fixtures__/Note.json
@@ -32,7 +32,7 @@
     ],
     "http://sinopia.io/vocabulary/hasResourceId": [
       {
-        "@id": "resourceTemplate:bf2:Note"
+        "@value": "resourceTemplate:bf2:Note"
       }
     ],
     "http://sinopia.io/vocabulary/hasClass": [

--- a/__tests__/__template_fixtures__/ResourceTemplate.json
+++ b/__tests__/__template_fixtures__/ResourceTemplate.json
@@ -32,7 +32,7 @@
     ],
     "http://sinopia.io/vocabulary/hasResourceId": [
       {
-        "@id": "sinopia:template:resource"
+        "@value": "sinopia:template:resource"
       }
     ],
     "http://sinopia.io/vocabulary/hasClass": [

--- a/__tests__/__template_fixtures__/SinopiaLookup.json
+++ b/__tests__/__template_fixtures__/SinopiaLookup.json
@@ -61,7 +61,7 @@
     ],
     "http://sinopia.io/vocabulary/hasResourceId": [
       {
-        "@id": "test:resource:SinopiaLookup"
+        "@value": "test:resource:SinopiaLookup"
       }
     ],
     "http://sinopia.io/vocabulary/hasClass": [

--- a/__tests__/__template_fixtures__/Title.json
+++ b/__tests__/__template_fixtures__/Title.json
@@ -172,7 +172,7 @@
     ],
     "http://sinopia.io/vocabulary/hasResourceId": [
       {
-        "@id": "resourceTemplate:bf2:Title"
+        "@value": "resourceTemplate:bf2:Title"
       }
     ],
     "http://sinopia.io/vocabulary/hasClass": [

--- a/__tests__/__template_fixtures__/TitleNote.json
+++ b/__tests__/__template_fixtures__/TitleNote.json
@@ -37,7 +37,7 @@
     ],
     "http://sinopia.io/vocabulary/hasResourceId": [
       {
-        "@id": "resourceTemplate:bf2:Title:Note"
+        "@value": "resourceTemplate:bf2:Title:Note"
       }
     ],
     "http://sinopia.io/vocabulary/hasClass": [

--- a/__tests__/__template_fixtures__/WikidataLookup.json
+++ b/__tests__/__template_fixtures__/WikidataLookup.json
@@ -58,7 +58,7 @@
     ],
     "http://sinopia.io/vocabulary/hasResourceId": [
       {
-        "@id": "test:resource:WikidataLookup"
+        "@value": "test:resource:WikidataLookup"
       }
     ],
     "http://sinopia.io/vocabulary/hasClass": [

--- a/__tests__/__template_fixtures__/WorkTitle.json
+++ b/__tests__/__template_fixtures__/WorkTitle.json
@@ -136,7 +136,7 @@
     ],
     "http://sinopia.io/vocabulary/hasResourceId": [
       {
-        "@id": "resourceTemplate:bf2:WorkTitle"
+        "@value": "resourceTemplate:bf2:WorkTitle"
       }
     ],
     "http://sinopia.io/vocabulary/hasClass": [

--- a/__tests__/__template_fixtures__/ld4p_RT_bf2_Form.json
+++ b/__tests__/__template_fixtures__/ld4p_RT_bf2_Form.json
@@ -53,7 +53,7 @@
     ],
     "http://sinopia.io/vocabulary/hasResourceId": [
       {
-        "@id": "ld4p:RT:bf2:Form"
+        "@value": "ld4p:RT:bf2:Form"
       }
     ],
     "http://sinopia.io/vocabulary/hasClass": [

--- a/__tests__/__template_fixtures__/ld4p_RT_bf2_RareMat_RBMS.json
+++ b/__tests__/__template_fixtures__/ld4p_RT_bf2_RareMat_RBMS.json
@@ -100,7 +100,7 @@
     ],
     "http://sinopia.io/vocabulary/hasResourceId": [
       {
-        "@id": "ld4p:RT:bf2:RareMat:RBMS"
+        "@value": "ld4p:RT:bf2:RareMat:RBMS"
       }
     ],
     "http://sinopia.io/vocabulary/hasClass": [

--- a/__tests__/__template_fixtures__/ld4p_RT_bf2_Title_AbbrTitle.json
+++ b/__tests__/__template_fixtures__/ld4p_RT_bf2_Title_AbbrTitle.json
@@ -32,7 +32,7 @@
     ],
     "http://sinopia.io/vocabulary/hasResourceId": [
       {
-        "@id": "ld4p:RT:bf2:Title:AbbrTitle"
+        "@value": "ld4p:RT:bf2:Title:AbbrTitle"
       }
     ],
     "http://sinopia.io/vocabulary/hasClass": [

--- a/__tests__/__template_fixtures__/multiple_loc.json
+++ b/__tests__/__template_fixtures__/multiple_loc.json
@@ -76,7 +76,7 @@
     ],
     "http://sinopia.io/vocabulary/hasResourceId": [
       {
-        "@id": "test:bf2:soundCharacteristics"
+        "@value": "test:bf2:soundCharacteristics"
       }
     ],
     "http://sinopia.io/vocabulary/hasClass": [

--- a/__tests__/__template_fixtures__/nonUniqueValueTemplateRefs.json
+++ b/__tests__/__template_fixtures__/nonUniqueValueTemplateRefs.json
@@ -56,7 +56,7 @@
     ],
     "http://sinopia.io/vocabulary/hasResourceId": [
       {
-        "@id": "test:RT:bf2:RareMat:Instance"
+        "@value": "test:RT:bf2:RareMat:Instance"
       }
     ],
     "http://sinopia.io/vocabulary/hasClass": [

--- a/__tests__/__template_fixtures__/notFoundValueTemplateRefs.json
+++ b/__tests__/__template_fixtures__/notFoundValueTemplateRefs.json
@@ -683,7 +683,7 @@
     ],
     "http://sinopia.io/vocabulary/hasResourceId": [
       {
-        "@id": "test:RT:bf2:notFoundValueTemplateRefs"
+        "@value": "test:RT:bf2:notFoundValueTemplateRefs"
       }
     ],
     "http://sinopia.io/vocabulary/hasClass": [

--- a/__tests__/__template_fixtures__/propertyURIRepeated.json
+++ b/__tests__/__template_fixtures__/propertyURIRepeated.json
@@ -73,7 +73,7 @@
     ],
     "http://sinopia.io/vocabulary/hasResourceId": [
       {
-        "@id": "rt:repeated:propertyURI:propertyLabel"
+        "@value": "rt:repeated:propertyURI:propertyLabel"
       }
     ],
     "http://sinopia.io/vocabulary/hasClass": [

--- a/__tests__/__template_fixtures__/uber_template1.json
+++ b/__tests__/__template_fixtures__/uber_template1.json
@@ -1142,7 +1142,7 @@
     ],
     "http://sinopia.io/vocabulary/hasResourceId": [
       {
-        "@id": "resourceTemplate:testing:uber1"
+        "@value": "resourceTemplate:testing:uber1"
       }
     ],
     "http://sinopia.io/vocabulary/hasClass": [

--- a/__tests__/__template_fixtures__/uber_template2.json
+++ b/__tests__/__template_fixtures__/uber_template2.json
@@ -42,7 +42,7 @@
     ],
     "http://sinopia.io/vocabulary/hasResourceId": [
       {
-        "@id": "resourceTemplate:testing:uber2"
+        "@value": "resourceTemplate:testing:uber2"
       }
     ],
     "http://sinopia.io/vocabulary/hasClass": [

--- a/__tests__/__template_fixtures__/uber_template3.json
+++ b/__tests__/__template_fixtures__/uber_template3.json
@@ -73,7 +73,7 @@
     ],
     "http://sinopia.io/vocabulary/hasResourceId": [
       {
-        "@id": "resourceTemplate:testing:uber3"
+        "@value": "resourceTemplate:testing:uber3"
       }
     ],
     "http://sinopia.io/vocabulary/hasClass": [

--- a/__tests__/__template_fixtures__/uber_template4.json
+++ b/__tests__/__template_fixtures__/uber_template4.json
@@ -45,7 +45,7 @@
     ],
     "http://sinopia.io/vocabulary/hasResourceId": [
       {
-        "@id": "resourceTemplate:testing:uber4"
+        "@value": "resourceTemplate:testing:uber4"
       }
     ],
     "http://sinopia.io/vocabulary/hasClass": [

--- a/__tests__/sinopiaApi.test.js
+++ b/__tests__/sinopiaApi.test.js
@@ -126,11 +126,11 @@ describe('postResource', () => {
       resource.properties.push({
         propertyTemplate: {
           uri: 'http://sinopia.io/vocabulary/hasResourceId',
-          type: 'uri',
+          type: 'literal',
         },
         values: [{
-          uri: 'resourceTemplate:bf2:Note',
-          property: { propertyTemplate: { type: 'uri' } },
+          literal: 'resourceTemplate:bf2:Note',
+          property: { propertyTemplate: { type: 'literal' } },
         }],
       })
       const result = await postResource(resource, currentUser, 'pcc')

--- a/cypress/fixtures/WorkTitle.txt
+++ b/cypress/fixtures/WorkTitle.txt
@@ -94,7 +94,7 @@
     ],
     "http://sinopia.io/vocabulary/hasResourceId": [
       {
-        "@id": "resourceTemplate:bf2:WorkTitle"
+        "@value": "resourceTemplate:bf2:WorkTitle"
       }
     ],
     "http://sinopia.io/vocabulary/hasClass": [

--- a/cypress/fixtures/uber_template1.txt
+++ b/cypress/fixtures/uber_template1.txt
@@ -1142,7 +1142,7 @@
     ],
     "http://sinopia.io/vocabulary/hasResourceId": [
       {
-        "@id": "resourceTemplate:testing:uber1"
+        "@value": "resourceTemplate:testing:uber1"
       }
     ],
     "http://sinopia.io/vocabulary/hasClass": [

--- a/cypress/fixtures/uber_template2.txt
+++ b/cypress/fixtures/uber_template2.txt
@@ -42,7 +42,7 @@
     ],
     "http://sinopia.io/vocabulary/hasResourceId": [
       {
-        "@id": "resourceTemplate:testing:uber2"
+        "@value": "resourceTemplate:testing:uber2"
       }
     ],
     "http://sinopia.io/vocabulary/hasClass": [

--- a/cypress/fixtures/uber_template3.txt
+++ b/cypress/fixtures/uber_template3.txt
@@ -73,7 +73,7 @@
     ],
     "http://sinopia.io/vocabulary/hasResourceId": [
       {
-        "@id": "resourceTemplate:testing:uber3"
+        "@value": "resourceTemplate:testing:uber3"
       }
     ],
     "http://sinopia.io/vocabulary/hasClass": [

--- a/cypress/fixtures/uber_template4.txt
+++ b/cypress/fixtures/uber_template4.txt
@@ -45,7 +45,7 @@
     ],
     "http://sinopia.io/vocabulary/hasResourceId": [
       {
-        "@id": "resourceTemplate:testing:uber4"
+        "@value": "resourceTemplate:testing:uber4"
       }
     ],
     "http://sinopia.io/vocabulary/hasClass": [

--- a/src/sinopiaApi.js
+++ b/src/sinopiaApi.js
@@ -119,7 +119,7 @@ const isTemplate = (resource) => resource.subjectTemplate.id === Config.rootReso
 
 const templateIdFor = (resource) => {
   const resourceIdProperty = resource.properties.find((property) => property.propertyTemplate.uri === 'http://sinopia.io/vocabulary/hasResourceId')
-  return resourceIdProperty.values[0].uri
+  return resourceIdProperty.values[0].literal
 }
 
 const getJwt = () => Auth.currentSession()


### PR DESCRIPTION
closes #2519

## Why was this change made?
The URN of the new resource template lives in the .literal property of the property template, not in the .uri property, due to a recent change in root templates.

## How was this change tested?
Locally and in CI.


## Which documentation and/or configurations were updated?
NA

