### PR TITLE
Render Discog context for all discog authorities.

### DIFF
--- a/__tests__/__template_fixtures__/DiscogsLookup.json
+++ b/__tests__/__template_fixtures__/DiscogsLookup.json
@@ -40,9 +40,15 @@
     "@type": [
       "http://sinopia.io/vocabulary/LookupPropertyTemplate"
     ],
-    "http://sinopia.io/vocabulary/hasAuthority": [
+     "http://sinopia.io/vocabulary/hasAuthority": [
       {
         "@id": "urn:discogs"
+      },
+      {
+        "@id": "urn:discogs:release"
+      },
+      {
+        "@id": "urn:discogs:master"
       }
     ]
   },

--- a/src/components/editor/property/RenderLookupContext.jsx
+++ b/src/components/editor/property/RenderLookupContext.jsx
@@ -8,12 +8,9 @@ import { getContextValues, getContextValue } from 'utilities/QuestioningAuthorit
 class RenderLookupContext extends Component {
   // Discogs specific functions
   renderContext = (innerResult, authURI) => {
-    switch (authURI) {
-      case 'urn:discogs':
-        return this.buildDiscogsContext(innerResult)
-      default:
-        return this.renderContextContent(innerResult, authURI)
-    }
+    if (authURI.startsWith('urn:discogs')) return this.buildDiscogsContext(innerResult)
+
+    return this.renderContextContent(innerResult, authURI)
   }
 
   buildDiscogsContext = (innerResult) => {


### PR DESCRIPTION
closes #2662

## Why was this change made?
Not all Discogs authorities render correctly.


## How was this change tested?
Locally.


## Which documentation and/or configurations were updated?
NA


