### PR TITLE
Adds result counts for lookup tabs.

### DIFF
--- a/src/components/editor/property/LookupTab.jsx
+++ b/src/components/editor/property/LookupTab.jsx
@@ -1,82 +1,23 @@
 // Copyright 2020 Stanford University see LICENSE for license
 
-import React, {
-  useState, useRef, useEffect,
-} from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
 import RenderLookupContext from './RenderLookupContext'
 import _ from 'lodash'
-import { getLookupResult } from 'utilities/Lookup'
 import SearchResultsPaging from '../../search/SearchResultsPaging'
 import Config from 'Config'
 
 const LookupTab = (props) => {
-  const [result, setResult] = useState(null)
-  const [startOfRange, setStartOfRange] = useState(0)
-
-  // Tokens allow us to cancel an existing search. Does not actually stop the
-  // search, but causes result to be ignored.
-  const tokens = useRef([])
-
   const query = props.query
   const authorityConfig = props.authorityConfig
-  useEffect(() => {
-    if (_.isEmpty(query)) return
-    // Clear the results.
-    // No re-render, so change not visible to user.
-    setResult(null)
-    setStartOfRange(0)
-
-    // Cancel all current searches
-    while (tokens.current.length > 0) {
-      tokens.current.pop().cancel = true
-    }
-
-    // Create a token for this search
-    const token = { cancel: false }
-    tokens.current.push(token)
-
-    getLookupResult(query, authorityConfig, 0)
-      .then((result) => {
-        // Only use these results if not cancelled.
-        if (!token.cancel) {
-          setResult(result)
-        }
-      })
-  }, [query, authorityConfig])
 
   const handleChangePage = (newStartOfRange) => {
-    setStartOfRange(newStartOfRange)
-    performLookup(query, authorityConfig, newStartOfRange)
-  }
-
-  const performLookup = (query, authorityConfig, lookupStartOfRange) => {
-    if (_.isEmpty(query)) return
-    // Clear the results.
-    // No re-render, so change not visible to user.
-    setResult(null)
-
-    // Cancel all current searches
-    while (tokens.current.length > 0) {
-      tokens.current.pop().cancel = true
-    }
-
-    // Create a token for this search
-    const token = { cancel: false }
-    tokens.current.push(token)
-
-    getLookupResult(query, authorityConfig, lookupStartOfRange)
-      .then((result) => {
-        // Only use these results if not cancelled.
-        if (!token.cancel) {
-          setResult(result)
-        }
-      })
+    props.handleChangePage(newStartOfRange, props.authorityConfig)
   }
 
   if (_.isEmpty(query)) return null
 
-  if (!result) {
+  if (!props.result) {
     return (
       <div className="spinner-border" role="status">
         <span className="sr-only">Results Loading...</span>
@@ -84,15 +25,15 @@ const LookupTab = (props) => {
     )
   }
 
-  if (!result.totalHits) {
-    return (<span>No results</span>)
+  if (!props.result.totalHits) {
+    return (<strong>No results</strong>)
   }
 
-  if (result.error) {
-    return (<span className="dropdown-error">{result.error}</span>)
+  if (props.result.error) {
+    return (<span className="dropdown-error">{props.result.error}</span>)
   }
 
-  const tabResults = result.results.map((hit) => (<div key={hit.uri}>
+  const tabResults = props.result.results.map((hit) => (<div key={hit.uri}>
     <button onClick={() => props.handleSelectionChanged(hit)} className="btn search-result">
       { hit.context ? (
         <RenderLookupContext innerResult={hit}
@@ -109,8 +50,8 @@ const LookupTab = (props) => {
       <SearchResultsPaging
         key="search-paging"
         resultsPerPage={Config.maxRecordsForQALookups}
-        startOfRange={startOfRange}
-        totalResults={result.totalHits}
+        startOfRange={props.result.options.startOfRange}
+        totalResults={props.result.totalHits}
         changePage={handleChangePage} />
     </React.Fragment>
   )
@@ -120,6 +61,8 @@ LookupTab.propTypes = {
   authorityConfig: PropTypes.object.isRequired,
   query: PropTypes.string,
   handleSelectionChanged: PropTypes.func.isRequired,
+  handleChangePage: PropTypes.func.isRequired,
+  result: PropTypes.object,
 }
 
 export default LookupTab

--- a/src/components/editor/property/LookupTabs.jsx
+++ b/src/components/editor/property/LookupTabs.jsx
@@ -1,22 +1,67 @@
 // Copyright 2020 Stanford University see LICENSE for license
 
-import React, { useState } from 'react'
+import React, { useState, useRef, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import Tab from '../Tab'
 import Tabs from '../Tabs'
 import LookupTab from './LookupTab'
+import _ from 'lodash'
+import { getLookupResult } from 'utilities/Lookup'
+
 
 const LookupTabs = (props) => {
   const [tabKey, setTabKey] = useState()
+  const [, setTriggerRender] = useState('')
+  // Using a ref so that can append to current list of results.
+  const results = useRef({})
 
-  const tabs = props.authorityConfigs.map((authorityConfig) => (
-    <Tab key={authorityConfig.uri} eventKey={authorityConfig.uri} title={authorityConfig.label}>
-      <LookupTab
-          authorityConfig={authorityConfig}
-          query={props.query}
-          handleSelectionChanged={ props.handleSelectionChanged } />
-    </Tab>
-  ))
+  useEffect(() => {
+    if (_.isEmpty(props.query)) return
+
+    // Clear the results.
+    // No re-render, so change not visible to user.
+    props.authorityConfigs.forEach((authorityConfig) => delete results.current[authorityConfig.uri])
+
+    props.authorityConfigs.forEach((authorityConfig) => {
+      getLookupResult(props.query, authorityConfig, 0)
+        .then((result) => {
+          result.options = { startOfRange: 0 }
+          results.current[authorityConfig.uri] = result
+          // Changing state triggers re-render.
+          setTriggerRender(result)
+        })
+    })
+  }, [props.query, props.authorityConfigs])
+
+  const handleChangePage = (newStartOfRange, authorityConfig) => {
+    // Clear the results.
+    // No re-render, so change not visible to user.
+    delete results.current[authorityConfig.uri]
+
+    getLookupResult(props.query, authorityConfig, newStartOfRange)
+      .then((result) => {
+        result.options = { startOfRange: newStartOfRange }
+        results.current[authorityConfig.uri] = result
+        // Changing state triggers re-render.
+        setTriggerRender(result)
+      })
+  }
+
+  const tabs = props.authorityConfigs.map((authorityConfig) => {
+    const totalHits = results.current[authorityConfig.uri]?.totalHits
+    const title = totalHits !== undefined ? `${authorityConfig.label} (${totalHits})` : authorityConfig.label
+    return (
+      <Tab key={authorityConfig.uri} eventKey={authorityConfig.uri} title={title}>
+        <LookupTab
+            authorityConfig={authorityConfig}
+            query={props.query}
+            handleSelectionChanged={ props.handleSelectionChanged }
+            handleChangePage={handleChangePage}
+            result={results.current[authorityConfig.uri]} />
+      </Tab>
+    )
+  })
+
   return (
     <Tabs
       id="controlled-tab-example"


### PR DESCRIPTION
closes #2653

## Why was this change made?
So that the user knows which tabs have results.


## How was this change tested?
I will be adding tests for InputLookup in a separate PR.


## Which documentation and/or configurations were updated?
NA


