### PR TITLE
Add Search spinner to QA InputLookup

### DIFF
--- a/src/components/editor/property/LookupWithMultipleAuthorities.jsx
+++ b/src/components/editor/property/LookupWithMultipleAuthorities.jsx
@@ -76,7 +76,7 @@ const LookupWithMultipleAuthorities = (props) => {
         }
       })
     })
-  }, [query, allAuthorities, getLookupResults])
+  }, [query, allAuthorities, getLookupResults, clearSearchResults])
 
   // hide the spinner after the results are fetched
   if (allResults.current.length > 0) loadingSearchRef.current.classList.add('hidden')


### PR DESCRIPTION
## Why was this change made?
Fixes #2615. Adds search spinner and ability to clear search results tor QA Authority InputLookup.


## How was this change tested?
Will be tested as part of #2257 as soon as that is unblocked

![2020-10-06 15-15-28 2020-10-06 15_16_33](https://user-images.githubusercontent.com/3093850/95265889-f3dab000-07e6-11eb-8a7c-b0cec7b3b289.gif)
