### PR TITLE
Removed list wrapper for config object, causing search to fail

### DIFF
--- a/src/actionCreators/search.js
+++ b/src/actionCreators/search.js
@@ -16,7 +16,7 @@ export const fetchSinopiaSearchResults = (query, options) => (dispatch) => getSe
 
 export const fetchQASearchResults = (query, uri, options = {}) => (dispatch) => {
   const authorityConfig = findAuthorityConfig(uri)
-  const searchPromise = createLookupPromise(query, [authorityConfig], options)
+  const searchPromise = createLookupPromise(query, authorityConfig, options)
 
   return searchPromise.then((response) => {
     if (response.isError) {


### PR DESCRIPTION
## Why was this change made?
Fixes error in all environments that was causing search in the search tab to fail. 

## How was this change tested?
Test suite.


## Which documentation and/or configurations were updated?
n/a


