### PR TITLE
Swallow extra label triples.

### DIFF
--- a/__tests__/actionCreators/resources.test.js
+++ b/__tests__/actionCreators/resources.test.js
@@ -144,6 +144,28 @@ describe('newResourceFromDataset', () => {
     })
   })
 
+  describe('loading a resource with extra label triple', () => {
+    const store = mockStore(createState())
+
+    it('dispatches actions', async () => {
+      const extraRdf = `<ubertemplate1:property5> <http://www.w3.org/2000/01/rdf-schema#label> "http://sinopia.io/ubertemplate1:property5" .
+`
+      const dataset = await datasetFromN3(n3 + extraRdf)
+      const result = await store.dispatch(newResourceFromDataset(dataset, uri, null, 'testerrorkey'))
+      expect(result).toBe(true)
+
+      const actions = store.getActions()
+
+      const addSubjectAction = actions.find((action) => action.type === 'ADD_SUBJECT')
+      expect(safeAction(addSubjectAction)).toEqual(expectedAddResourceAction)
+
+      expect(actions).toHaveAction('SET_UNUSED_RDF', {
+        resourceKey: 'abc0',
+        rdf: null,
+      })
+    })
+  })
+
   describe('loading a new resource', () => {
     const store = mockStore(createState())
 

--- a/src/actionCreators/resourceHelpers.js
+++ b/src/actionCreators/resourceHelpers.js
@@ -238,8 +238,11 @@ const newUriFromObject = (obj, property, dataset, usedDataset) => {
   const labelQuads = dataset.match(obj, rdf.namedNode('http://www.w3.org/2000/01/rdf-schema#label')).toArray()
   let label = uri
   if (labelQuads.length > 0) {
-    label = labelQuads[0].object.value // Use first match
-    usedDataset.add(labelQuads[0])
+    // First that doesn't start with http or first
+    const labelQuad = labelQuads.find((labelQuad) => !labelQuad.object.value.startsWith('http')) || labelQuads[0]
+    label = labelQuad.object.value
+    // Adding all to usedData, even though only using first. This is to avoid user confusion over extra triples, e.g., https://github.com/LD4P/sinopia_editor/issues/2634
+    usedDataset.addAll(labelQuads)
   }
   return newUriValue(property, uri, label)
 }


### PR DESCRIPTION
closes #2634

## Why was this change made?
To avoid user confusion when there are extra labels.


## How was this change tested?
Unit, locally.


## Which documentation and/or configurations were updated?
NA


