### PR TITLE
Align buttons in left nav to the left

### DIFF
--- a/src/styles/resourceNav.scss
+++ b/src/styles/resourceNav.scss
@@ -18,6 +18,10 @@
       border-color: $vanilla;
     }
 
+    button {
+      text-align: left; // Ensures the indent structure of the outline works when zoomed in.
+    }
+
     li {
       list-style-type: none;
 
@@ -25,6 +29,5 @@
         list-style-type: '\2713';
       }
     }
-
   }
 }


### PR DESCRIPTION


## Why was this change made?
This ensures that centering the text at high font sizes doesn't contribute to an unbalanced indent structure
Fixes #2565 

<img width="359" alt="Screen Shot 2020-10-01 at 8 07 35 AM" src="https://user-images.githubusercontent.com/92044/94813155-410ceb00-03bd-11eb-9618-0e1d651feec2.png">

## How was this change tested?



## Which documentation and/or configurations were updated?



