### PR TITLE
Adds nonexistent relative href to prevent jumping to top of screen

### DIFF
--- a/cypress/integration/leftNav.spec.js
+++ b/cypress/integration/leftNav.spec.js
@@ -109,6 +109,10 @@ describe('Left-nav test', () => {
     // And disappears when anything else is clicked
     cy.get('button[aria-label="Go to Uber template1, property1"]').click()
     cy.get('body').should('not.contain', tooltipText)
+    // Clicks tooltip for property at the bottom of the page
+    cy.get('a[data-testid="Uber template1, property20"]').click()
+    // Ensure the viewport didn't shift to the top of the package
+    cy.get('a[data-testid="Uber template1, property20"]').should('be.visible')
   })
 
   it('Marks properties with values with a check', () => {

--- a/src/components/editor/property/PropertyLabelInfoTooltip.jsx
+++ b/src/components/editor/property/PropertyLabelInfoTooltip.jsx
@@ -14,7 +14,7 @@ const PropertyLabelInfoTooltip = (props) => {
   }, [key])
 
   return (
-    <a href="#"
+    <a href="#tooltip"
        className="tooltip-heading"
        tabIndex="0"
        data-toggle="popover"


### PR DESCRIPTION
## Why was this change made?
Fixes problem when user clicks on a tooltip and the page jumps to the top of the window.


## How was this change tested?
Testing suite


## Which documentation and/or configurations were updated?
n/a

