### PR TITLE
add click event to ensure diacritics language is shown

### DIFF
--- a/src/components/editor/diacritics/VocabChoice.jsx
+++ b/src/components/editor/diacritics/VocabChoice.jsx
@@ -24,7 +24,8 @@ const VocabChoice = (props) => {
             aria-label="Select vocabulary"
             data-testid="Select vocabulary"
             onBlur={handleChange}
-            onChange={handleChange}>
+            onChange={handleChange}
+            onClick={handleChange}>
     {getOptions()}
   </select>)
 }


### PR DESCRIPTION
## Why was this change made?

Fixes #2604 

It appears when the new diacritics panel is shown, the first item in the list if selected but not yet shown.  The current events to switch languages are "change" or "blur", neither of which are called if you click on Latin.  Add a "click" event ensures it gets called each time the user selects a new language (even if its the first on the list).


## How was this change tested?

Local browser

## Which documentation and/or configurations were updated?



