### PR TITLE
Add docker login to avoid anonymous image pulls.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,6 +56,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker
+      - run: echo $DOCKER_PASS | docker login -u $DOCKER_USER --password-stdin
       - run: docker build -t ld4l/sinopia_editor --build-arg USE_FIXTURES=false --build-arg INDEX_URL=http://elasticsearch:9200 --build-arg SINOPIA_API_BASE_URL=http://api:3000 .
       - run: docker build -f Dockerfile.cypress -t ld4l/sinopia_editor_cypress .
       - run:
@@ -102,9 +103,9 @@ jobs:
       - run:
           name: Build & Register Images
           command: |
+            echo $DOCKER_PASS | docker login -u $DOCKER_USER --password-stdin
             docker build -t ld4p/sinopia_editor:latest .
             docker build -t ld4p/sinopia_editor:dev --build-arg SINOPIA_API_BASE_URL=$SINOPIA_API_BASE_URL_DEV --build-arg SINOPIA_ENV=DEV --build-arg SINOPIA_URI=$SINOPIA_URI_DEV --build-arg AWS_COGNITO_DOMAIN=$AWS_COGNITO_DOMAIN_DEV --build-arg COGNITO_CLIENT_ID=$COGNITO_CLIENT_ID_DEV --build-arg COGNITO_USER_POOL_ID=$COGNITO_USER_POOL_ID_DEV --build-arg INDEX_URL=$INDEX_URL_DEV --build-arg SEARCH_HOST=$INDEX_URL_DEV --build-arg EXPORT_BUCKET_URL=$EXPORT_BUCKET_URL_DEV --build-arg HONEYBADGER_API_KEY=$HONEYBADGER_API_KEY --build-arg HONEYBADGER_REVISION=$CIRCLE_SHA1 .
-            echo $DOCKER_PASS | docker login -u $DOCKER_USER --password-stdin
             docker push ld4p/sinopia_editor:latest
             docker push ld4p/sinopia_editor:dev
   register_tag_image:
@@ -119,9 +120,9 @@ jobs:
       - run:
           name: Build & Register Images
           command: |
+            echo $DOCKER_PASS | docker login -u $DOCKER_USER --password-stdin
             docker build -t ld4p/sinopia_editor:$CIRCLE_TAG-stage --build-arg SINOPIA_API_BASE_URL=$SINOPIA_API_BASE_URL_STAGE --build-arg SINOPIA_ENV=STAGE --build-arg SINOPIA_URI=$SINOPIA_URI_STAGE --build-arg AWS_COGNITO_DOMAIN=$AWS_COGNITO_DOMAIN_STAGE --build-arg COGNITO_CLIENT_ID=$COGNITO_CLIENT_ID_STAGE --build-arg COGNITO_USER_POOL_ID=$COGNITO_USER_POOL_ID_STAGE --build-arg INDEX_URL=$INDEX_URL_STAGE --build-arg SEARCH_HOST=$INDEX_URL_STAGE --build-arg EXPORT_BUCKET_URL=$EXPORT_BUCKET_URL_STAGE --build-arg HONEYBADGER_API_KEY=$HONEYBADGER_API_KEY --build-arg HONEYBADGER_REVISION=$CIRCLE_SHA1 .
             docker build -t ld4p/sinopia_editor:$CIRCLE_TAG-prod --build-arg SINOPIA_API_BASE_URL=$SINOPIA_API_BASE_URL_PROD --build-arg SINOPIA_URI=$SINOPIA_URI_PROD --build-arg AWS_COGNITO_DOMAIN=$AWS_COGNITO_DOMAIN_PROD --build-arg COGNITO_CLIENT_ID=$COGNITO_CLIENT_ID_PROD --build-arg COGNITO_USER_POOL_ID=$COGNITO_USER_POOL_ID_PROD --build-arg INDEX_URL=$INDEX_URL_PROD --build-arg SEARCH_HOST=$INDEX_URL_PROD --build-arg EXPORT_BUCKET_URL=$EXPORT_BUCKET_URL_PROD --build-arg HONEYBADGER_API_KEY=$HONEYBADGER_API_KEY --build-arg HONEYBADGER_REVISION=$CIRCLE_SHA1 .
-            echo $DOCKER_PASS | docker login -u $DOCKER_USER --password-stdin
             docker push ld4p/sinopia_editor:$CIRCLE_TAG-stage
             docker push ld4p/sinopia_editor:$CIRCLE_TAG-prod
 


### PR DESCRIPTION
## Why was this change made?
```

On November 1st, Docker Hub will begin limiting anonymous image pulls. We want to make sure you know how you might be impacted and what you can do to avoid interruptions to your workflow.

Adding Docker authentication to your pipeline config is the easiest way to avoid any service disruptions. If you use the Docker executor or pull Docker images when using the machine executor on CircleCI, we encourage you to authenticate. Because the anonymous API rate limits are based on IP addresses, they will impact CircleCI cloud customers. Authenticated users get higher per-user rate limits, regardless of IP.

We are currently working on a partnership with Docker to minimize the impact of this change for our users and will share more details as we get them.

For more information or to leave a question for us, please head over to Discuss or contact support.

Thanks and happy building,

- The CircleCI team 
```


## How was this change tested?
NA


## Which documentation and/or configurations were updated?
NA


