### PR TITLE
Display nested resources from dataset and template

### DIFF
--- a/__tests__/__action_fixtures__/loadResourceNestedResource-ADD_SUBJECT.json
+++ b/__tests__/__action_fixtures__/loadResourceNestedResource-ADD_SUBJECT.json
@@ -2,7 +2,7 @@
   "type": "ADD_SUBJECT",
   "payload": {
     "key": "abc0",
-    "uri": "http://localhost:3000/resource/c7db5404-7d7d-40ac-b38e-c821d2c3ae3f",
+    "uri": "http://localhost:3000/resource/a4181509-8046-47c8-9327-6e576c517d70",
     "subjectTemplate": {
       "key": "resourceTemplate:testing:uber1",
       "uri": "http://localhost:3000/resource/resourceTemplate:testing:uber1",
@@ -580,13 +580,13 @@
         "key": "abc1",
         "values": [
           {
-            "key": "abc63",
+            "key": "abc40",
             "literal": null,
             "lang": null,
             "uri": null,
             "label": null,
             "valueSubject": {
-              "key": "abc43",
+              "key": "abc35",
               "uri": null,
               "subjectTemplate": {
                 "key": "resourceTemplate:testing:uber2",
@@ -621,57 +621,21 @@
               },
               "properties": [
                 {
-                  "key": "abc50",
-                  "values": [
-                    {
-                      "key": "abc57",
-                      "literal": "Uber template2, property1",
-                      "lang": "eng",
-                      "uri": null,
-                      "label": null,
-                      "valueSubject": null
-                    }
-                  ],
+                  "key": "abc37",
+                  "values": null,
                   "show": false
                 }
               ]
             }
           },
           {
-            "key": "abc64",
+            "key": "abc34",
             "literal": null,
             "lang": null,
             "uri": null,
             "label": null,
             "valueSubject": {
-              "key": "abc44",
-              "uri": null,
-              "properties": [
-                {
-                  "key": "abc51",
-                  "values": [
-                    {
-                      "key": "abc58",
-                      "literal": "Uber template2, property1b",
-                      "lang": "eng",
-                      "uri": null,
-                      "label": null,
-                      "valueSubject": null
-                    }
-                  ],
-                  "show": false
-                }
-              ]
-            }
-          },
-          {
-            "key": "abc62",
-            "literal": null,
-            "lang": null,
-            "uri": null,
-            "label": null,
-            "valueSubject": {
-              "key": "abc42",
+              "key": "abc29",
               "uri": null,
               "subjectTemplate": {
                 "key": "resourceTemplate:testing:uber3",
@@ -723,10 +687,10 @@
               },
               "properties": [
                 {
-                  "key": "abc48",
+                  "key": "abc30",
                   "values": [
                     {
-                      "key": "abc55",
+                      "key": "abc32",
                       "literal": "Uber template3, property1",
                       "lang": "eng",
                       "uri": null,
@@ -737,10 +701,10 @@
                   "show": false
                 },
                 {
-                  "key": "abc49",
+                  "key": "abc31",
                   "values": [
                     {
-                      "key": "abc56",
+                      "key": "abc33",
                       "literal": "Uber template3, property2",
                       "lang": "eng",
                       "uri": null,
@@ -758,16 +722,7 @@
       },
       {
         "key": "abc2",
-        "values": [
-          {
-            "key": "abc29",
-            "literal": "Uber template1, property2",
-            "lang": "eng",
-            "uri": null,
-            "label": null,
-            "valueSubject": null
-          }
-        ],
+        "values": null,
         "show": false
       },
       {
@@ -777,44 +732,17 @@
       },
       {
         "key": "abc4",
-        "values": [
-          {
-            "key": "abc30",
-            "literal": "Uber template1, property4",
-            "lang": "eng",
-            "uri": null,
-            "label": null,
-            "valueSubject": null
-          }
-        ],
+        "values": [],
         "show": true
       },
       {
         "key": "abc5",
-        "values": [
-          {
-            "key": "abc31",
-            "literal": null,
-            "lang": null,
-            "uri": "ubertemplate1:property5",
-            "label": "ubertemplate1:property5",
-            "valueSubject": null
-          }
-        ],
+        "values": [],
         "show": true
       },
       {
         "key": "abc6",
-        "values": [
-          {
-            "key": "abc32",
-            "literal": null,
-            "lang": null,
-            "uri": "ubertemplate1:property6",
-            "label": "ubertemplate1:property6",
-            "valueSubject": null
-          }
-        ],
+        "values": [],
         "show": true
       },
       {
@@ -829,141 +757,60 @@
       },
       {
         "key": "abc9",
-        "values": [
-          {
-            "key": "abc33",
-            "literal": "Uber template1, property9",
-            "lang": "eng",
-            "uri": null,
-            "label": null,
-            "valueSubject": null
-          }
-        ],
+        "values": [],
         "show": true
       },
       {
         "key": "abc10",
-        "values": [
-          {
-            "key": "abc34",
-            "literal": null,
-            "lang": null,
-            "uri": "http://id.loc.gov/vocabulary/mrectype/analog",
-            "label": "analog",
-            "valueSubject": null
-          }
-        ],
+        "values": [],
         "show": true
       },
       {
         "key": "abc11",
-        "values": [
-          {
-            "key": "abc35",
-            "literal": null,
-            "lang": null,
-            "uri": "http://id.loc.gov/vocabulary/mrectype/digital",
-            "label": "digital",
-            "valueSubject": null
-          }
-        ],
+        "values": [],
         "show": true
       },
       {
         "key": "abc12",
-        "values": [
-          {
-            "key": "abc36",
-            "literal": null,
-            "lang": null,
-            "uri": "http://id.loc.gov/vocabulary/mrecmedium/mag",
-            "label": "magnetic",
-            "valueSubject": null
-          }
-        ],
+        "values": [],
         "show": true
       },
       {
         "key": "abc13",
-        "values": [
-          {
-            "key": "abc37",
-            "literal": null,
-            "lang": null,
-            "uri": "http://aims.fao.org/aos/agrovoc/c_35856",
-            "label": "summer squash",
-            "valueSubject": null
-          }
-        ],
+        "values": [],
         "show": true
       },
       {
         "key": "abc14",
-        "values": [
-          {
-            "key": "abc38",
-            "literal": null,
-            "lang": null,
-            "uri": "http://aims.fao.org/aos/agrovoc/c_331388",
-            "label": "corn sheller",
-            "valueSubject": null
-          }
-        ],
+        "values": [],
         "show": true
       },
       {
         "key": "abc15",
-        "values": [
-          {
-            "key": "abc39",
-            "literal": null,
-            "lang": null,
-            "uri": "http://sws.geonames.org/5098279/",
-            "label": "Freehold Borough High School (US)",
-            "valueSubject": null
-          }
-        ],
+        "values": [],
         "show": true
       },
       {
         "key": "abc16",
-        "values": [
-          {
-            "key": "abc40",
-            "literal": null,
-            "lang": null,
-            "uri": "http://localhost:3000/resource/c7db5404-7d7d-40ac-b38e-c821d2c3ae3f",
-            "label": "foo",
-            "valueSubject": null
-          }
-        ],
+        "values": [],
         "show": true
       },
       {
         "key": "abc17",
-        "values": [
-          {
-            "key": "abc41",
-            "literal": null,
-            "lang": null,
-            "uri": "http://localhost:3000/resource/c7db5404-7d7d-40ac-b38e-c821d2c3ae3f",
-            "label": "foo",
-            "valueSubject": null
-          }
-        ],
+        "values": [],
         "show": true
       },
       {
         "key": "abc18",
         "values": [
           {
-            "key": "abc65",
+            "key": "abc28",
             "literal": null,
             "lang": null,
             "uri": null,
             "label": null,
             "valueSubject": {
-              "key": "abc45",
+              "key": "abc19",
               "uri": null,
               "subjectTemplate": {
                 "key": "resourceTemplate:testing:uber4",
@@ -998,17 +845,8 @@
               },
               "properties": [
                 {
-                  "key": "abc52",
-                  "values": [
-                    {
-                      "key": "abc59",
-                      "literal": "Uber template4, property1",
-                      "lang": "eng",
-                      "uri": null,
-                      "label": null,
-                      "valueSubject": null
-                    }
-                  ],
+                  "key": "abc27",
+                  "values": [],
                   "show": true
                 }
               ]
@@ -1019,62 +857,7 @@
       },
       {
         "key": "abc20",
-        "values": [
-          {
-            "key": "abc66",
-            "literal": null,
-            "lang": null,
-            "uri": null,
-            "label": null,
-            "valueSubject": {
-              "key": "abc46",
-              "uri": null,
-              "properties": [
-                {
-                  "key": "abc53",
-                  "values": [
-                    {
-                      "key": "abc60",
-                      "literal": "Uber template4, property1, first",
-                      "lang": "eng",
-                      "uri": null,
-                      "label": null,
-                      "valueSubject": null
-                    }
-                  ],
-                  "show": true
-                }
-              ]
-            }
-          },
-          {
-            "key": "abc67",
-            "literal": null,
-            "lang": null,
-            "uri": null,
-            "label": null,
-            "valueSubject": {
-              "key": "abc47",
-              "uri": null,
-              "properties": [
-                {
-                  "key": "abc54",
-                  "values": [
-                    {
-                      "key": "abc61",
-                      "literal": "Uber template4, property1, second",
-                      "lang": "eng",
-                      "uri": null,
-                      "label": null,
-                      "valueSubject": null
-                    }
-                  ],
-                  "show": true
-                }
-              ]
-            }
-          }
-        ],
+        "values": null,
         "show": false
       },
       {

--- a/__tests__/__action_fixtures__/newResourceFromDataset-ADD_SUBJECT.json
+++ b/__tests__/__action_fixtures__/newResourceFromDataset-ADD_SUBJECT.json
@@ -5,12 +5,12 @@
     "uri": "http://localhost:3000/resource/c7db5404-7d7d-40ac-b38e-c821d2c3ae3f",
     "subjectTemplate": {
       "key": "resourceTemplate:testing:uber1",
+      "uri": "http://localhost:3000/resource/resourceTemplate:testing:uber1",
       "id": "resourceTemplate:testing:uber1",
       "class": "http://id.loc.gov/ontologies/bibframe/Uber1",
       "label": "Uber template1",
       "author": "Justin Littman",
       "remark": "Template for testing purposes.",
-      "uri": "http://localhost:3000/resource/resourceTemplate:testing:uber1",
       "date": "2020-07-27",
       "propertyTemplateKeys": [
         "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property1",
@@ -549,36 +549,121 @@
           "component": "InputLookupSinopia"
         },
         {
-           "authorities": [],
-           "component": "InputLiteral",
-           "defaults": [
-             {
-               "lang": null,
-               "literal": "Default required literal1"
-             },
-             {
-               "lang": null,
-               "literal": "Default required literal2"
-             }
-           ],
-           "key": "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property20",
-           "label": "Uber template1, property20",
-           "ordered": false,
-           "remark": "A required, repeatable literal with defaults.",
-           "remarkUrl": null,
-           "repeatable": false,
-           "required": true,
-           "subjectTemplateKey": "resourceTemplate:testing:uber1",
-           "type": "literal",
-           "uri": "http://id.loc.gov/ontologies/bibframe/uber/template1/property20",
-           "valueSubjectTemplateKeys": []
-         }
+          "key": "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property20",
+          "subjectTemplateKey": "resourceTemplate:testing:uber1",
+          "label": "Uber template1, property20",
+          "uri": "http://id.loc.gov/ontologies/bibframe/uber/template1/property20",
+          "required": true,
+          "repeatable": false,
+          "ordered": false,
+          "remark": "A required, repeatable literal with defaults.",
+          "remarkUrl": null,
+          "defaults": [
+            {
+              "literal": "Default required literal1",
+              "lang": null
+            },
+            {
+              "literal": "Default required literal2",
+              "lang": null
+            }
+          ],
+          "valueSubjectTemplateKeys": [],
+          "authorities": [],
+          "type": "literal",
+          "component": "InputLiteral"
+        }
       ]
     },
     "properties": [
       {
         "key": "abc1",
         "values": [
+          {
+            "key": "abc45",
+            "literal": null,
+            "lang": null,
+            "uri": null,
+            "label": null,
+            "valueSubject": {
+              "key": "abc34",
+              "uri": null,
+              "subjectTemplate": {
+                "key": "resourceTemplate:testing:uber2",
+                "uri": "http://localhost:3000/resource/resourceTemplate:testing:uber2",
+                "id": "resourceTemplate:testing:uber2",
+                "class": "http://id.loc.gov/ontologies/bibframe/Uber2",
+                "label": "Uber template2",
+                "author": null,
+                "remark": "Template for testing purposes with single repeatable literal.",
+                "date": null,
+                "propertyTemplateKeys": [
+                  "resourceTemplate:testing:uber2 > http://id.loc.gov/ontologies/bibframe/uber/template2/property1"
+                ],
+                "propertyTemplates": [
+                  {
+                    "key": "resourceTemplate:testing:uber2 > http://id.loc.gov/ontologies/bibframe/uber/template2/property1",
+                    "subjectTemplateKey": "resourceTemplate:testing:uber2",
+                    "label": "Uber template2, property1",
+                    "uri": "http://id.loc.gov/ontologies/bibframe/uber/template2/property1",
+                    "required": false,
+                    "repeatable": true,
+                    "ordered": false,
+                    "remark": "A repeatable literal",
+                    "remarkUrl": null,
+                    "defaults": [],
+                    "valueSubjectTemplateKeys": [],
+                    "authorities": [],
+                    "type": "literal",
+                    "component": "InputLiteral"
+                  }
+                ]
+              },
+              "properties": [
+                {
+                  "key": "abc38",
+                  "values": [
+                    {
+                      "key": "abc42",
+                      "literal": "Uber template2, property1",
+                      "lang": "eng",
+                      "uri": null,
+                      "label": null,
+                      "valueSubject": null
+                    }
+                  ],
+                  "show": false
+                }
+              ]
+            }
+          },
+          {
+            "key": "abc46",
+            "literal": null,
+            "lang": null,
+            "uri": null,
+            "label": null,
+            "valueSubject": {
+              "key": "abc35",
+              "uri": null,
+              "properties": [
+                {
+                  "key": "abc39",
+                  "values": [
+                    {
+                      "key": "abc43",
+                      "literal": "Uber template2, property1b",
+                      "lang": "eng",
+                      "uri": null,
+                      "label": null,
+                      "valueSubject": null
+                    }
+                  ],
+                  "show": false
+                }
+              ]
+            }
+          },
           {
             "key": "abc44",
             "literal": null,
@@ -590,12 +675,12 @@
               "uri": null,
               "subjectTemplate": {
                 "key": "resourceTemplate:testing:uber3",
+                "uri": "http://localhost:3000/resource/resourceTemplate:testing:uber3",
                 "id": "resourceTemplate:testing:uber3",
                 "class": "http://id.loc.gov/ontologies/bibframe/Uber3",
                 "label": "Uber template3",
                 "author": null,
                 "remark": "Template for testing purposes with multiple literal.",
-                "uri": "http://localhost:3000/resource/resourceTemplate:testing:uber3",
                 "date": null,
                 "propertyTemplateKeys": [
                   "resourceTemplate:testing:uber3 > http://id.loc.gov/ontologies/bibframe/uber/template3/property1",
@@ -657,91 +742,6 @@
                     {
                       "key": "abc41",
                       "literal": "Uber template3, property2",
-                      "lang": "eng",
-                      "uri": null,
-                      "label": null,
-                      "valueSubject": null
-                    }
-                  ],
-                  "show": false
-                }
-              ]
-            }
-          },
-          {
-            "key": "abc45",
-            "literal": null,
-            "lang": null,
-            "uri": null,
-            "label": null,
-            "valueSubject": {
-              "key": "abc34",
-              "uri": null,
-              "subjectTemplate": {
-                "key": "resourceTemplate:testing:uber2",
-                "id": "resourceTemplate:testing:uber2",
-                "class": "http://id.loc.gov/ontologies/bibframe/Uber2",
-                "label": "Uber template2",
-                "author": null,
-                "remark": "Template for testing purposes with single repeatable literal.",
-                "uri": "http://localhost:3000/resource/resourceTemplate:testing:uber2",
-                "date": null,
-                "propertyTemplateKeys": [
-                  "resourceTemplate:testing:uber2 > http://id.loc.gov/ontologies/bibframe/uber/template2/property1"
-                ],
-                "propertyTemplates": [
-                  {
-                    "key": "resourceTemplate:testing:uber2 > http://id.loc.gov/ontologies/bibframe/uber/template2/property1",
-                    "subjectTemplateKey": "resourceTemplate:testing:uber2",
-                    "label": "Uber template2, property1",
-                    "uri": "http://id.loc.gov/ontologies/bibframe/uber/template2/property1",
-                    "required": false,
-                    "repeatable": true,
-                    "ordered": false,
-                    "remark": "A repeatable literal",
-                    "remarkUrl": null,
-                    "defaults": [],
-                    "valueSubjectTemplateKeys": [],
-                    "authorities": [],
-                    "type": "literal",
-                    "component": "InputLiteral"
-                  }
-                ]
-              },
-              "properties": [
-                {
-                  "key": "abc38",
-                  "values": [
-                    {
-                      "key": "abc42",
-                      "literal": "Uber template2, property1",
-                      "lang": "eng",
-                      "uri": null,
-                      "label": null,
-                      "valueSubject": null
-                    }
-                  ],
-                  "show": false
-                }
-              ]
-            }
-          },
-          {
-            "key": "abc46",
-            "literal": null,
-            "lang": null,
-            "uri": null,
-            "label": null,
-            "valueSubject": {
-              "key": "abc35",
-              "uri": null,
-              "properties": [
-                {
-                  "key": "abc39",
-                  "values": [
-                    {
-                      "key": "abc43",
-                      "literal": "Uber template2, property1b",
                       "lang": "eng",
                       "uri": null,
                       "label": null,
@@ -886,12 +886,12 @@
               "uri": null,
               "subjectTemplate": {
                 "key": "resourceTemplate:testing:uber4",
+                "uri": "http://localhost:3000/resource/resourceTemplate:testing:uber4",
                 "id": "resourceTemplate:testing:uber4",
                 "class": "http://id.loc.gov/ontologies/bibframe/Uber4",
                 "label": "Uber template4",
                 "author": null,
                 "remark": "Template for testing purposes with single repeatable, required literal.",
-                "uri": "http://localhost:3000/resource/resourceTemplate:testing:uber4",
                 "date": null,
                 "propertyTemplateKeys": [
                   "resourceTemplate:testing:uber4 > http://id.loc.gov/ontologies/bibframe/uber/template4/property1"
@@ -959,8 +959,8 @@
       },
       {
         "key": "abc26",
-        "show": true,
-        "values": []
+        "values": [],
+        "show": true
       }
     ]
   }

--- a/__tests__/__resource_fixtures__/test2.json
+++ b/__tests__/__resource_fixtures__/test2.json
@@ -1,0 +1,36 @@
+[
+  {
+    "@id": "_:b1",
+    "@type": [
+      "http://id.loc.gov/ontologies/bibframe/Uber3"
+    ],
+    "http://id.loc.gov/ontologies/bibframe/uber/template3/property1": [
+      {
+        "@value": "Uber template3, property1",
+        "@language": "eng"
+      }
+    ],
+    "http://id.loc.gov/ontologies/bibframe/uber/template3/property2": [
+      {
+        "@value": "Uber template3, property2",
+        "@language": "eng"
+      }
+    ]
+  },
+  {
+    "@id": "http://localhost:3000/resource/a4181509-8046-47c8-9327-6e576c517d70",
+    "http://sinopia.io/vocabulary/hasResourceTemplate": [
+      {
+        "@value": "resourceTemplate:testing:uber1"
+      }
+    ],
+    "@type": [
+      "http://id.loc.gov/ontologies/bibframe/Uber1"
+    ],
+    "http://id.loc.gov/ontologies/bibframe/uber/template1/property1": [
+      {
+        "@id": "_:b1"
+      }
+    ]
+  }
+]

--- a/__tests__/actionCreators/resources.test.js
+++ b/__tests__/actionCreators/resources.test.js
@@ -314,6 +314,23 @@ describe('loadResource', () => {
       })
     })
   })
+
+  describe('load resource with nested resource', () => {
+    const store = mockStore(createState())
+    const expectedAddResourceNestedResourceAction = require('../__action_fixtures__/loadResourceNestedResource-ADD_SUBJECT.json')
+    it('should have nested resources from loading resource and templates', async () => {
+      const uri = 'http://localhost:3000/resource/a4181509-8046-47c8-9327-6e576c517d70'
+      const result = await store.dispatch(loadResource(uri, 'testerrorkey'))
+      expect(result).toBe(true)
+
+      const actions = store.getActions()
+
+      const addSubjectAction = actions.find((action) => action.type === 'ADD_SUBJECT')
+      expect(addSubjectAction).not.toBeNull()
+      // safeStringify is used because it removes circular references
+      expect(safeAction(addSubjectAction)).toEqual(expectedAddResourceNestedResourceAction)
+    })
+  })
 })
 
 describe('newResource', () => {

--- a/__tests__/feature/loadResource.test.js
+++ b/__tests__/feature/loadResource.test.js
@@ -44,7 +44,7 @@ describe('loading saved resource', () => {
       screen.getByText('Uber template1', { selector: 'h3' })
       screen.getByText('Uber template1, property1', { selector: 'span' })
       screen.getAllByText('Uber template2', { selector: 'h5' })
-      screen.getByText('Uber template3', { selector: 'h5' })
+      screen.getAllByText('Uber template3', { selector: 'h5' })
       // Length is the heading and the value.
       expect(screen.getAllByText('Uber template3, property1')).toHaveLength(3)
       expect(screen.getAllByText('Uber template3, property2')).toHaveLength(3)

--- a/__tests__/feature/previewRdf.test.js
+++ b/__tests__/feature/previewRdf.test.js
@@ -12,9 +12,7 @@ const rdf = `<> <http://sinopia.io/vocabulary/hasResourceTemplate> "resourceTemp
     <http://id.loc.gov/ontologies/bibframe/uber/template1/property8> <http://sinopia.io/defaultURI1>.
 <http://sinopia.io/defaultURI1> <http://www.w3.org/2000/01/rdf-schema#label> "Default URI1".
 <> <http://id.loc.gov/ontologies/bibframe/uber/template1/property8> <http://sinopia.io/defaultURI2>;
-    <http://id.loc.gov/ontologies/bibframe/uber/template1/property19> _:b1.
-_:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil>.
-<> <http://id.loc.gov/ontologies/bibframe/uber/template1/property20> "Default required literal1", "Default required literal2".
+    <http://id.loc.gov/ontologies/bibframe/uber/template1/property20> "Default required literal1", "Default required literal2".
 `
 
 describe('preview RDF after editing', () => {

--- a/__tests__/testUtilities/fixtureLoaderHelper.js
+++ b/__tests__/testUtilities/fixtureLoaderHelper.js
@@ -5,6 +5,7 @@ import _ from 'lodash'
 const resourceFilenames = {
   'c7db5404-7d7d-40ac-b38e-c821d2c3ae3f': 'test.json',
   'c7db5404-7d7d-40ac-b38e-c821d2c3ae3f-invalid': 'invalid_rt.json',
+  'a4181509-8046-47c8-9327-6e576c517d70': 'test2.json',
 }
 
 const templateFilenames = {

--- a/src/GraphBuilder.js
+++ b/src/GraphBuilder.js
@@ -52,7 +52,7 @@ export default class GraphBuilder {
   }
 
   buildProperty(property, subjectTerm) {
-    if (property.values == null || property.values.length === 0) return
+    if (!this.shouldAddProperty(property)) return
 
     if (property.propertyTemplate.ordered) {
       let nextNode = rdf.blankNode()
@@ -104,6 +104,10 @@ export default class GraphBuilder {
   // Add only if there is actually a value somewhere.
   shouldAddValueSubject(value) {
     return this.checkSubjectHasValue(value.valueSubject)
+  }
+
+  shouldAddProperty(property) {
+    return this.checkPropertyHasValue(property)
   }
 
   checkSubjectHasValue(subject) {


### PR DESCRIPTION
## Why was this change made?
To fix a bug whereby when loading a resource that has a property that has multiple nested resource templates, only the resource templates with data were being displayed.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?
NA


