### PR TITLE
add spacing between resource nav tabs

### DIFF
--- a/src/components/editor/ResourcesNav.jsx
+++ b/src/components/editor/ResourcesNav.jsx
@@ -19,7 +19,7 @@ const ResourcesNav = () => {
     resourceKeys.forEach((resourceKey) => {
       const subjectTemplate = selectSubjectTemplateFor(state, resourceKey)
       const resourceLabel = subjectTemplate.label
-      labels[resourceKey] = resourceLabel.length > 40 ? `${resourceLabel.slice(0, 40)}...` : resourceLabel
+      labels[resourceKey] = resourceLabel.length > 38 ? `${resourceLabel.slice(0, 38)}...` : resourceLabel
     })
     return labels
   })

--- a/src/styles/resourceTabs.scss
+++ b/src/styles/resourceTabs.scss
@@ -1,16 +1,28 @@
 .resources-nav-tabs {
   margin-bottom: 5px;
+  margin-top: 10px;
 
   .nav-item {
     border: 1px solid $gray-600;
     margin-bottom: -1px;
     margin-right: 10px;
+    width: 350px;
+    margin-bottom: 5px;
+    height: 50px;
 
     .nav-link {
       border: 0;
       border-radius: 0;
       color: $gray-600;
       text-decoration: none;
+    }
+
+    .btn-group {
+      width: 100%;
+    }
+
+    .button {
+      text-align: right;
     }
   }
 


### PR DESCRIPTION
## Why was this change made?

Fixes #2608 

1. Force the tabs to always be the same width (so they stack up nicely when in rows).  Width is set to 350px. This seems like a reasonable number to allow for three to four tabs across the page in a normal sized browser window, but I had to actually shrink the number of characters in the tab down to 38 (from 40) before you get the truncation to prevent overflow of text when tab widths are no bigger than 350px.

2. Add some spacing between them (so they aren't stuck together). 

3. Make better use of the tab width by removing the padding that comes from bootstrap.

4. Move the 'x' button over to the far right.

![Screen Shot 2020-10-07 at 2.59.31 PM.png](https://images.zenhubusercontent.com/59b9a35fb0222d5de477a1fb/9b06aec9-cde6-48c0-8baa-2422770c64bf)

## How was this change tested?

Localhost browser


## Which documentation and/or configurations were updated?

None
