### PR TITLE
Version bump to 3.5.10

### DIFF
--- a/__tests__/feature/readNews.test.js
+++ b/__tests__/feature/readNews.test.js
@@ -7,7 +7,7 @@ describe('reading the latest Sinopia news items', () => {
   it('displays a div containing the latest news, version of Sinopia, link to github site, and a static text list', async () => {
     const { container } = renderApp()
     await screen.findByText('Latest news')
-    await screen.findByText(/Sinopia Version \d\.\d\.\d highlights/)
+    await screen.findByText(/Sinopia Version \d+\.\d+\.\d+ highlights/)
     screen.getByText('Sinopia help site', { selector: 'a' })
     expect(container.querySelectorAll('li').length).not.toBeLessThan(1)
   })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sinopia_editor",
-  "version": "3.5.8",
+  "version": "3.5.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "editor",
     "rdf"
   ],
-  "version": "3.5.9",
+  "version": "3.5.10",
   "homepage": "http://github.com/LD4P/sinopia_editor/",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Why was this change made?
Version bump to sync with `sinopa_editor` npm package. Fixed test failure that used restrictive regex.


## How was this change tested?
Testing suite


## Which documentation and/or configurations were updated?
n/a


