### PR TITLE
Fix entering value onBlur. 

### DIFF
--- a/src/components/editor/property/InputLiteral.jsx
+++ b/src/components/editor/property/InputLiteral.jsx
@@ -18,14 +18,14 @@ import useDiacritics from 'hooks/useDiacritics'
 const InputLiteral = (props) => {
   const inputLiteralRef = useRef(null)
   const [lang, setLang] = useState(defaultLanguageId)
+  const id = `inputliteral-${props.property.key}`
+  const diacriticsId = `diacritics-${props.property.key}`
   const {
     clearContent, handleKeyDownDiacritics, handleChangeDiacritics,
     handleBlurDiacritics, toggleDiacritics, closeDiacritics,
     handleAddCharacter, handleClickDiacritics,
     currentContent, setCurrentContent, showDiacritics,
   } = useDiacritics(inputLiteralRef, id, diacriticsId)
-  const id = `inputliteral-${props.property.key}`
-  const diacriticsId = `diacritics-${props.property.key}`
   const readOnly = useSelector((state) => selectCurrentResourceIsReadOnly(state))
 
   const disabled = readOnly || (!props.propertyTemplate.repeatable

--- a/src/components/editor/property/InputLookup.jsx
+++ b/src/components/editor/property/InputLookup.jsx
@@ -18,14 +18,14 @@ import DiacriticsSelection from 'components/editor/diacritics/DiacriticsSelectio
 
 const InputLookup = (props) => {
   const inputLookupRef = useRef(null)
+  const id = `inputlookup-${props.property.key}`
+  const diacriticsId = `diacritics-${props.property.key}`
   const {
     clearContent, handleKeyDownDiacritics, handleChangeDiacritics,
     handleBlurDiacritics, toggleDiacritics, closeDiacritics,
     handleAddCharacter, handleClickDiacritics,
     currentContent, showDiacritics,
   } = useDiacritics(inputLookupRef, id, diacriticsId)
-  const id = `inputlookup-${props.property.key}`
-  const diacriticsId = `diacritics-${props.property.key}`
 
   const displayValidations = useSelector((state) => displayResourceValidations(state, props.property.rootSubjectKey))
   const errors = props.property.errors

--- a/src/hooks/useDiacritics.js
+++ b/src/hooks/useDiacritics.js
@@ -28,6 +28,8 @@ const useDiacritics = (inputRef, inputId, diacriticsId) => {
     if (focusIn(event, inputId)) return false
 
     setShowDiacritics(false)
+
+    return true
   }
 
   const toggleDiacritics = (event) => {


### PR DESCRIPTION
closes #2361

## Why was this change made?
Fix a regression introduced when moving diacritics into a hook.


## How was this change tested?
Locally, dev environment by PO


## Which documentation and/or configurations were updated?
NA


