### PR TITLE
npmignore updates

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
+__mocks__
 __tests__
-!__tests__/fixtureLoaderHelper.js
 cypress
+*.env*


### PR DESCRIPTION
## Why was this change made?
Local `.env` variables were being copied into a publicly available package when published to the npm registry.


## How was this change tested?
Testing suite


## Which documentation and/or configurations were updated?
Yes


