### PR TITLE
Allow user to add URI or literal in Lookup Modal

### DIFF
--- a/__tests__/feature/editing/selectFromLookup.test.js
+++ b/__tests__/feature/editing/selectFromLookup.test.js
@@ -25,11 +25,18 @@ describe('selecting a value from the lookup modal', () => {
     await waitFor(() => expect(screen.getByLabelText('Instance of (lookup)')))
 
     const input = screen.getByLabelText('Instance of (lookup)')
-    fireEvent.change(input, { target: { value: 'test' } })
+
+    fireEvent.keyUp(input, { target: { value: 'test' } })
 
     expect(input).toHaveValue('test')
 
-    // TODO: Add additional selection testing after https://github.com/LD4P/sinopia_editor/issues/2398
-    // This test is limited by the selectors assigned in AsyncTypeahead and will be replaced
+    // Checks if the Add Literal button is available
+    screen.getByLabelText(/add as new literal/i)
+
+    // Adds URI to search on
+    fireEvent.keyUp(input, { target: { value: 'http://example.com/' } })
+
+    // Checks if the  Add URI button is available
+    screen.getByLabelText(/add as new uri/i)
   })
 })

--- a/src/components/editor/property/LookupWithMultipleAuthorities.jsx
+++ b/src/components/editor/property/LookupWithMultipleAuthorities.jsx
@@ -11,6 +11,7 @@ import { newUriValue, newLiteralValue } from 'utilities/valueFactory'
 import { addProperty } from 'actions/resources'
 import { hideModal } from 'actions/modals'
 import { selectNormValues } from 'selectors/resources'
+import { isValidURI } from 'utilities/Utilities'
 
 import RenderLookupContext from './RenderLookupContext'
 import Tab from '../Tab'
@@ -70,6 +71,25 @@ const LookupWithMultipleAuthorities = (props) => {
       })
     })
   }, [query, allAuthorities, getLookupResults])
+
+  const addUriOrLiteral = () => {
+    if (!query) return
+    const item = {}
+    let typeOf = 'Literal'
+    if (isValidURI(query)) {
+      item.uri = query
+      item.label = query
+      typeOf = 'URI'
+    } else {
+      item.content = query
+    }
+    const ariaLabel = `Add as new ${typeOf}`
+    return (<button onClick={() => selectionChanged(item)}
+                    aria-label={ariaLabel}
+                    className="btn search-result">
+      <strong>New {typeOf}:</strong> {query}</button>
+    )
+  }
 
   const selectionChanged = (item) => {
     dispatch(hideModal())
@@ -167,6 +187,7 @@ const LookupWithMultipleAuthorities = (props) => {
               <label htmlFor="search">{props.propertyTemplate.label}</label>
               <input id="search" type="search" className="form-control"
                      onKeyUp={(e) => setQuery(e.target.value)}></input>
+              {addUriOrLiteral()}
             </div>
 
             <button type="button" className="close" onClick={close} aria-label="Close">


### PR DESCRIPTION
## Why was this change made?
Quick fix for #2564

New button under text input that the cataloger can click to add a literal:

<img width="551" alt="Screen Shot 2020-09-30 at 2 50 02 PM" src="https://user-images.githubusercontent.com/71847/94738357-892ffd00-032c-11eb-845f-ef85f34bd499.png">

For a URI:
<img width="558" alt="Screen Shot 2020-09-30 at 2 50 21 PM" src="https://user-images.githubusercontent.com/71847/94738437-a5339e80-032c-11eb-8e5e-3d99e0d0d47b.png">

## How was this change tested?
Ran testing suite


## Which documentation and/or configurations were updated?
n/a


