### PR TITLE
Set maxwidth for MARC preview.

### DIFF
--- a/src/components/editor/actions/MarcButton.jsx
+++ b/src/components/editor/actions/MarcButton.jsx
@@ -67,7 +67,7 @@ const MarcButton = () => {
   }
 
   return (
-    <div className="dropleft">
+    <div className="btn-group dropleft">
       <button type="button"
               id="marcBtn"
               className={btnClasses.join(' ')}
@@ -83,7 +83,7 @@ const MarcButton = () => {
             <button className="btn btn-link dropdown-item" onClick={(event) => handleDownloadTxt(event)}>Download text</button>
             <button className="btn btn-link dropdown-item" onClick={(event) => handleDownloadMarc(event)}>Download MARC</button>
             <pre style={{
-              marginLeft: '10px', marginRight: '10px', paddingLeft: '10px', paddingRight: '10px',
+              marginLeft: '10px', marginRight: '10px', paddingLeft: '10px', paddingRight: '10px', maxWidth: '750px',
             }}>{marc}</pre>
           </React.Fragment>
         }


### PR DESCRIPTION
closes #2624

## Why was this change made?
The MARC preview was dropping right, which made it difficult to use.


## How was this change tested?
Locally


## Which documentation and/or configurations were updated?
NA


