### PR TITLE
Remember resource and template search state

### DIFF
--- a/__tests__/feature/searchAndOpenTemplate.test.js
+++ b/__tests__/feature/searchAndOpenTemplate.test.js
@@ -45,9 +45,11 @@ describe('searching and opening a resource', () => {
   it('adds the template to recently used template history', async () => {
     renderApp(store, history)
 
+    const queryString = 'title'
+
     // Search for a template
     const input = screen.getByPlaceholderText('Enter id, label, URI, remark, or author')
-    await fireEvent.change(input, { target: { value: 'title' } })
+    await fireEvent.change(input, { target: { value: queryString } })
     await screen.findByText('resourceTemplate:bf2:Title:Note')
 
     // open the template
@@ -55,9 +57,16 @@ describe('searching and opening a resource', () => {
     fireEvent.click(link)
     await act(() => promise)
 
-    // return the the RT list
+    // return to the RT list
     const rtLink = await screen.findByText('Resource Templates', { selector: 'a' })
     fireEvent.click(rtLink)
+
+    // confirm RT query is still in place (stored in state and not cleared)
+    expect(input.value).toEqual(queryString)
+
+    // Clear search button empties the search field
+    fireEvent.click(screen.getByTestId('Clear query string', { selector: 'button' }))
+    expect(screen.getByPlaceholderText('Enter id, label, URI, remark, or author').value).toEqual('')
 
     // see the recently used RTs
     const histTemplateBtn = await screen.findByText('Most recently used resource templates')

--- a/__tests__/feature/searchAndViewResource.test.js
+++ b/__tests__/feature/searchAndViewResource.test.js
@@ -21,11 +21,11 @@ describe('searching and viewing a resource', () => {
     error: undefined,
   })
 
-  it('renders a modal without edit controls', async () => {
-    // Setup search component to return known resource
-    const uri = 'http://localhost:3000/resource/c7db5404-7d7d-40ac-b38e-c821d2c3ae3f'
-    sinopiaSearch.getSearchResultsWithFacets.mockResolvedValue(resourceSearchResults(uri))
+  // Setup search component to return known resource
+  const uri = 'http://localhost:3000/resource/c7db5404-7d7d-40ac-b38e-c821d2c3ae3f'
+  sinopiaSearch.getSearchResultsWithFacets.mockResolvedValue(resourceSearchResults(uri))
 
+  it('renders a modal without edit controls', async () => {
     renderApp()
 
     fireEvent.click(screen.getByText('Linked Data Editor', { selector: 'a' }))
@@ -75,5 +75,15 @@ describe('searching and viewing a resource', () => {
     fireEvent.click(screen.getByLabelText('Edit', { selector: 'button', exact: true }))
     expect(screen.getByText('Uber template1', { selector: 'h3' })).toBeInTheDocument()
     expect(screen.getByText('Copy URI', { selector: 'button' })).toBeInTheDocument()
+
+    // Switch back to search page
+    fireEvent.click(screen.getByText('Search', { selector: 'a' }))
+
+    // Confirm search query is still in place (stored in state and not cleared)
+    expect(await screen.getByLabelText('Query').value).toEqual(uri)
+
+    // Clear search button empties the search field
+    fireEvent.click(screen.getByTestId('Clear query string', { selector: 'button' }))
+    expect(await screen.getByLabelText('Query').value).toEqual('')
   })
 })

--- a/cypress/integration/end2end.spec.js
+++ b/cypress/integration/end2end.spec.js
@@ -67,7 +67,6 @@ describe('End-to-end test', () => {
           cy.url().should('include', '/templates')
 
           cy.get('#searchInput')
-            .type('resourceTemplate:bf2:WorkTitle')
             .should('have.value', 'resourceTemplate:bf2:WorkTitle')
 
           // eslint-disable-next-line cypress/no-unnecessary-waiting
@@ -114,6 +113,9 @@ describe('End-to-end test', () => {
 
     cy.get('a').contains('Search').click()
     cy.url().should('include', '/search')
+
+    // Test search clear button
+    cy.get('button[title="Clear query string"]').click()
 
     // Indexing latency is possible problem here.
     // Force is necessary because reflow of search inputs is suboptimal.

--- a/cypress/integration/leftNav.spec.js
+++ b/cypress/integration/leftNav.spec.js
@@ -50,7 +50,6 @@ describe('Left-nav test', () => {
         cy.url().should('include', '/templates')
 
         cy.get('#searchInput')
-          .type('resourceTemplate:testing:uber1')
           .should('have.value', 'resourceTemplate:testing:uber1')
 
         // eslint-disable-next-line cypress/no-unnecessary-waiting

--- a/src/components/templates/TemplateSearch.jsx
+++ b/src/components/templates/TemplateSearch.jsx
@@ -10,9 +10,10 @@ import Alert from '../Alert'
 import SinopiaResourceTemplates from './SinopiaResourceTemplates'
 import SearchResultsPaging from 'components/search/SearchResultsPaging'
 import NewResourceTemplateButton from './NewResourceTemplateButton'
-import { selectSearchError } from 'selectors/search'
+import { selectSearchError, selectSearchQuery } from 'selectors/search'
 import PropTypes from 'prop-types'
-
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faTrashAlt } from '@fortawesome/free-solid-svg-icons'
 
 const TemplateSearch = (props) => {
   const dispatch = useDispatch()
@@ -20,15 +21,17 @@ const TemplateSearch = (props) => {
   // search, but causes result to be ignored.
   const tokens = useRef([])
 
-  const [query, setQueryText] = useState('')
+  const error = useSelector((state) => selectSearchError(state, 'template'))
+  const lastQueryString = useSelector((state) => selectSearchQuery(state, 'template'))
+
+  const [queryString, setQueryString] = useState(lastQueryString || '')
   const [startOfRange, setStartOfRange] = useState(0)
 
-  const error = useSelector((state) => selectSearchError(state, 'template'))
   const clearSearchResults = useCallback(() => dispatch(clearSearchResultsAction('template')), [dispatch])
 
   useEffect(() => {
-    clearSearchResults()
-  }, [clearSearchResults])
+    if (!queryString) clearSearchResults()
+  }, [clearSearchResults, queryString])
 
   useEffect(() => {
     // Cancel all current searches
@@ -39,10 +42,10 @@ const TemplateSearch = (props) => {
     // Create a token for this set of searches
     const token = { cancel: false }
     tokens.current.push(token)
-    getTemplateSearchResults(query, { startOfRange }).then((response) => {
-      if (!token.cancel) dispatch(setSearchResults('template', null, response.results, response.totalHits, {}, null, { startOfRange }, response.error))
+    getTemplateSearchResults(queryString, { startOfRange }).then((response) => {
+      if (!token.cancel) dispatch(setSearchResults('template', null, response.results, response.totalHits, {}, queryString, { startOfRange }, response.error))
     })
-  }, [dispatch, query, startOfRange])
+  }, [dispatch, queryString, startOfRange])
 
   const changePage = (startOfRange) => {
     setStartOfRange(startOfRange)
@@ -50,7 +53,7 @@ const TemplateSearch = (props) => {
 
   const updateSearch = (e) => {
     setStartOfRange(0)
-    setQueryText(e.target.value)
+    setQueryString(e.target.value)
   }
 
   return (
@@ -63,9 +66,22 @@ const TemplateSearch = (props) => {
               <div className="form-group" style={{ paddingBottom: '10px', paddingTop: '10px' }}>
                 <label className="font-weight-bold" htmlFor="searchInput">Find a resource template</label>&nbsp;
                 <div className="input-group" style={{ width: '750px', paddingLeft: '5px' }}>
-                  <input id="searchInput" type="text" className="form-control"
+                  <input id="searchInput"
+                         type="text"
+                         className="form-control"
                          onChange={ updateSearch }
-                         placeholder="Enter id, label, URI, remark, or author" />
+                         placeholder="Enter id, label, URI, remark, or author"
+                         value={ queryString } />
+                  <span className="input-group-btn">
+                    <button className="btn btn-default"
+                            type="button"
+                            aria-label="Clear query string"
+                            title="Clear query string"
+                            data-testid="Clear query string"
+                            onClick={() => setQueryString('') }>
+                      <FontAwesomeIcon className="trash-icon" icon={faTrashAlt} />
+                    </button>
+                  </span>
                 </div>
               </div>
             </form>


### PR DESCRIPTION
Fixes #2227

Also adds clear search button to both search screens which resets state and input elements.

See screencast to watch feature in action:

![Peek 2020-10-01 11-26](https://user-images.githubusercontent.com/131982/94848600-13359f80-03d9-11eb-95fd-c1aabbdbe3d4.gif)

## Why was this change made?

To prevent catalogers from having to re-type searches for resources and templates over and over again

## How was this change tested?

CI and in browser locally

## Which documentation and/or configurations were updated?

None

