### PR TITLE
New Templates link is now a blue buttton

### DIFF
--- a/__tests__/feature/newResourceTemplate.test.js
+++ b/__tests__/feature/newResourceTemplate.test.js
@@ -12,7 +12,7 @@ describe('creating new resource template ', () => {
     fireEvent.click(screen.getByText('Resource Templates', { selector: 'a' }))
 
     // Click the new resource template button
-    fireEvent.click(screen.getByText('+ New template', { selector: 'a' }))
+    fireEvent.click(screen.getByText('New template'))
     await waitFor(() => expect((screen.getByText('Resource Template (dummy)', { selector: 'h3' }))))
   }, 15000)
 })

--- a/src/components/templates/NewResourceTemplateButton.jsx
+++ b/src/components/templates/NewResourceTemplateButton.jsx
@@ -36,7 +36,11 @@ const NewResourceTemplateButton = (props) => {
     })
   }
   return (
-    <Link to={{ pathname: '/editor', state: { } }} onClick={(e) => handleClick(e)}>+ New template</Link>
+    <button className="btn btn-primary">
+      <Link to={{ pathname: '/editor', state: { } }}
+            onClick={(e) => handleClick(e)}
+            className="text-white text-decoration-none">New template</Link>
+    </button>
   )
 }
 


### PR DESCRIPTION
## Why was this change made?
Fixes #2610. Removed "+" in label to be consistent with other buttons in the editor.


## How was this change tested?
Unit and Integration tests


## Which documentation and/or configurations were updated?
n/a


