### PR TITLE
add timeouts to QA search

### DIFF
--- a/__tests__/sinopiaSearch.test.js
+++ b/__tests__/sinopiaSearch.test.js
@@ -107,7 +107,14 @@ describe('getSearchResults', () => {
       size: 10,
       sort: ['_score'],
     }
-    expect(global.fetch).toHaveBeenCalledWith('/api/search/sinopia_resources/sinopia/_search', { body: JSON.stringify(body), headers: { 'Content-Type': 'application/json' }, method: 'POST' })
+    const controller = new AbortController()
+    expect(global.fetch).toHaveBeenCalledWith('/api/search/sinopia_resources/sinopia/_search',
+      {
+        body: JSON.stringify(body),
+        headers: { 'Content-Type': 'application/json' },
+        method: 'POST',
+        signal: controller.signal,
+      })
   })
 
   it('performs a search with specified page and sort order and returns results', async () => {
@@ -133,7 +140,14 @@ describe('getSearchResults', () => {
         label: 'desc',
       }],
     }
-    expect(global.fetch).toHaveBeenCalledWith('/api/search/sinopia_resources/sinopia/_search', { body: JSON.stringify(body), headers: { 'Content-Type': 'application/json' }, method: 'POST' })
+    const controller = new AbortController()
+    expect(global.fetch).toHaveBeenCalledWith('/api/search/sinopia_resources/sinopia/_search',
+      {
+        body: JSON.stringify(body),
+        headers: { 'Content-Type': 'application/json' },
+        method: 'POST',
+        signal: controller.signal,
+      })
   })
 
   it('performs a search and handles ES error', async () => {
@@ -310,7 +324,14 @@ describe('getSearchResultsWithFacets', () => {
         },
       },
     }
-    expect(global.fetch).toHaveBeenCalledWith('/api/search/sinopia_resources/sinopia/_search', { body: JSON.stringify(body), headers: { 'Content-Type': 'application/json' }, method: 'POST' })
+    const controller = new AbortController()
+    expect(global.fetch).toHaveBeenCalledWith('/api/search/sinopia_resources/sinopia/_search',
+      {
+        body: JSON.stringify(body),
+        headers: { 'Content-Type': 'application/json' },
+        method: 'POST',
+        signal: controller.signal,
+      })
   })
 
   it('performs a search with specified filters and no aggs and returns results', async () => {
@@ -346,7 +367,14 @@ describe('getSearchResultsWithFacets', () => {
       size: 10,
       sort: ['_score'],
     }
-    expect(global.fetch).toHaveBeenCalledWith('/api/search/sinopia_resources/sinopia/_search', { body: JSON.stringify(body), headers: { 'Content-Type': 'application/json' }, method: 'POST' })
+    const controller = new AbortController()
+    expect(global.fetch).toHaveBeenCalledWith('/api/search/sinopia_resources/sinopia/_search',
+      {
+        body: JSON.stringify(body),
+        headers: { 'Content-Type': 'application/json' },
+        method: 'POST',
+        signal: controller.signal,
+      })
   })
 })
 
@@ -491,6 +519,7 @@ describe('getTemplateSearchResults', () => {
       error: undefined,
     })
 
+    const controller = new AbortController()
     expect(global.fetch).toHaveBeenCalledWith('/api/search/sinopia_templates/sinopia/_search',
       {
         body: '{"query":{"bool":{"should":[{"wildcard":{"id":{"value":"*Cartographic:Item*"}}},{"wildcard":{"resourceLabel":{"value":"*Cartographic:Item*"}}},{"wildcard":{"resourceURI":{"value":"*Cartographic:Item*"}}},{"wildcard":{"remark":{"value":"*Cartographic:Item*"}}},{"wildcard":{"author":{"value":"*Cartographic:Item*"}}}]}},"sort":[{"resourceLabel":"asc"}],"size":250,"from":0}',
@@ -498,6 +527,7 @@ describe('getTemplateSearchResults', () => {
           'Content-Type': 'application/json',
         },
         method: 'POST',
+        signal: controller.signal,
       })
   })
 
@@ -539,6 +569,7 @@ describe('getTemplateSearchResultsByIds', () => {
       error: undefined,
     })
 
+    const controller = new AbortController()
     expect(global.fetch).toHaveBeenCalledWith('/api/search/sinopia_templates/sinopia/_search',
       {
         body: '{"query":{"terms":{"id":["ld4p:RT:bf2:Cartographic:Item"]}},"size":1}',
@@ -546,6 +577,7 @@ describe('getTemplateSearchResultsByIds', () => {
           'Content-Type': 'application/json',
         },
         method: 'POST',
+        signal: controller.signal,
       })
   })
 })

--- a/__tests__/utilities/QuestioningAuthority.test.js
+++ b/__tests__/utilities/QuestioningAuthority.test.js
@@ -92,7 +92,8 @@ describe('getTerm', () => {
 
     expect(global.fetch).toHaveBeenCalledTimes(1)
     const url = 'https://lookup.ld4l.org/authorities/fetch/linked_data/sharevde_chicago_ld4l_cache?format=n3&uri=http://share-vde.org/sharevde/rdfBibframe/Work/4840195'
-    expect(global.fetch).toHaveBeenCalledWith(url)
+    const controller = new AbortController()
+    expect(global.fetch).toHaveBeenCalledWith(url, { signal: controller.signal })
   })
   it('fetches N3 from QA with id', async () => {
     global.fetch = jest.fn().mockImplementation(() => Promise.resolve({ text: () => 'n3' }))
@@ -102,6 +103,7 @@ describe('getTerm', () => {
 
     expect(global.fetch).toHaveBeenCalledTimes(1)
     const url = 'https://lookup.ld4l.org/authorities/show/discogs/master/132553?format=n3'
-    expect(global.fetch).toHaveBeenCalledWith(url)
+    const controller = new AbortController()
+    expect(global.fetch).toHaveBeenCalledWith(url, { signal: controller.signal })
   })
 })

--- a/src/sinopiaSearch.js
+++ b/src/sinopiaSearch.js
@@ -6,6 +6,9 @@ import {
 } from '../__tests__/testUtilities/fixtureLoaderHelper'
 import _ from 'lodash'
 
+const controller = new AbortController()
+setTimeout(() => controller.abort(), 30000) // 30 second timeout for Sinopia search calls
+
 /* eslint-enable node/no-unpublished-import */
 
 // Not using ES client because not intended for use in browser.
@@ -69,7 +72,13 @@ export const getSearchResultsWithFacets = async (query, options = {}) => {
   }
   const url = `${Config.searchHost}${Config.searchPath}`
 
-  return fetch(url, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) })
+  return fetch(url,
+    {
+      signal: controller.signal,
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    })
     .then((resp) => {
       if (resp.status >= 300) {
         return {
@@ -159,7 +168,13 @@ const fetchTemplateSearchResults = async (body) => {
   }
 
   const url = `${Config.searchHost}${Config.templateSearchPath}`
-  return fetch(url, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) })
+  return fetch(url,
+    {
+      signal: controller.signal,
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    })
     .then((resp) => {
       if (resp.status >= 300) {
         return {

--- a/src/utilities/QuestioningAuthority.js
+++ b/src/utilities/QuestioningAuthority.js
@@ -7,6 +7,9 @@ import Config from 'Config'
 import { findAuthorityConfig } from 'utilities/authorityConfig'
 import _ from 'lodash'
 
+const controller = new AbortController()
+setTimeout(() => controller.abort(), 30000) // 30 second timeout for QA search calls
+
 export const getSearchResults = (query, lookupConfigs, options = {}) => createLookupPromises(query, lookupConfigs, options)
   .map((lookupPromise, i) => lookupPromise.then((value) => {
     if (value) {
@@ -93,7 +96,7 @@ export const getTerm = (uri, id, searchUri, format = 'n3') => {
     url = `${Config.qaUrl}/authorities/fetch/linked_data/${authority.toLowerCase()}?format=${format}&uri=${uri}`
   }
 
-  return fetch(url)
+  return fetch(url, { signal: controller.signal })
     .then((resp) => resp.text())
 }
 


### PR DESCRIPTION
## Why was this change made?

Addresses part of #2182 (search timeouts)
Search spinner is in #2567

This is the timeout error message (not great, but matches the error message style you get for other search messages, and a custom message will potentially be substantially more work to implement):

![Screen Shot 2020-09-30 at 4 40 45 PM](https://user-images.githubusercontent.com/47137/94750835-e1bac680-033b-11eb-8700-341fbbc30ba2.png)


## How was this change tested?

Updated tests

## Which documentation and/or configurations were updated?



