### PR TITLE
Makes lookup search input and values look better

### DIFF
--- a/src/components/editor/property/InputLookup.jsx
+++ b/src/components/editor/property/InputLookup.jsx
@@ -94,7 +94,6 @@ const InputLookup = (props) => {
       <div className="form-inline" style={{ marginBottom: '5px' }}>
         <div className="input-group" onBlur={handleBlurDiacritics} id={id}>
           <input id={inputId} type="text" className={controlClasses.join(' ')}
-                 style={{ width: '750px' }}
                  onChange={handleChangeDiacritics}
                  onKeyDown={handleKeyDown}
                  placeholder="Enter lookup query"
@@ -109,17 +108,17 @@ const InputLookup = (props) => {
                     data-testid={`Select diacritics for ${props.propertyTemplate.label}`}
                     onClick={toggleDiacritics}>&auml;</button>
           </div>
+          <button className="btn btn-primary"
+                  type="submit"
+                  title="Submit lookup"
+                  onClick={handleSubmit}
+                  disabled={isDisabled}
+                  style={{ marginLeft: '5px' }}
+                  aria-label={`Submit lookup for ${props.propertyTemplate.label}`}
+                  data-testid={`Submit lookup for ${props.propertyTemplate.label}`}>
+            Lookup
+          </button>
         </div>
-        <button className="btn btn-primary"
-                type="submit"
-                title="Submit lookup"
-                onClick={handleSubmit}
-                disabled={isDisabled}
-                style={{ marginLeft: '5px' }}
-                aria-label={`Submit lookup for ${props.propertyTemplate.label}`}
-                data-testid={`Submit lookup for ${props.propertyTemplate.label}`}>
-          Lookup
-        </button>
       </div>
       {error && <span className="invalid-feedback">{error}</span>}
       <div className="row">

--- a/src/components/search/Search.jsx
+++ b/src/components/search/Search.jsx
@@ -137,7 +137,7 @@ const Search = (props) => {
               width: '750px', marginTop: '10px', paddingLeft: '5px', paddingBottom: '10px',
             }}>
               <label className="sr-only" htmlFor="searchInput">Query</label>
-              <div className="input-group" style={{ width: '100%' }}>
+              <div className="input-group">
                 <input id="searchInput" type="text" className="form-control"
                        onChange={ (event) => setQueryString(event.target.value) }
                        onKeyPress={handleKeyPress}

--- a/src/components/templates/NewResourceTemplateButton.jsx
+++ b/src/components/templates/NewResourceTemplateButton.jsx
@@ -38,7 +38,7 @@ const NewResourceTemplateButton = (props) => {
   return (
     <Link to={{ pathname: '/editor', state: { } }}
           onClick={(e) => handleClick(e)}>
-      <button className="btn btn-primary">
+      <button className="btn btn-primary" style={{ marginTop: '10px' }}>
         New template
       </button>
     </Link>

--- a/src/components/templates/TemplateSearch.jsx
+++ b/src/components/templates/TemplateSearch.jsx
@@ -65,14 +65,15 @@ const TemplateSearch = (props) => {
       <div id="search">
         <Alert text={error} />
         <div className="row">
-          <div className="col">
+          <div className="col-md-10">
             <form className="form-inline" onSubmit={(event) => event.preventDefault()}>
-              <div className="form-group" style={{ paddingBottom: '10px', paddingTop: '10px' }}>
-                <label className="font-weight-bold" htmlFor="searchInput">Find a resource template</label>&nbsp;
-                <div className="input-group" style={{ width: '750px', paddingLeft: '5px' }}>
+              <div className="form-group" style={{ paddingBottom: '10px', paddingTop: '10px', width: '100%' }}>
+                <div className="input-group">
+                  <label className="font-weight-bold" htmlFor="searchInput">Find a resource template</label>&nbsp;
                   <input id="searchInput"
                          type="text"
                          className="form-control"
+                         style ={{ marginLeft: '5px' }}
                          onChange={ updateSearch }
                          placeholder="Enter id, label, URI, remark, or author"
                          value={ queryString } />
@@ -90,7 +91,7 @@ const TemplateSearch = (props) => {
               </div>
             </form>
           </div>
-          <div className="col-sm-2">
+          <div className="col-md-2">
             <NewResourceTemplateButton history={props.history} />
           </div>
         </div>

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -274,7 +274,7 @@ button.btn-add-instance {
   display: flex;
   justify-content: center;
   align-items: center;
-  margin-right: 10px;
+  margin: 1px 0px 10px 15px;
 
   span {
     padding: 5px 12px 5px 12px;
@@ -295,8 +295,12 @@ button.btn-add-instance {
   }
 }
 
-.input-group-btn {
-  margin-left: 5px;
+.input-group {
+  width: 100% !important;
+
+   .input-group-btn {
+     margin-left: 5px;
+   }
 }
 
 .hidden {


### PR DESCRIPTION
## Why was this change made?
- Fixes display of lookup values for a non-nested resource lookup, and to be adaptive to browser width.
- Fixes display of resource template search to be adaptive to browser width.

## How was this change tested?
N/A only CSS changes were made

Before:
![Screen Shot 2020-10-09 at 2 28 03 PM](https://user-images.githubusercontent.com/3093850/95633061-bd49a300-0a3b-11eb-9807-f9a4930dc9a4.png)

After:
![Screen Shot 2020-10-09 at 2 28 14 PM](https://user-images.githubusercontent.com/3093850/95633071-c3d81a80-0a3b-11eb-9f23-cdd3327a3c13.png)

Before:
![Screen Shot 2020-10-09 at 1 58 18 PM](https://user-images.githubusercontent.com/3093850/95630926-8f625f80-0a37-11eb-8c46-35650771c603.png)
After:
![Screen Shot 2020-10-09 at 1 58 07 PM](https://user-images.githubusercontent.com/3093850/95630933-94271380-0a37-11eb-81b9-b03bbba02a92.png)

