### PR TITLE
add search spinner while waiting for search to run

### DIFF
--- a/__tests__/feature/search.test.js
+++ b/__tests__/feature/search.test.js
@@ -152,10 +152,16 @@ describe('sinopia resource search', () => {
 
     fireEvent.click(screen.getByText(/Linked Data Editor/, { selector: 'a' }))
     fireEvent.click(screen.getByText(/Search/, { selector: 'a' }))
+
+    const searchSpinner = document.querySelector('#search-results-loading')
+    expect(searchSpinner.classList.contains('hidden')).toBe(true) // search spinner starts as hidden
+
     fireEvent.change(screen.getByLabelText('Query', { selector: 'input#searchInput' }), { target: { value: '*' } })
     fireEvent.click(screen.getByLabelText('Submit search', { selector: 'button' }))
+    expect(searchSpinner.classList.contains('hidden')).toBe(false) // search spinner shown
 
     await screen.findByText(/foo bar/)
+    expect(searchSpinner.classList.contains('hidden')).toBe(true) // search spinner hidden again
 
     // TODO: why don't filtering options show up in test UI?
     // screen.debug()

--- a/src/components/search/Search.jsx
+++ b/src/components/search/Search.jsx
@@ -33,6 +33,7 @@ const Search = (props) => {
   const clearSearchResults = useCallback(() => dispatch(clearSearchResultsAction('resource')), [dispatch])
 
   const topRef = useRef(null)
+  const loadingSearchRef = useRef(null)
 
   const [queryString, setQueryString] = useState(lastQueryString || '')
   const [uri, setUri] = useState(searchUri || sinopiaSearchUri)
@@ -65,7 +66,12 @@ const Search = (props) => {
     if (queryString === '') {
       return
     }
+
     fetchNewSearchResults(queryString, uri)
+
+    loadingSearchRef.current.classList.remove('hidden')
+    clearSearchResults()
+
     if (error && topRef.current) window.scrollTo(0, topRef.current.offsetTop)
   }
 
@@ -80,7 +86,9 @@ const Search = (props) => {
   const options = searchConfig.map((config) => (<option key={config.uri} value={config.uri}>{config.label}</option>))
 
   let results
+
   if (searchUri === sinopiaSearchUri) {
+    loadingSearchRef.current.classList.add('hidden')
     results = (
       <div>
         <SinopiaSearchResults {...props} key="search-results" />
@@ -89,6 +97,7 @@ const Search = (props) => {
       </div>
     )
   } else if (searchUri) {
+    loadingSearchRef.current.classList.add('hidden')
     results = (
       <div>
         <QASearchResults history={props.history} key="search-results" />
@@ -157,6 +166,11 @@ const Search = (props) => {
             default operator for multiple terms is AND; use | (pipe) as OR operator;
             use quotation marks for exact match. For more details see <a href="https://github.com/LD4P/sinopia/wiki/Searching-in-Sinopia">Searching in Sinopia</a>.
           </span>
+        </div>
+      </div>
+      <div ref={loadingSearchRef} id="search-results-loading" className="hidden text-center">
+        <div className="spinner-border" role="status">
+          <span className="sr-only">Results Loading...</span>
         </div>
       </div>
       {results}

--- a/src/components/search/Search.jsx
+++ b/src/components/search/Search.jsx
@@ -66,12 +66,9 @@ const Search = (props) => {
     if (queryString === '') {
       return
     }
-
     fetchNewSearchResults(queryString, uri)
-
     loadingSearchRef.current.classList.remove('hidden')
     clearSearchResults()
-
     if (error && topRef.current) window.scrollTo(0, topRef.current.offsetTop)
   }
 

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -287,6 +287,7 @@ button.btn-add-instance {
   thead {
     background-color: $spring-wood;
   }
+}
 
 .hidden {
   display: none;

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -287,4 +287,7 @@ button.btn-add-instance {
   thead {
     background-color: $spring-wood;
   }
+
+.hidden {
+  display: none;
 }


### PR DESCRIPTION
## Why was this change made?

Addresses part of #2182 (search spinner)
Timeouts are in #2583

- adds search spinner when searches are executing (sinopia or QA)
- clears any current search results as soon as a new search is started (and shows the spinner when running the new search of course)

This is how the loading spinner looks: (Note: the "results loading" text is in a span that only shows for screen readers.)

![spinner](https://user-images.githubusercontent.com/47137/94726817-9dff9700-0312-11eb-90e5-f145738de66a.gif)

## How was this change tested?

- Localhost browser


## Which documentation and/or configurations were updated?

None

