### PR TITLE
Remove inoperative class btn-default

### DIFF
--- a/src/components/editor/property/InputValue.jsx
+++ b/src/components/editor/property/InputValue.jsx
@@ -41,7 +41,7 @@ const InputValue = (props) => {
       style={ { marginRight: '.25em' } }
       aria-label={`Edit ${label}`}
       data-testid={`Edit ${label}`}
-      className="btn btn-sm btn-secondary btn-default">
+      className="btn btn-sm btn-secondary">
       Edit
     </button> }
     { isLiteral ? (<LanguageButton value={props.value} />) : '' }

--- a/src/components/editor/property/NestedPropertyHeader.jsx
+++ b/src/components/editor/property/NestedPropertyHeader.jsx
@@ -44,7 +44,7 @@ const NestedPropertyHeader = (props) => {
     return (
       <div className={groupClasses}>
         <button type="button"
-                className="btn btn-default btn-add btn-add-property"
+                className="btn btn-add btn-add-property"
                 onClick={() => props.expandProperty(props.property.key, resourceEditErrorKey(props.resourceKey))}
                 aria-label={`Add ${props.propertyTemplate.label}`}
                 data-testid={`Add ${props.propertyTemplate.label}`}


### PR DESCRIPTION


## Why was this change made?
This is a holdover from bootstrap 3


## How was this change tested?



## Which documentation and/or configurations were updated?



