### PR TITLE
Reset read-only state when dismissing ViewResourceModal

### DIFF
--- a/__tests__/feature/searchAndViewResource.test.js
+++ b/__tests__/feature/searchAndViewResource.test.js
@@ -9,9 +9,27 @@ jest.mock('sinopiaSearch')
 
 describe('searching and viewing a resource', () => {
   sinopiaSearch.getTemplateSearchResults.mockResolvedValue({
-    totalHits: 0,
-    results: [],
-    error: undefined,
+    results: [
+      {
+        id: 'resourceTemplate:bf2:Title',
+        uri: 'http://localhost:3000/resource/resourceTemplate:bf2:Title',
+        remark: 'Title information relating to a resource',
+        resourceLabel: 'Instance Title',
+        resourceURI: 'http://id.loc.gov/ontologies/bibframe/Title',
+      },
+      {
+        id: 'resourceTemplate:bf2:Title:Note',
+        uri: 'http://localhost:3000/resource/resourceTemplate:bf2:Title:Note',
+        remark: 'Note about the title',
+        resourceLabel: 'Title note',
+        resourceURI: 'http://id.loc.gov/ontologies/bibframe/Note',
+      },
+    ],
+    totalHits: 2,
+    options: {
+      startOfRange: 0,
+      resultsPerPage: 10,
+    },
   })
 
   // Setup search component to return known resource
@@ -68,6 +86,11 @@ describe('searching and viewing a resource', () => {
     fireEvent.click(screen.getByLabelText('Edit', { selector: 'button', exact: true }))
     expect(screen.getByText('Uber template1', { selector: 'h3' })).toBeInTheDocument()
     expect(screen.getByText('Copy URI', { selector: 'button' })).toBeInTheDocument()
+
+    // Make sure nav panel didn't disappear
+    fireEvent.click(screen.getByText('Resource Templates', { selector: 'a' }))
+    fireEvent.click(await screen.findByText('Title note', { selector: 'a' }))
+    expect(await screen.findByTestId('Go to Note Text', { selector: 'button' })).toBeInTheDocument()
 
     // Switch back to search page
     fireEvent.click(screen.getByText('Search', { selector: 'a' }))

--- a/src/components/ViewResourceModal.jsx
+++ b/src/components/ViewResourceModal.jsx
@@ -7,6 +7,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCopy, faEdit } from '@fortawesome/free-solid-svg-icons'
 import ModalWrapper, { useDisplayStyle, useModalCss } from 'components/ModalWrapper'
 import { hideModal } from 'actions/modals'
+import { setCurrentResourceIsReadOnly } from 'actions/resources'
 import { selectModalType } from 'selectors/modals'
 import { selectCurrentResourceKey, selectNormSubject } from 'selectors/resources'
 import ResourceComponent from './editor/ResourceComponent'
@@ -22,6 +23,7 @@ const ViewResourceModal = (props) => {
 
   const close = (event) => {
     event.preventDefault()
+    dispatch(setCurrentResourceIsReadOnly(false))
     dispatch(hideModal())
   }
 


### PR DESCRIPTION
Fixes #2580

## Why was this change made?

This prevents a scenario where the resource edit page continues hiding the property panel because the state was not updated.


## How was this change tested?

CI and browser.

## Which documentation and/or configurations were updated?

None

