### PR TITLE
Handles non-unique LC authority entries.

### DIFF
--- a/__tests__/actionCreators/lookups.test.js
+++ b/__tests__/actionCreators/lookups.test.js
@@ -12,7 +12,17 @@ const mockStore = configureMockStore([thunk])
 shortid.generate = jest.fn().mockReturnValue('abc123')
 
 const uri = 'https://id.loc.gov/vocabulary/carriers'
+// Note that this has a duplicate to test de-duping.
+// For some reason, some authorities have dupes.
 const carriers = [{
+  '@id': 'http://id.loc.gov/vocabulary/carriers/nn',
+  '@type': [
+    'http://www.loc.gov/mads/rdf/v1#Authority',
+  ],
+  'http://www.loc.gov/mads/rdf/v1#authoritativeLabel': [{
+    '@value': 'flipchart',
+  }],
+}, {
   '@id': 'http://id.loc.gov/vocabulary/carriers/nn',
   '@type': [
     'http://www.loc.gov/mads/rdf/v1#Authority',

--- a/src/actionCreators/lookups.js
+++ b/src/actionCreators/lookups.js
@@ -1,6 +1,7 @@
 import { selectLookup } from 'selectors/lookups'
 import { lookupOptionsRetrieved } from 'actions/lookups'
 import shortid from 'shortid'
+import _ from 'lodash'
 
 // A thunk that fetches a lookup, transforms it, and adds to state.
 export const fetchLookup = (uri) => (dispatch, getState) => {
@@ -54,7 +55,8 @@ const responseToOptions = (json) => {
       // Ignore
     }
   }
-  return opts
+
+  return _.uniqBy(opts, (opt) => opt.uri)
 }
 
 export const noop = () => {}


### PR DESCRIPTION
closes #2593

## Why was this change made?
Remove duplicates from LC authorities.


## How was this change tested?
Unit, locally.


## Which documentation and/or configurations were updated?
NA


