### PR TITLE
bump version to 3.5.15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sinopia_editor",
-  "version": "3.5.13",
+  "version": "3.5.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "editor",
     "rdf"
   ],
-  "version": "3.5.13",
+  "version": "3.5.15",
   "homepage": "http://github.com/LD4P/sinopia_editor/",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Why was this change made?

to deploy weekly dependency updates (https://github.com/LD4P/sinopia_editor/issues/2767)

(jump from 3.5.13 is because 3.5.14 was tagged, but it seems package.json and package-lock.json weren't updated)


## How was this change tested?

n/a, version bump only

## Which documentation and/or configurations were updated?

`package.json` (and `package-lock.json`)

