### PR TITLE
turn PropertyLabel into an HTML <label>

### DIFF
--- a/__tests__/feature/loadResource.test.js
+++ b/__tests__/feature/loadResource.test.js
@@ -62,6 +62,10 @@ describe('loading saved resource', () => {
 
       // confirm that the input field has an accessible label
       screen.getByLabelText('Uber template3, property1')
+
+      // TODO: would expect this to work too, but it doesn't seem to, either in Firefox or in this test suite.
+      // see https://github.com/LD4P/sinopia_editor/issues/2683
+      // screen.getByLabelText('Uber template1, property1')
     })
   })
 

--- a/__tests__/feature/loadResource.test.js
+++ b/__tests__/feature/loadResource.test.js
@@ -42,7 +42,7 @@ describe('loading saved resource', () => {
 
       // Headings
       screen.getByText('Uber template1', { selector: 'h3' })
-      screen.getByText('Uber template1, property1', { selector: 'span' })
+      screen.getByText('Uber template1, property1', { selector: 'label' })
       screen.getAllByText('Uber template2', { selector: 'h5' })
       screen.getAllByText('Uber template3', { selector: 'h5' })
       // Length is the heading and the value.
@@ -59,6 +59,9 @@ describe('loading saved resource', () => {
       screen.getByPlaceholderText('Uber template3, property1')
       screen.getByPlaceholderText('Uber template3, property2')
       screen.getByPlaceholderText('Uber template1, property2')
+
+      // confirm that the input field has an accessible label
+      screen.getByLabelText('Uber template3, property1')
     })
   })
 

--- a/__tests__/feature/search.test.js
+++ b/__tests__/feature/search.test.js
@@ -163,7 +163,7 @@ describe('sinopia resource search', () => {
     await screen.findByText(/foo bar/)
     expect(searchSpinner.classList.contains('hidden')).toBe(true) // search spinner hidden again
 
-    // TODO: why don't filtering options show up in test UI?
+    // TODO: why don't filtering options show up in test UI? -- https://github.com/LD4P/sinopia_editor/issues/2499
     // screen.debug()
     // fireEvent.click(screen.getByText(/Filter by institution/, { selector: 'button' }))
     // fireEvent.click(screen.getByText('Cornell University'))

--- a/__tests__/feature/searchAndViewResource.test.js
+++ b/__tests__/feature/searchAndViewResource.test.js
@@ -58,7 +58,7 @@ describe('searching and viewing a resource', () => {
 
     // Modal has now rendered
     expect((await screen.findByTestId('view-resource-modal')).classList).toContain('show')
-    expect((await screen.findAllByText('Uber template1, property1', { selector: 'span' }))).toHaveLength(1)
+    expect((await screen.findAllByText('Uber template1, property1', { selector: 'label' }))).toHaveLength(1)
 
     // Edit controls are disabled in view modal
     screen.getAllByTestId('Remove Uber template3, property1').forEach((removeButton) => {

--- a/src/components/editor/property/InputList.jsx
+++ b/src/components/editor/property/InputList.jsx
@@ -94,6 +94,7 @@ const InputList = (props) => {
           onBlur={selectionChanged}
           aria-label={`Select ${props.propertyTemplate.label}`}
           data-testid="list"
+          id={props.propertyLabelId}
         >{options}
         </select>
         {error && <span className="invalid-feedback">{error}</span>}
@@ -109,6 +110,7 @@ InputList.propTypes = {
   propertyTemplate: PropTypes.object.isRequired,
   values: PropTypes.array,
   addValue: PropTypes.func,
+  propertyLabelId: PropTypes.string.isRequired,
 }
 
 const mapStateToProps = (state, ownProps) => ({

--- a/src/components/editor/property/InputLiteral.jsx
+++ b/src/components/editor/property/InputLiteral.jsx
@@ -75,6 +75,7 @@ const InputLiteral = (props) => {
   }
 
   // TextareaAutosize does not disable well, so using a disabled input.
+
   return (
     <div className="form-group">
       <div className="input-group" onBlur={handleBlur} id={id}>
@@ -93,7 +94,8 @@ const InputLiteral = (props) => {
               onKeyDown={handleKeyDown}
               onClick={handleClickDiacritics}
               value={currentContent}
-              ref={inputLiteralRef} />
+              ref={inputLiteralRef}
+              id={props.propertyLabelId} />
         }
         <div className="input-group-append" tabIndex="0">
           <button className="btn btn-outline-primary"
@@ -120,6 +122,7 @@ InputLiteral.propTypes = {
   propertyTemplate: PropTypes.object.isRequired,
   addValue: PropTypes.func,
   content: PropTypes.string,
+  propertyLabelId: PropTypes.string.isRequired,
 }
 
 const mapStateToProps = (state, ownProps) => ({

--- a/src/components/editor/property/NestedProperty.jsx
+++ b/src/components/editor/property/NestedProperty.jsx
@@ -6,21 +6,23 @@ import NestedPropertyHeader from './NestedPropertyHeader'
 import PropertyComponent from './PropertyComponent'
 import { selectNormProperty } from 'selectors/resources'
 import { connect } from 'react-redux'
+import shortid from 'shortid'
 import useNavigableComponent from 'hooks/useNavigableComponent'
 import { selectPropertyTemplate } from 'selectors/templates'
 
 const NestedProperty = (props) => {
   const [navEl, navClickHandler] = useNavigableComponent(props.property.rootSubjectKey, props.property.rootPropertyKey, props.property.key)
+  const propertyLabelId = `labelled-by-${shortid.generate()}`
   // onClick is to support left navigation, so ignoring jsx-ally seems reasonable.
   /* eslint-disable jsx-a11y/click-events-have-key-events */
   /* eslint-disable jsx-a11y/no-static-element-interactions */
   return (
     <div ref={navEl} onClick={navClickHandler} className="rtOutline" data-label={props.propertyTemplate.label}>
-      <NestedPropertyHeader property={ props.property } propertyTemplate={ props.propertyTemplate } />
+      <NestedPropertyHeader id={propertyLabelId} property={ props.property } propertyTemplate={ props.propertyTemplate } />
       { props.property.valueKeys && props.property.show
           && (
             <div className="rOutline-property">
-              <PropertyComponent property={ props.property } propertyTemplate={ props.propertyTemplate } />
+              <PropertyComponent propertyLabelId={propertyLabelId} property={ props.property } propertyTemplate={ props.propertyTemplate } />
             </div>
           )
       }

--- a/src/components/editor/property/NestedPropertyHeader.jsx
+++ b/src/components/editor/property/NestedPropertyHeader.jsx
@@ -48,8 +48,9 @@ const NestedPropertyHeader = (props) => {
                 onClick={() => props.expandProperty(props.property.key, resourceEditErrorKey(props.resourceKey))}
                 aria-label={`Add ${props.propertyTemplate.label}`}
                 data-testid={`Add ${props.propertyTemplate.label}`}
-                data-id={props.property.key}>
-          + Add <strong><PropertyLabel propertyTemplate={props.propertyTemplate} /></strong>
+                data-id={props.property.key}
+                id={props.property.key}>
+          + Add <strong><PropertyLabel forId={props.property.key} propertyTemplate={props.propertyTemplate} /></strong>
         </button>
         <PropertyLabelInfo propertyTemplate={ props.propertyTemplate } />
         { error && <span className="invalid-feedback">{error}</span>}
@@ -68,7 +69,7 @@ const NestedPropertyHeader = (props) => {
               onClick={() => toggleProperty()}>
         <FontAwesomeIcon className="toggle-icon" icon={toggleIcon} />
       </button>
-      <strong><PropertyLabel propertyTemplate={props.propertyTemplate} /></strong>
+      <strong><PropertyLabel forId={props.id} propertyTemplate={props.propertyTemplate} /></strong>
       <PropertyLabelInfo propertyTemplate={ props.propertyTemplate } />
       <button type="button"
               className="btn btn-sm btn-remove pull-right"
@@ -97,6 +98,7 @@ NestedPropertyHeader.propTypes = {
   hideProperty: PropTypes.func,
   id: PropTypes.string,
   resourceKey: PropTypes.string,
+  propertyLabelId: PropTypes.string,
 }
 
 const mapStateToProps = (state, ownProps) => ({

--- a/src/components/editor/property/PanelProperty.jsx
+++ b/src/components/editor/property/PanelProperty.jsx
@@ -14,6 +14,7 @@ import { expandProperty, contractProperty } from 'actionCreators/resources'
 import { selectNormProperty, selectCurrentResourceKey, selectCurrentResourceIsReadOnly } from 'selectors/resources'
 import { selectPropertyTemplate } from 'selectors/templates'
 import useNavigableComponent from 'hooks/useNavigableComponent'
+import shortid from 'shortid'
 
 const PanelProperty = (props) => {
   // Null values indicates that can be added.
@@ -31,6 +32,9 @@ const PanelProperty = (props) => {
   }
 
 
+  // used to associate the PropertyComponent field to be labeled with the PropertyLabel
+  const propertyLabelId = `labelled-by-${shortid.generate()}`
+
   // onClick is to support left navigation, so ignoring jsx-ally seems reasonable.
   /* eslint-disable jsx-a11y/click-events-have-key-events */
   /* eslint-disable jsx-a11y/no-static-element-interactions */
@@ -39,7 +43,7 @@ const PanelProperty = (props) => {
       <div className={cardClassName.join(' ')} data-testid={cardClassName[1]} data-label={ props.propertyTemplate.label } style={{ marginBottom: '1em' }}>
         <div className="card-header prop-heading">
           <h5 className="card-title">
-            <PropertyLabel propertyTemplate={ props.propertyTemplate } />
+            <PropertyLabel forId={propertyLabelId} propertyTemplate={ props.propertyTemplate } />
             <PropertyLabelInfo propertyTemplate={ props.propertyTemplate } />{nbsp}
             { isAdd && !readOnly && (
               <button
@@ -57,7 +61,8 @@ const PanelProperty = (props) => {
                       className="btn btn-sm btn-remove pull-right"
                       aria-label={`Remove ${props.propertyTemplate.label}`}
                       data-testid={`Remove ${props.propertyTemplate.label}`}
-                      onClick={() => props.contractProperty(props.property.key)} data-id={props.id}>
+                      onClick={() => props.contractProperty(props.property.key)}
+                      data-id={props.id}>
                 <FontAwesomeIcon className="fa-inverse trash-icon" icon={trashIcon} />
               </button>
             )}
@@ -65,7 +70,7 @@ const PanelProperty = (props) => {
         </div>
         { !isAdd && (
           <div className="card-body panel-property">
-            <PropertyComponent property={ props.property } propertyTemplate={ props.propertyTemplate } />
+            <PropertyComponent propertyLabelId={propertyLabelId} property={ props.property } propertyTemplate={ props.propertyTemplate } />
           </div>
         )}
       </div>

--- a/src/components/editor/property/PropertyComponent.jsx
+++ b/src/components/editor/property/PropertyComponent.jsx
@@ -19,7 +19,7 @@ const PropertyComponent = (props) => {
       ))
     case 'InputLiteral':
       return (
-        <InputLiteral property={props.property} propertyTemplate={props.propertyTemplate} />
+        <InputLiteral propertyLabelId={props.propertyLabelId} property={props.property} propertyTemplate={props.propertyTemplate} />
       )
     case 'InputURI':
       return (
@@ -31,7 +31,7 @@ const PropertyComponent = (props) => {
       )
     case 'InputList':
       return (
-        <InputList property={props.property} propertyTemplate={props.propertyTemplate} />
+        <InputList propertyLabelId={props.propertyLabelId} property={props.property} propertyTemplate={props.propertyTemplate} />
       )
     default:
       return (
@@ -43,6 +43,7 @@ const PropertyComponent = (props) => {
 PropertyComponent.propTypes = {
   property: PropTypes.object.isRequired,
   propertyTemplate: PropTypes.object.isRequired,
+  propertyLabelId: PropTypes.string.isRequired,
 }
 
 export default PropertyComponent

--- a/src/components/editor/property/PropertyLabel.jsx
+++ b/src/components/editor/property/PropertyLabel.jsx
@@ -6,7 +6,7 @@ import RequiredSuperscript from './RequiredSuperscript'
 
 const PropertyLabel = (props) => {
   const title = [(
-    <span key={props.propertyTemplate.key}>{props.propertyTemplate.label}</span>
+    <label htmlFor={props.forId} key={props.propertyTemplate.key}>{props.propertyTemplate.label}</label>
   )]
 
   if (props.propertyTemplate.required) {


### PR DESCRIPTION
## Why was this change made?

to make usage of the `PropertyLabel` component more accessible, per #2494

_note_, per #2683, this does not always make the `<label>` association work, despite the right pieces seeming to be in place.

## How was this change tested?

manual testing in browser, unit tests

## Which documentation and/or configurations were updated?

n/a