### PR TITLE
Support lookup of existing resources when creating a template.

### DIFF
--- a/__tests__/sinopiaSearch.test.js
+++ b/__tests__/sinopiaSearch.test.js
@@ -354,6 +354,7 @@ describe('getLookupResults', () => {
   const lookupConfigs = findAuthorityConfigs([
     'urn:ld4p:sinopia:bibframe:instance',
     'urn:ld4p:sinopia:bibframe:work',
+    'urn:ld4p:sinopia:resourceTemplate',
   ])
   const instanceResult = {
     took: 5,
@@ -413,6 +414,7 @@ describe('getLookupResults', () => {
     global.fetch = jest.fn()
       .mockImplementationOnce(() => Promise.resolve({ json: () => instanceResult }))
       .mockImplementationOnce(() => Promise.resolve({ json: () => workResult }))
+      .mockImplementationOnce(() => Promise.resolve({ json: () => templateResult }))
 
     const results = await Promise.all(getLookupResults('foo', lookupConfigs))
     expect(results).toEqual([{
@@ -435,6 +437,16 @@ describe('getLookupResults', () => {
       authURI: 'urn:ld4p:sinopia:bibframe:work',
       label: 'Sinopia BIBFRAME work resources',
       id: 'urn:ld4p:sinopia:bibframe:work',
+    }, {
+      totalHits: 1,
+      results: [{
+        label: 'Cartographic Item (BIBFRAME) (ld4p:RT:bf2:Cartographic:Item)',
+        uri: 'ld4p:RT:bf2:Cartographic:Item',
+      }],
+      authLabel: 'Sinopia templates',
+      authURI: 'urn:ld4p:sinopia:resourceTemplate',
+      id: 'urn:ld4p:sinopia:resourceTemplate',
+      label: 'Sinopia templates',
     }])
   })
 })

--- a/static/authorityConfig.json
+++ b/static/authorityConfig.json
@@ -29,6 +29,12 @@
     "component": "local-lookup"
   },
   {
+    "label": "Sinopia templates",
+    "uri": "urn:ld4p:sinopia:resourceTemplate",
+    "type": "http://sinopia.io/vocabulary/ResourceTemplate",
+    "component": "local-lookup"
+  },
+  {
     "label": "AGROVOC (QA)",
     "uri": "urn:ld4p:qa:agrovoc",
     "authority": "agrovoc_ld4l_cache",


### PR DESCRIPTION
refs #2360

## Why was this change made?
Allow a user to lookup existing resource templates when creating a template.


## How was this change tested?
Unit, locally


## Which documentation and/or configurations were updated?
NA


