### PR TITLE
hide previously opened diacritics panels

### DIFF
--- a/src/components/editor/property/InputLiteral.jsx
+++ b/src/components/editor/property/InputLiteral.jsx
@@ -113,6 +113,7 @@ const InputLiteral = (props) => {
 
   // This handles if they focus into the field using tab (no click)
   const handleFocus = () => {
+    props.hideDiacritics() // hide any previously opened diacritic panels to avoid cross input problems
     props.updateCursorPosition(inputLiteralRef.current.selectionStart)
   }
 


### PR DESCRIPTION
## Why was this change made?

Fixes #2523 

This fixes the problem by basically forcing the diacritics panel to close anytime focus returns to a new input literal.  If you open the diacritics panel, enter some text, and then click back into the same input field or a new input field, the panel will close.  If you want to enter diacritics again, you toggle it open with the button, and it will be re-connected to the correct input literal.  This (a) prevents the diacritics panel from ever being connected to the wrong input literal (thus fixing the bug), but (b) means that if you click on the same input field you are entering diacritics into, this will also close the diacritics panel.

Reviewing the behavior with Jeremy, and we both agree this is not necessarily a problem... as clicking back into the input literal signifies you are likely ready to start typing again anyway and don't need the panel.

If we don't want this behavior, we would try and determine if the literal that just received focus has the same ID that is connected to the currently open diacritics, and if it is not, we could leave the panel open.  

## How was this change tested?

Localhost


## Which documentation and/or configurations were updated?



