### PR TITLE
Adds support for suppressing blank node when a nested resource.

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ The following are only in the resource subject (that is, the base subject).
   author: <author>,
   remark: <remark>,
   date: <date>,
+  suppressible: <true | false>,
   propertyKeys: [key of property templates, ...]
 }
 ```

--- a/__tests__/GraphBuilder.test.js
+++ b/__tests__/GraphBuilder.test.js
@@ -345,5 +345,337 @@ _:c14n3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ont
 <> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Uber1> .`
       expect(new GraphBuilder(resource).graph.toCanonical()).toMatch(rdf)
     })
+
+    it('builds a graph for suppressible nested resource with uri', () => {
+      const resource = {
+        subjectTemplate: {
+          id: 'resourceTemplate:testing:uber1',
+          class: 'http://id.loc.gov/ontologies/bibframe/Uber1',
+        },
+        properties: [
+          {
+            propertyTemplate: {
+              uri: 'http://id.loc.gov/ontologies/bibframe/uber/template1/property1',
+            },
+            values: [
+              {
+                uri: null,
+                property: {
+                  propertyTemplate: {
+                    type: 'resource',
+                  },
+                },
+                valueSubject: {
+                  subjectTemplate: {
+                    class: 'http://id.loc.gov/ontologies/bibframe/Uber2',
+                    suppressible: true,
+                  },
+                  properties: [
+                    {
+                      propertyTemplate: {
+                        uri: 'http://id.loc.gov/ontologies/bibframe/uber/template2/property1',
+                      },
+                      values: [
+                        {
+                          uri: 'http://sinopia.io/uri1',
+                          label: 'URI1',
+                          literal: null,
+                          lang: null,
+                          property: {
+                            propertyTemplate: {
+                              type: 'uri',
+                            },
+                          },
+                        },
+                      ],
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        ],
+      }
+      const rdf = `<> <http://id.loc.gov/ontologies/bibframe/uber/template1/property1> <http://sinopia.io/uri1> .
+<> <http://sinopia.io/vocabulary/hasResourceTemplate> "resourceTemplate:testing:uber1" .
+<> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Uber1> .
+<http://sinopia.io/uri1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Uber2> .
+<http://sinopia.io/uri1> <http://www.w3.org/2000/01/rdf-schema#label> "URI1" .`
+      expect(new GraphBuilder(resource).graph.toCanonical()).toMatch(rdf)
+    })
+
+    it('builds a graph for suppressible nested resource with multiple uris', () => {
+      const resource = {
+        subjectTemplate: {
+          id: 'resourceTemplate:testing:uber1',
+          class: 'http://id.loc.gov/ontologies/bibframe/Uber1',
+        },
+        properties: [
+          {
+            propertyTemplate: {
+              uri: 'http://id.loc.gov/ontologies/bibframe/uber/template1/property1',
+            },
+            values: [
+              {
+                uri: null,
+                property: {
+                  propertyTemplate: {
+                    type: 'resource',
+                  },
+                },
+                valueSubject: {
+                  subjectTemplate: {
+                    class: 'http://id.loc.gov/ontologies/bibframe/Uber2',
+                    suppressible: true,
+                  },
+                  properties: [
+                    {
+                      propertyTemplate: {
+                        uri: 'http://id.loc.gov/ontologies/bibframe/uber/template2/property1',
+                      },
+                      values: [
+                        {
+                          uri: 'http://sinopia.io/uri1',
+                          label: 'URI1',
+                          literal: null,
+                          lang: null,
+                          property: {
+                            propertyTemplate: {
+                              type: 'uri',
+                            },
+                          },
+                        },
+                        {
+                          uri: 'http://sinopia.io/uri2',
+                          label: 'URI2',
+                          literal: null,
+                          lang: null,
+                          property: {
+                            propertyTemplate: {
+                              type: 'uri',
+                            },
+                          },
+                        },
+                      ],
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        ],
+      }
+      const rdf = `<> <http://id.loc.gov/ontologies/bibframe/uber/template1/property1> <http://sinopia.io/uri1> .
+<> <http://id.loc.gov/ontologies/bibframe/uber/template1/property1> <http://sinopia.io/uri2> .
+<> <http://sinopia.io/vocabulary/hasResourceTemplate> "resourceTemplate:testing:uber1" .
+<> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Uber1> .
+<http://sinopia.io/uri1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Uber2> .
+<http://sinopia.io/uri1> <http://www.w3.org/2000/01/rdf-schema#label> "URI1" .
+<http://sinopia.io/uri2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Uber2> .
+<http://sinopia.io/uri2> <http://www.w3.org/2000/01/rdf-schema#label> "URI2" .`
+      expect(new GraphBuilder(resource).graph.toCanonical()).toMatch(rdf)
+    })
+
+    it('builds a graph for suppresible nested resource with literal', () => {
+      const resource = {
+        subjectTemplate: {
+          id: 'resourceTemplate:testing:uber1',
+          class: 'http://id.loc.gov/ontologies/bibframe/Uber1',
+        },
+        properties: [
+          {
+            propertyTemplate: {
+              uri: 'http://id.loc.gov/ontologies/bibframe/uber/template1/property1',
+            },
+            values: [
+              {
+                uri: null,
+                property: {
+                  propertyTemplate: {
+                    type: 'resource',
+                  },
+                },
+                valueSubject: {
+                  subjectTemplate: {
+                    class: 'http://id.loc.gov/ontologies/bibframe/Uber2',
+                  },
+                  properties: [
+                    {
+                      propertyTemplate: {
+                        uri: 'http://id.loc.gov/ontologies/bibframe/uber/template2/property1',
+                      },
+                      values: [
+                        {
+                          uri: null,
+                          label: null,
+                          literal: 'literal3',
+                          lang: 'eng',
+                          property: {
+                            propertyTemplate: {
+                              type: 'uri',
+                              suppresible: true,
+                            },
+                          },
+                        },
+                      ],
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        ],
+      }
+      const rdf = `<> <http://id.loc.gov/ontologies/bibframe/uber/template1/property1> _:c14n0 .
+<> <http://sinopia.io/vocabulary/hasResourceTemplate> "resourceTemplate:testing:uber1" .
+<> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Uber1> .
+_:c14n0 <http://id.loc.gov/ontologies/bibframe/uber/template2/property1> "literal3"@eng .
+_:c14n0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Uber2> .`
+      expect(new GraphBuilder(resource).graph.toCanonical()).toMatch(rdf)
+    })
+  })
+
+  it('builds a graph for suppresible nested resource with multiple literal', () => {
+    const resource = {
+      subjectTemplate: {
+        id: 'resourceTemplate:testing:uber1',
+        class: 'http://id.loc.gov/ontologies/bibframe/Uber1',
+      },
+      properties: [
+        {
+          propertyTemplate: {
+            uri: 'http://id.loc.gov/ontologies/bibframe/uber/template1/property1',
+          },
+          values: [
+            {
+              uri: null,
+              property: {
+                propertyTemplate: {
+                  type: 'resource',
+                },
+              },
+              valueSubject: {
+                subjectTemplate: {
+                  class: 'http://id.loc.gov/ontologies/bibframe/Uber2',
+                },
+                properties: [
+                  {
+                    propertyTemplate: {
+                      uri: 'http://id.loc.gov/ontologies/bibframe/uber/template2/property1',
+                    },
+                    values: [
+                      {
+                        uri: null,
+                        label: null,
+                        literal: 'literal3',
+                        lang: 'eng',
+                        property: {
+                          propertyTemplate: {
+                            type: 'uri',
+                            suppresible: true,
+                          },
+                        },
+                      },
+                      {
+                        uri: null,
+                        label: null,
+                        literal: 'literal4',
+                        lang: 'eng',
+                        property: {
+                          propertyTemplate: {
+                            type: 'uri',
+                            suppresible: true,
+                          },
+                        },
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    }
+    const rdf = `<> <http://id.loc.gov/ontologies/bibframe/uber/template1/property1> _:c14n0 .
+<> <http://sinopia.io/vocabulary/hasResourceTemplate> "resourceTemplate:testing:uber1" .
+<> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Uber1> .
+_:c14n0 <http://id.loc.gov/ontologies/bibframe/uber/template2/property1> "literal3"@eng .
+_:c14n0 <http://id.loc.gov/ontologies/bibframe/uber/template2/property1> "literal4"@eng .
+_:c14n0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Uber2> .`
+    expect(new GraphBuilder(resource).graph.toCanonical()).toMatch(rdf)
+  })
+
+  it('builds a graph for suppressible nested resource with uri and literal', () => {
+    const resource = {
+      subjectTemplate: {
+        id: 'resourceTemplate:testing:uber1',
+        class: 'http://id.loc.gov/ontologies/bibframe/Uber1',
+      },
+      properties: [
+        {
+          propertyTemplate: {
+            uri: 'http://id.loc.gov/ontologies/bibframe/uber/template1/property1',
+          },
+          values: [
+            {
+              uri: null,
+              property: {
+                propertyTemplate: {
+                  type: 'resource',
+                },
+              },
+              valueSubject: {
+                subjectTemplate: {
+                  class: 'http://id.loc.gov/ontologies/bibframe/Uber2',
+                  suppressible: true,
+                },
+                properties: [
+                  {
+                    propertyTemplate: {
+                      uri: 'http://id.loc.gov/ontologies/bibframe/uber/template2/property1',
+                    },
+                    values: [
+                      {
+                        uri: 'http://sinopia.io/uri1',
+                        label: 'URI1',
+                        literal: null,
+                        lang: null,
+                        property: {
+                          propertyTemplate: {
+                            type: 'uri',
+                          },
+                        },
+                      },
+                      {
+                        uri: null,
+                        label: null,
+                        literal: 'literal3',
+                        lang: 'eng',
+                        property: {
+                          propertyTemplate: {
+                            type: 'uri',
+                            suppresible: true,
+                          },
+                        },
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    }
+    const rdf = `<> <http://id.loc.gov/ontologies/bibframe/uber/template1/property1> <http://sinopia.io/uri1> .
+<> <http://id.loc.gov/ontologies/bibframe/uber/template1/property1> _:c14n0 .
+<> <http://sinopia.io/vocabulary/hasResourceTemplate> "resourceTemplate:testing:uber1" .
+<> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Uber1> .
+<http://sinopia.io/uri1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Uber2> .
+<http://sinopia.io/uri1> <http://www.w3.org/2000/01/rdf-schema#label> "URI1" .
+_:c14n0 <http://id.loc.gov/ontologies/bibframe/uber/template2/property1> "literal3"@eng .
+_:c14n0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Uber2> .`
+    expect(new GraphBuilder(resource).graph.toCanonical()).toMatch(rdf)
   })
 })

--- a/__tests__/TemplatesBuilder.test.js
+++ b/__tests__/TemplatesBuilder.test.js
@@ -10,7 +10,8 @@ describe('TemplatesBuilder', () => {
 <> <http://sinopia.io/vocabulary/hasResourceId> <resourceTemplate:testing:uber1> .
 <> <http://sinopia.io/vocabulary/hasResourceTemplate> "sinopia:template:resource" .
 <> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://sinopia.io/vocabulary/ResourceTemplate> .
-<> <http://www.w3.org/2000/01/rdf-schema#label> "Uber template1"@eng .`
+<> <http://www.w3.org/2000/01/rdf-schema#label> "Uber template1"@eng .
+<> <http://sinopia.io/vocabulary/hasResourceAttribute> <http://sinopia.io/vocabulary/resourceAttribute/suppressible> .`
 
     const dataset = await datasetFromN3(rdf)
     const subjectTemplate = new TemplatesBuilder(dataset, '').build()
@@ -25,6 +26,7 @@ describe('TemplatesBuilder', () => {
       date: '2020-07-27',
       propertyTemplateKeys: [],
       propertyTemplates: [],
+      suppressible: true,
     })
   })
 

--- a/__tests__/__action_fixtures__/expandProperty-ADD_VALUE.json
+++ b/__tests__/__action_fixtures__/expandProperty-ADD_VALUE.json
@@ -1,113 +1,114 @@
 {
-      "type": "ADD_VALUE",
-      "payload": {
-        "value": {
-          "key": "abc2",
-          "property": {
-            "key": "v1o90QO1Qx",
-            "subjectKey": "ljAblGiBW",
-            "rootSubjectKey": "ljAblGiBW",
-            "descUriOrLiteralValueKeys": [],
-            "descWithErrorPropertyKeys": [],
-            "rootPropertyKey": "v1o90QO1Qx",
-            "propertyTemplateKey": "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property1",
-            "valueKeys": null,
-            "show": true,
-            "errors": [],
-            "subject": {
-              "key": "ljAblGiBW",
-              "uri": null,
-              "rootSubjectKey": "ljAblGiBW",
-              "descUriOrLiteralValueKeys": [],
-              "descWithErrorPropertyKeys": [],
-              "rootPropertyKey": null,
-              "subjectTemplateKey": "resourceTemplate:testing:uber1",
-              "bfAdminMetadataRefs": [],
-              "bfInstanceRefs": [],
-              "bfItemRefs": [],
-              "bfWorkRefs": [],
-              "group": null,
-              "propertyKeys": [
-                "v1o90QO1Qx"
-              ],
-              "changed": false,
-              "subjectTemplate": {
-                "key": "resourceTemplate:testing:uber1",
-                "id": "resourceTemplate:testing:uber1",
-                "class": "http://id.loc.gov/ontologies/bibframe/Uber1",
-                "label": "Uber template1",
-                "remark": "Template for testing purposes.",
-                "propertyTemplateKeys": [
-                  "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property1"
-                ]
-              },
-              "valueSubjectOfKey": null
-            },
-            "propertyTemplate": {
-              "key": "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property1",
-              "subjectTemplateKey": "resourceTemplate:testing:uber1",
-              "label": "Uber template1, property1",
-              "uri": "http://id.loc.gov/ontologies/bibframe/uber/template1/property1",
-              "required": false,
-              "repeatable": true,
-              "defaults": [],
-              "remark": "Nested, repeatable resource template.",
-              "remarkUrl": null,
-              "type": "resource",
-              "component": "InputURI",
-              "valueSubjectTemplateKeys": [
-                "resourceTemplate:testing:uber2"
-              ],
-              "authorities": []
-            },
-            "values": null
-          },
-          "literal": null,
-          "lang": null,
+  "type": "ADD_VALUE",
+  "payload": {
+    "value": {
+      "key": "abc2",
+      "property": {
+        "key": "v1o90QO1Qx",
+        "subjectKey": "ljAblGiBW",
+        "rootSubjectKey": "ljAblGiBW",
+        "rootPropertyKey": "v1o90QO1Qx",
+        "propertyTemplateKey": "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property1",
+        "valueKeys": null,
+        "show": true,
+        "errors": [],
+        "descUriOrLiteralValueKeys": [],
+        "descWithErrorPropertyKeys": [],
+        "subject": {
+          "key": "ljAblGiBW",
           "uri": null,
-          "label": null,
-          "valueSubject": {
-            "key": "abc0",
-            "uri": null,
-            "subjectTemplate": {
-              "key": "resourceTemplate:testing:uber2",
-              "id": "resourceTemplate:testing:uber2",
-              "author": null,
-              "class": "http://id.loc.gov/ontologies/bibframe/Uber2",
-              "date": null,
-              "label": "Uber template2",
-              "remark": "Template for testing purposes with single repeatable literal.",
-              "uri": "http://localhost:3000/resource/resourceTemplate:testing:uber2",
-              "propertyTemplateKeys": [
-                "resourceTemplate:testing:uber2 > http://id.loc.gov/ontologies/bibframe/uber/template2/property1"
-              ],
-              "propertyTemplates": [
-                {
-                  "key": "resourceTemplate:testing:uber2 > http://id.loc.gov/ontologies/bibframe/uber/template2/property1",
-                  "subjectTemplateKey": "resourceTemplate:testing:uber2",
-                  "label": "Uber template2, property1",
-                  "uri": "http://id.loc.gov/ontologies/bibframe/uber/template2/property1",
-                  "required": false,
-                  "repeatable": true,
-                  "ordered": false,
-                  "defaults": [],
-                  "remark": "A repeatable literal",
-                  "remarkUrl": null,
-                  "type": "literal",
-                  "component": "InputLiteral",
-                  "valueSubjectTemplateKeys": [],
-                  "authorities": []
-                }
-              ]
-            },
-            "properties": [
-              {
-                "key": "abc1",
-                "values": null,
-                "show": false
-              }
+          "rootSubjectKey": "ljAblGiBW",
+          "rootPropertyKey": null,
+          "valueSubjectOfKey": null,
+          "subjectTemplateKey": "resourceTemplate:testing:uber1",
+          "propertyKeys": [
+            "v1o90QO1Qx"
+          ],
+          "changed": false,
+          "bfAdminMetadataRefs": [],
+          "bfInstanceRefs": [],
+          "bfItemRefs": [],
+          "bfWorkRefs": [],
+          "group": null,
+          "descUriOrLiteralValueKeys": [],
+          "descWithErrorPropertyKeys": [],
+          "subjectTemplate": {
+            "key": "resourceTemplate:testing:uber1",
+            "id": "resourceTemplate:testing:uber1",
+            "class": "http://id.loc.gov/ontologies/bibframe/Uber1",
+            "label": "Uber template1",
+            "remark": "Template for testing purposes.",
+            "propertyTemplateKeys": [
+              "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property1"
             ]
           }
-        }
+        },
+        "propertyTemplate": {
+          "key": "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property1",
+          "subjectTemplateKey": "resourceTemplate:testing:uber1",
+          "label": "Uber template1, property1",
+          "uri": "http://id.loc.gov/ontologies/bibframe/uber/template1/property1",
+          "required": false,
+          "repeatable": true,
+          "defaults": [],
+          "remark": "Nested, repeatable resource template.",
+          "remarkUrl": null,
+          "type": "resource",
+          "component": "InputURI",
+          "valueSubjectTemplateKeys": [
+            "resourceTemplate:testing:uber2"
+          ],
+          "authorities": []
+        },
+        "values": null
+      },
+      "literal": null,
+      "lang": null,
+      "uri": null,
+      "label": null,
+      "valueSubject": {
+        "key": "abc0",
+        "uri": null,
+        "subjectTemplate": {
+          "key": "resourceTemplate:testing:uber2",
+          "uri": "http://localhost:3000/resource/resourceTemplate:testing:uber2",
+          "id": "resourceTemplate:testing:uber2",
+          "class": "http://id.loc.gov/ontologies/bibframe/Uber2",
+          "label": "Uber template2",
+          "author": null,
+          "remark": "Template for testing purposes with single repeatable literal.",
+          "date": null,
+          "suppressible": false,
+          "propertyTemplateKeys": [
+            "resourceTemplate:testing:uber2 > http://id.loc.gov/ontologies/bibframe/uber/template2/property1"
+          ],
+          "propertyTemplates": [
+            {
+              "key": "resourceTemplate:testing:uber2 > http://id.loc.gov/ontologies/bibframe/uber/template2/property1",
+              "subjectTemplateKey": "resourceTemplate:testing:uber2",
+              "label": "Uber template2, property1",
+              "uri": "http://id.loc.gov/ontologies/bibframe/uber/template2/property1",
+              "required": false,
+              "repeatable": true,
+              "ordered": false,
+              "remark": "A repeatable literal",
+              "remarkUrl": null,
+              "defaults": [],
+              "valueSubjectTemplateKeys": [],
+              "authorities": [],
+              "type": "literal",
+              "component": "InputLiteral"
+            }
+          ]
+        },
+        "properties": [
+          {
+            "key": "abc1",
+            "values": null,
+            "show": false
+          }
+        ]
       }
     }
+  }
+}

--- a/__tests__/__action_fixtures__/loadResource-ADD_SUBJECT.json
+++ b/__tests__/__action_fixtures__/loadResource-ADD_SUBJECT.json
@@ -12,6 +12,7 @@
       "author": "Justin Littman",
       "remark": "Template for testing purposes.",
       "date": "2020-07-27",
+      "suppressible": false,
       "propertyTemplateKeys": [
         "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property1",
         "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property2",
@@ -37,7 +38,8 @@
         "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/instanceOf",
         "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/hasItem",
         "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/itemOf",
-        "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property20"
+        "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property20",
+        "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property21"
       ],
       "propertyTemplates": [
         {
@@ -374,8 +376,8 @@
             {
               "uri": "urn:ld4p:sinopia:bibframe:instance",
               "label": "Sinopia BIBFRAME instance resources",
-              "type": "http://id.loc.gov/ontologies/bibframe/Instance",
-              "nonldLookup": false
+              "nonldLookup": false,
+              "type": "http://id.loc.gov/ontologies/bibframe/Instance"
             }
           ],
           "type": "uri",
@@ -397,8 +399,8 @@
             {
               "uri": "urn:ld4p:sinopia:bibframe:instance",
               "label": "Sinopia BIBFRAME instance resources",
-              "type": "http://id.loc.gov/ontologies/bibframe/Instance",
-              "nonldLookup": false
+              "nonldLookup": false,
+              "type": "http://id.loc.gov/ontologies/bibframe/Instance"
             }
           ],
           "type": "uri",
@@ -456,8 +458,8 @@
             {
               "uri": "urn:ld4p:sinopia:bibframe:adminMetadata",
               "label": "Sinopia BIBFRAME admin metadata resources",
-              "type": "http://id.loc.gov/ontologies/bibframe/AdminMetadata",
-              "nonldLookup": false
+              "nonldLookup": false,
+              "type": "http://id.loc.gov/ontologies/bibframe/AdminMetadata"
             }
           ],
           "type": "uri",
@@ -479,8 +481,8 @@
             {
               "uri": "urn:ld4p:sinopia:bibframe:instance",
               "label": "Sinopia BIBFRAME instance resources",
-              "type": "http://id.loc.gov/ontologies/bibframe/Instance",
-              "nonldLookup": false
+              "nonldLookup": false,
+              "type": "http://id.loc.gov/ontologies/bibframe/Instance"
             }
           ],
           "type": "uri",
@@ -502,8 +504,8 @@
             {
               "uri": "urn:ld4p:sinopia:bibframe:work",
               "label": "Sinopia BIBFRAME work resources",
-              "type": "http://id.loc.gov/ontologies/bibframe/Work",
-              "nonldLookup": false
+              "nonldLookup": false,
+              "type": "http://id.loc.gov/ontologies/bibframe/Work"
             }
           ],
           "type": "uri",
@@ -525,8 +527,8 @@
             {
               "uri": "urn:ld4p:sinopia:bibframe:item",
               "label": "Sinopia BIBFRAME item resources",
-              "type": "http://id.loc.gov/ontologies/bibframe/Item",
-              "nonldLookup": false
+              "nonldLookup": false,
+              "type": "http://id.loc.gov/ontologies/bibframe/Item"
             }
           ],
           "type": "uri",
@@ -548,8 +550,8 @@
             {
               "uri": "urn:ld4p:sinopia:bibframe:instance",
               "label": "Sinopia BIBFRAME instance resources",
-              "type": "http://id.loc.gov/ontologies/bibframe/Instance",
-              "nonldLookup": false
+              "nonldLookup": false,
+              "type": "http://id.loc.gov/ontologies/bibframe/Instance"
             }
           ],
           "type": "uri",
@@ -579,6 +581,24 @@
           "authorities": [],
           "type": "literal",
           "component": "InputLiteral"
+        },
+        {
+          "key": "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property21",
+          "subjectTemplateKey": "resourceTemplate:testing:uber1",
+          "label": "Uber template1, property21",
+          "uri": "http://id.loc.gov/ontologies/bibframe/uber/template1/property21",
+          "required": false,
+          "repeatable": true,
+          "ordered": false,
+          "remark": "Nested, repeatable, suppressible resource template.",
+          "remarkUrl": null,
+          "defaults": [],
+          "valueSubjectTemplateKeys": [
+            "resourceTemplate:testing:uber5"
+          ],
+          "authorities": [],
+          "type": "resource",
+          "component": "NestedResource"
         }
       ]
     },
@@ -587,13 +607,13 @@
         "key": "abc1",
         "values": [
           {
-            "key": "abc63",
+            "key": "abc64",
             "literal": null,
             "lang": null,
             "uri": null,
             "label": null,
             "valueSubject": {
-              "key": "abc43",
+              "key": "abc44",
               "uri": null,
               "subjectTemplate": {
                 "key": "resourceTemplate:testing:uber2",
@@ -604,6 +624,7 @@
                 "author": null,
                 "remark": "Template for testing purposes with single repeatable literal.",
                 "date": null,
+                "suppressible": false,
                 "propertyTemplateKeys": [
                   "resourceTemplate:testing:uber2 > http://id.loc.gov/ontologies/bibframe/uber/template2/property1"
                 ],
@@ -628,10 +649,10 @@
               },
               "properties": [
                 {
-                  "key": "abc50",
+                  "key": "abc51",
                   "values": [
                     {
-                      "key": "abc57",
+                      "key": "abc58",
                       "literal": "Uber template2, property1",
                       "lang": "eng",
                       "uri": null,
@@ -645,20 +666,20 @@
             }
           },
           {
-            "key": "abc64",
+            "key": "abc65",
             "literal": null,
             "lang": null,
             "uri": null,
             "label": null,
             "valueSubject": {
-              "key": "abc44",
+              "key": "abc45",
               "uri": null,
               "properties": [
                 {
-                  "key": "abc51",
+                  "key": "abc52",
                   "values": [
                     {
-                      "key": "abc58",
+                      "key": "abc59",
                       "literal": "Uber template2, property1b",
                       "lang": "eng",
                       "uri": null,
@@ -672,13 +693,13 @@
             }
           },
           {
-            "key": "abc62",
+            "key": "abc63",
             "literal": null,
             "lang": null,
             "uri": null,
             "label": null,
             "valueSubject": {
-              "key": "abc42",
+              "key": "abc43",
               "uri": null,
               "subjectTemplate": {
                 "key": "resourceTemplate:testing:uber3",
@@ -689,6 +710,7 @@
                 "author": null,
                 "remark": "Template for testing purposes with multiple literal.",
                 "date": null,
+                "suppressible": false,
                 "propertyTemplateKeys": [
                   "resourceTemplate:testing:uber3 > http://id.loc.gov/ontologies/bibframe/uber/template3/property1",
                   "resourceTemplate:testing:uber3 > http://id.loc.gov/ontologies/bibframe/uber/template3/property2"
@@ -730,10 +752,10 @@
               },
               "properties": [
                 {
-                  "key": "abc48",
+                  "key": "abc49",
                   "values": [
                     {
-                      "key": "abc55",
+                      "key": "abc56",
                       "literal": "Uber template3, property1",
                       "lang": "eng",
                       "uri": null,
@@ -744,10 +766,10 @@
                   "show": false
                 },
                 {
-                  "key": "abc49",
+                  "key": "abc50",
                   "values": [
                     {
-                      "key": "abc56",
+                      "key": "abc57",
                       "literal": "Uber template3, property2",
                       "lang": "eng",
                       "uri": null,
@@ -767,7 +789,7 @@
         "key": "abc2",
         "values": [
           {
-            "key": "abc29",
+            "key": "abc30",
             "literal": "Uber template1, property2",
             "lang": "eng",
             "uri": null,
@@ -786,7 +808,7 @@
         "key": "abc4",
         "values": [
           {
-            "key": "abc30",
+            "key": "abc31",
             "literal": "Uber template1, property4",
             "lang": "eng",
             "uri": null,
@@ -800,7 +822,7 @@
         "key": "abc5",
         "values": [
           {
-            "key": "abc31",
+            "key": "abc32",
             "literal": null,
             "lang": null,
             "uri": "ubertemplate1:property5",
@@ -814,7 +836,7 @@
         "key": "abc6",
         "values": [
           {
-            "key": "abc32",
+            "key": "abc33",
             "literal": null,
             "lang": null,
             "uri": "ubertemplate1:property6",
@@ -838,7 +860,7 @@
         "key": "abc9",
         "values": [
           {
-            "key": "abc33",
+            "key": "abc34",
             "literal": "Uber template1, property9",
             "lang": "eng",
             "uri": null,
@@ -852,7 +874,7 @@
         "key": "abc10",
         "values": [
           {
-            "key": "abc34",
+            "key": "abc35",
             "literal": null,
             "lang": null,
             "uri": "http://id.loc.gov/vocabulary/mrectype/analog",
@@ -866,7 +888,7 @@
         "key": "abc11",
         "values": [
           {
-            "key": "abc35",
+            "key": "abc36",
             "literal": null,
             "lang": null,
             "uri": "http://id.loc.gov/vocabulary/mrectype/digital",
@@ -880,7 +902,7 @@
         "key": "abc12",
         "values": [
           {
-            "key": "abc36",
+            "key": "abc37",
             "literal": null,
             "lang": null,
             "uri": "http://id.loc.gov/vocabulary/mrecmedium/mag",
@@ -894,7 +916,7 @@
         "key": "abc13",
         "values": [
           {
-            "key": "abc37",
+            "key": "abc38",
             "literal": null,
             "lang": null,
             "uri": "http://aims.fao.org/aos/agrovoc/c_35856",
@@ -908,7 +930,7 @@
         "key": "abc14",
         "values": [
           {
-            "key": "abc38",
+            "key": "abc39",
             "literal": null,
             "lang": null,
             "uri": "http://aims.fao.org/aos/agrovoc/c_331388",
@@ -922,7 +944,7 @@
         "key": "abc15",
         "values": [
           {
-            "key": "abc39",
+            "key": "abc40",
             "literal": null,
             "lang": null,
             "uri": "http://sws.geonames.org/5098279/",
@@ -936,7 +958,7 @@
         "key": "abc16",
         "values": [
           {
-            "key": "abc40",
+            "key": "abc41",
             "literal": null,
             "lang": null,
             "uri": "http://localhost:3000/resource/c7db5404-7d7d-40ac-b38e-c821d2c3ae3f",
@@ -950,7 +972,7 @@
         "key": "abc17",
         "values": [
           {
-            "key": "abc41",
+            "key": "abc42",
             "literal": null,
             "lang": null,
             "uri": "http://localhost:3000/resource/c7db5404-7d7d-40ac-b38e-c821d2c3ae3f",
@@ -964,13 +986,13 @@
         "key": "abc18",
         "values": [
           {
-            "key": "abc65",
+            "key": "abc66",
             "literal": null,
             "lang": null,
             "uri": null,
             "label": null,
             "valueSubject": {
-              "key": "abc45",
+              "key": "abc46",
               "uri": null,
               "subjectTemplate": {
                 "key": "resourceTemplate:testing:uber4",
@@ -981,6 +1003,7 @@
                 "author": null,
                 "remark": "Template for testing purposes with single repeatable, required literal.",
                 "date": null,
+                "suppressible": false,
                 "propertyTemplateKeys": [
                   "resourceTemplate:testing:uber4 > http://id.loc.gov/ontologies/bibframe/uber/template4/property1"
                 ],
@@ -1005,10 +1028,10 @@
               },
               "properties": [
                 {
-                  "key": "abc52",
+                  "key": "abc53",
                   "values": [
                     {
-                      "key": "abc59",
+                      "key": "abc60",
                       "literal": "Uber template4, property1",
                       "lang": "eng",
                       "uri": null,
@@ -1028,33 +1051,6 @@
         "key": "abc20",
         "values": [
           {
-            "key": "abc66",
-            "literal": null,
-            "lang": null,
-            "uri": null,
-            "label": null,
-            "valueSubject": {
-              "key": "abc46",
-              "uri": null,
-              "properties": [
-                {
-                  "key": "abc53",
-                  "values": [
-                    {
-                      "key": "abc60",
-                      "literal": "Uber template4, property1, first",
-                      "lang": "eng",
-                      "uri": null,
-                      "label": null,
-                      "valueSubject": null
-                    }
-                  ],
-                  "show": true
-                }
-              ]
-            }
-          },
-          {
             "key": "abc67",
             "literal": null,
             "lang": null,
@@ -1069,6 +1065,33 @@
                   "values": [
                     {
                       "key": "abc61",
+                      "literal": "Uber template4, property1, first",
+                      "lang": "eng",
+                      "uri": null,
+                      "label": null,
+                      "valueSubject": null
+                    }
+                  ],
+                  "show": true
+                }
+              ]
+            }
+          },
+          {
+            "key": "abc68",
+            "literal": null,
+            "lang": null,
+            "uri": null,
+            "label": null,
+            "valueSubject": {
+              "key": "abc48",
+              "uri": null,
+              "properties": [
+                {
+                  "key": "abc55",
+                  "values": [
+                    {
+                      "key": "abc62",
                       "literal": "Uber template4, property1, second",
                       "lang": "eng",
                       "uri": null,
@@ -1113,6 +1136,11 @@
         "key": "abc26",
         "values": [],
         "show": true
+      },
+      {
+        "key": "abc27",
+        "values": null,
+        "show": false
       }
     ],
     "group": "stanford"

--- a/__tests__/__action_fixtures__/loadResourceNestedResource-ADD_SUBJECT.json
+++ b/__tests__/__action_fixtures__/loadResourceNestedResource-ADD_SUBJECT.json
@@ -12,6 +12,7 @@
       "author": "Justin Littman",
       "remark": "Template for testing purposes.",
       "date": "2020-07-27",
+      "suppressible": false,
       "propertyTemplateKeys": [
         "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property1",
         "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property2",
@@ -37,7 +38,8 @@
         "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/instanceOf",
         "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/hasItem",
         "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/itemOf",
-        "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property20"
+        "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property20",
+        "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property21"
       ],
       "propertyTemplates": [
         {
@@ -374,8 +376,8 @@
             {
               "uri": "urn:ld4p:sinopia:bibframe:instance",
               "label": "Sinopia BIBFRAME instance resources",
-              "type": "http://id.loc.gov/ontologies/bibframe/Instance",
-              "nonldLookup": false
+              "nonldLookup": false,
+              "type": "http://id.loc.gov/ontologies/bibframe/Instance"
             }
           ],
           "type": "uri",
@@ -397,8 +399,8 @@
             {
               "uri": "urn:ld4p:sinopia:bibframe:instance",
               "label": "Sinopia BIBFRAME instance resources",
-              "type": "http://id.loc.gov/ontologies/bibframe/Instance",
-              "nonldLookup": false
+              "nonldLookup": false,
+              "type": "http://id.loc.gov/ontologies/bibframe/Instance"
             }
           ],
           "type": "uri",
@@ -456,8 +458,8 @@
             {
               "uri": "urn:ld4p:sinopia:bibframe:adminMetadata",
               "label": "Sinopia BIBFRAME admin metadata resources",
-              "type": "http://id.loc.gov/ontologies/bibframe/AdminMetadata",
-              "nonldLookup": false
+              "nonldLookup": false,
+              "type": "http://id.loc.gov/ontologies/bibframe/AdminMetadata"
             }
           ],
           "type": "uri",
@@ -479,8 +481,8 @@
             {
               "uri": "urn:ld4p:sinopia:bibframe:instance",
               "label": "Sinopia BIBFRAME instance resources",
-              "type": "http://id.loc.gov/ontologies/bibframe/Instance",
-              "nonldLookup": false
+              "nonldLookup": false,
+              "type": "http://id.loc.gov/ontologies/bibframe/Instance"
             }
           ],
           "type": "uri",
@@ -502,8 +504,8 @@
             {
               "uri": "urn:ld4p:sinopia:bibframe:work",
               "label": "Sinopia BIBFRAME work resources",
-              "type": "http://id.loc.gov/ontologies/bibframe/Work",
-              "nonldLookup": false
+              "nonldLookup": false,
+              "type": "http://id.loc.gov/ontologies/bibframe/Work"
             }
           ],
           "type": "uri",
@@ -525,8 +527,8 @@
             {
               "uri": "urn:ld4p:sinopia:bibframe:item",
               "label": "Sinopia BIBFRAME item resources",
-              "type": "http://id.loc.gov/ontologies/bibframe/Item",
-              "nonldLookup": false
+              "nonldLookup": false,
+              "type": "http://id.loc.gov/ontologies/bibframe/Item"
             }
           ],
           "type": "uri",
@@ -548,8 +550,8 @@
             {
               "uri": "urn:ld4p:sinopia:bibframe:instance",
               "label": "Sinopia BIBFRAME instance resources",
-              "type": "http://id.loc.gov/ontologies/bibframe/Instance",
-              "nonldLookup": false
+              "nonldLookup": false,
+              "type": "http://id.loc.gov/ontologies/bibframe/Instance"
             }
           ],
           "type": "uri",
@@ -579,6 +581,24 @@
           "authorities": [],
           "type": "literal",
           "component": "InputLiteral"
+        },
+        {
+          "key": "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property21",
+          "subjectTemplateKey": "resourceTemplate:testing:uber1",
+          "label": "Uber template1, property21",
+          "uri": "http://id.loc.gov/ontologies/bibframe/uber/template1/property21",
+          "required": false,
+          "repeatable": true,
+          "ordered": false,
+          "remark": "Nested, repeatable, suppressible resource template.",
+          "remarkUrl": null,
+          "defaults": [],
+          "valueSubjectTemplateKeys": [
+            "resourceTemplate:testing:uber5"
+          ],
+          "authorities": [],
+          "type": "resource",
+          "component": "NestedResource"
         }
       ]
     },
@@ -587,13 +607,13 @@
         "key": "abc1",
         "values": [
           {
-            "key": "abc40",
+            "key": "abc41",
             "literal": null,
             "lang": null,
             "uri": null,
             "label": null,
             "valueSubject": {
-              "key": "abc35",
+              "key": "abc36",
               "uri": null,
               "subjectTemplate": {
                 "key": "resourceTemplate:testing:uber2",
@@ -604,6 +624,7 @@
                 "author": null,
                 "remark": "Template for testing purposes with single repeatable literal.",
                 "date": null,
+                "suppressible": false,
                 "propertyTemplateKeys": [
                   "resourceTemplate:testing:uber2 > http://id.loc.gov/ontologies/bibframe/uber/template2/property1"
                 ],
@@ -628,7 +649,7 @@
               },
               "properties": [
                 {
-                  "key": "abc37",
+                  "key": "abc38",
                   "values": null,
                   "show": false
                 }
@@ -636,13 +657,13 @@
             }
           },
           {
-            "key": "abc34",
+            "key": "abc35",
             "literal": null,
             "lang": null,
             "uri": null,
             "label": null,
             "valueSubject": {
-              "key": "abc29",
+              "key": "abc30",
               "uri": null,
               "subjectTemplate": {
                 "key": "resourceTemplate:testing:uber3",
@@ -653,6 +674,7 @@
                 "author": null,
                 "remark": "Template for testing purposes with multiple literal.",
                 "date": null,
+                "suppressible": false,
                 "propertyTemplateKeys": [
                   "resourceTemplate:testing:uber3 > http://id.loc.gov/ontologies/bibframe/uber/template3/property1",
                   "resourceTemplate:testing:uber3 > http://id.loc.gov/ontologies/bibframe/uber/template3/property2"
@@ -694,10 +716,10 @@
               },
               "properties": [
                 {
-                  "key": "abc30",
+                  "key": "abc31",
                   "values": [
                     {
-                      "key": "abc32",
+                      "key": "abc33",
                       "literal": "Uber template3, property1",
                       "lang": "eng",
                       "uri": null,
@@ -708,10 +730,10 @@
                   "show": false
                 },
                 {
-                  "key": "abc31",
+                  "key": "abc32",
                   "values": [
                     {
-                      "key": "abc33",
+                      "key": "abc34",
                       "literal": "Uber template3, property2",
                       "lang": "eng",
                       "uri": null,
@@ -811,7 +833,7 @@
         "key": "abc18",
         "values": [
           {
-            "key": "abc28",
+            "key": "abc29",
             "literal": null,
             "lang": null,
             "uri": null,
@@ -828,6 +850,7 @@
                 "author": null,
                 "remark": "Template for testing purposes with single repeatable, required literal.",
                 "date": null,
+                "suppressible": false,
                 "propertyTemplateKeys": [
                   "resourceTemplate:testing:uber4 > http://id.loc.gov/ontologies/bibframe/uber/template4/property1"
                 ],
@@ -852,7 +875,7 @@
               },
               "properties": [
                 {
-                  "key": "abc27",
+                  "key": "abc28",
                   "values": [],
                   "show": true
                 }
@@ -896,6 +919,11 @@
         "key": "abc26",
         "values": [],
         "show": true
+      },
+      {
+        "key": "abc27",
+        "values": null,
+        "show": false
       }
     ],
     "group": "stanford"

--- a/__tests__/__action_fixtures__/newResource-ADD_SUBJECT.json
+++ b/__tests__/__action_fixtures__/newResource-ADD_SUBJECT.json
@@ -12,6 +12,7 @@
       "author": "Justin Littman",
       "remark": "Template for testing purposes.",
       "date": "2020-07-27",
+      "suppressible": false,
       "propertyTemplateKeys": [
         "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property1",
         "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property2",
@@ -37,7 +38,8 @@
         "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/instanceOf",
         "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/hasItem",
         "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/itemOf",
-        "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property20"
+        "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property20",
+        "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property21"
       ],
       "propertyTemplates": [
         {
@@ -374,8 +376,8 @@
             {
               "uri": "urn:ld4p:sinopia:bibframe:instance",
               "label": "Sinopia BIBFRAME instance resources",
-              "type": "http://id.loc.gov/ontologies/bibframe/Instance",
-              "nonldLookup": false
+              "nonldLookup": false,
+              "type": "http://id.loc.gov/ontologies/bibframe/Instance"
             }
           ],
           "type": "uri",
@@ -397,8 +399,8 @@
             {
               "uri": "urn:ld4p:sinopia:bibframe:instance",
               "label": "Sinopia BIBFRAME instance resources",
-              "type": "http://id.loc.gov/ontologies/bibframe/Instance",
-              "nonldLookup": false
+              "nonldLookup": false,
+              "type": "http://id.loc.gov/ontologies/bibframe/Instance"
             }
           ],
           "type": "uri",
@@ -456,8 +458,8 @@
             {
               "uri": "urn:ld4p:sinopia:bibframe:adminMetadata",
               "label": "Sinopia BIBFRAME admin metadata resources",
-              "type": "http://id.loc.gov/ontologies/bibframe/AdminMetadata",
-              "nonldLookup": false
+              "nonldLookup": false,
+              "type": "http://id.loc.gov/ontologies/bibframe/AdminMetadata"
             }
           ],
           "type": "uri",
@@ -479,8 +481,8 @@
             {
               "uri": "urn:ld4p:sinopia:bibframe:instance",
               "label": "Sinopia BIBFRAME instance resources",
-              "type": "http://id.loc.gov/ontologies/bibframe/Instance",
-              "nonldLookup": false
+              "nonldLookup": false,
+              "type": "http://id.loc.gov/ontologies/bibframe/Instance"
             }
           ],
           "type": "uri",
@@ -502,8 +504,8 @@
             {
               "uri": "urn:ld4p:sinopia:bibframe:work",
               "label": "Sinopia BIBFRAME work resources",
-              "type": "http://id.loc.gov/ontologies/bibframe/Work",
-              "nonldLookup": false
+              "nonldLookup": false,
+              "type": "http://id.loc.gov/ontologies/bibframe/Work"
             }
           ],
           "type": "uri",
@@ -525,8 +527,8 @@
             {
               "uri": "urn:ld4p:sinopia:bibframe:item",
               "label": "Sinopia BIBFRAME item resources",
-              "type": "http://id.loc.gov/ontologies/bibframe/Item",
-              "nonldLookup": false
+              "nonldLookup": false,
+              "type": "http://id.loc.gov/ontologies/bibframe/Item"
             }
           ],
           "type": "uri",
@@ -548,8 +550,8 @@
             {
               "uri": "urn:ld4p:sinopia:bibframe:instance",
               "label": "Sinopia BIBFRAME instance resources",
-              "type": "http://id.loc.gov/ontologies/bibframe/Instance",
-              "nonldLookup": false
+              "nonldLookup": false,
+              "type": "http://id.loc.gov/ontologies/bibframe/Instance"
             }
           ],
           "type": "uri",
@@ -579,6 +581,24 @@
           "authorities": [],
           "type": "literal",
           "component": "InputLiteral"
+        },
+        {
+          "key": "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property21",
+          "subjectTemplateKey": "resourceTemplate:testing:uber1",
+          "label": "Uber template1, property21",
+          "uri": "http://id.loc.gov/ontologies/bibframe/uber/template1/property21",
+          "required": false,
+          "repeatable": true,
+          "ordered": false,
+          "remark": "Nested, repeatable, suppressible resource template.",
+          "remarkUrl": null,
+          "defaults": [],
+          "valueSubjectTemplateKeys": [
+            "resourceTemplate:testing:uber5"
+          ],
+          "authorities": [],
+          "type": "resource",
+          "component": "NestedResource"
         }
       ]
     },
@@ -587,13 +607,13 @@
         "key": "abc1",
         "values": [
           {
-            "key": "abc55",
+            "key": "abc58",
             "literal": null,
             "lang": null,
             "uri": null,
             "label": null,
             "valueSubject": {
-              "key": "abc35",
+              "key": "abc36",
               "uri": null,
               "subjectTemplate": {
                 "key": "resourceTemplate:testing:uber2",
@@ -604,6 +624,7 @@
                 "author": null,
                 "remark": "Template for testing purposes with single repeatable literal.",
                 "date": null,
+                "suppressible": false,
                 "propertyTemplateKeys": [
                   "resourceTemplate:testing:uber2 > http://id.loc.gov/ontologies/bibframe/uber/template2/property1"
                 ],
@@ -628,7 +649,7 @@
               },
               "properties": [
                 {
-                  "key": "abc47",
+                  "key": "abc49",
                   "values": null,
                   "show": false
                 }
@@ -636,13 +657,13 @@
             }
           },
           {
-            "key": "abc57",
+            "key": "abc61",
             "literal": null,
             "lang": null,
             "uri": null,
             "label": null,
             "valueSubject": {
-              "key": "abc36",
+              "key": "abc37",
               "uri": null,
               "subjectTemplate": {
                 "key": "resourceTemplate:testing:uber3",
@@ -653,6 +674,7 @@
                 "author": null,
                 "remark": "Template for testing purposes with multiple literal.",
                 "date": null,
+                "suppressible": false,
                 "propertyTemplateKeys": [
                   "resourceTemplate:testing:uber3 > http://id.loc.gov/ontologies/bibframe/uber/template3/property1",
                   "resourceTemplate:testing:uber3 > http://id.loc.gov/ontologies/bibframe/uber/template3/property2"
@@ -694,12 +716,12 @@
               },
               "properties": [
                 {
-                  "key": "abc51",
+                  "key": "abc54",
                   "values": null,
                   "show": false
                 },
                 {
-                  "key": "abc52",
+                  "key": "abc55",
                   "values": null,
                   "show": false
                 }
@@ -718,13 +740,13 @@
         "key": "abc3",
         "values": [
           {
-            "key": "abc56",
+            "key": "abc59",
             "literal": null,
             "lang": null,
             "uri": null,
             "label": null,
             "valueSubject": {
-              "key": "abc37",
+              "key": "abc38",
               "uri": null,
               "subjectTemplate": {
                 "key": "resourceTemplate:testing:uber2",
@@ -735,6 +757,7 @@
                 "author": null,
                 "remark": "Template for testing purposes with single repeatable literal.",
                 "date": null,
+                "suppressible": false,
                 "propertyTemplateKeys": [
                   "resourceTemplate:testing:uber2 > http://id.loc.gov/ontologies/bibframe/uber/template2/property1"
                 ],
@@ -759,7 +782,7 @@
               },
               "properties": [
                 {
-                  "key": "abc48",
+                  "key": "abc50",
                   "values": null,
                   "show": false
                 }
@@ -767,13 +790,13 @@
             }
           },
           {
-            "key": "abc58",
+            "key": "abc62",
             "literal": null,
             "lang": null,
             "uri": null,
             "label": null,
             "valueSubject": {
-              "key": "abc38",
+              "key": "abc39",
               "uri": null,
               "subjectTemplate": {
                 "key": "resourceTemplate:testing:uber3",
@@ -784,6 +807,7 @@
                 "author": null,
                 "remark": "Template for testing purposes with multiple literal.",
                 "date": null,
+                "suppressible": false,
                 "propertyTemplateKeys": [
                   "resourceTemplate:testing:uber3 > http://id.loc.gov/ontologies/bibframe/uber/template3/property1",
                   "resourceTemplate:testing:uber3 > http://id.loc.gov/ontologies/bibframe/uber/template3/property2"
@@ -825,12 +849,12 @@
               },
               "properties": [
                 {
-                  "key": "abc53",
+                  "key": "abc56",
                   "values": null,
                   "show": false
                 },
                 {
-                  "key": "abc54",
+                  "key": "abc57",
                   "values": null,
                   "show": false
                 }
@@ -859,7 +883,7 @@
         "key": "abc7",
         "values": [
           {
-            "key": "abc39",
+            "key": "abc40",
             "literal": "Default literal1",
             "lang": null,
             "uri": null,
@@ -867,7 +891,7 @@
             "valueSubject": null
           },
           {
-            "key": "abc40",
+            "key": "abc41",
             "literal": "Default literal2",
             "lang": null,
             "uri": null,
@@ -881,7 +905,7 @@
         "key": "abc10",
         "values": [
           {
-            "key": "abc41",
+            "key": "abc42",
             "literal": null,
             "lang": null,
             "uri": "http://sinopia.io/defaultURI1",
@@ -889,7 +913,7 @@
             "valueSubject": null
           },
           {
-            "key": "abc42",
+            "key": "abc43",
             "literal": null,
             "lang": null,
             "uri": "http://sinopia.io/defaultURI2",
@@ -948,62 +972,7 @@
         "key": "abc22",
         "values": [
           {
-            "key": "abc59",
-            "literal": null,
-            "lang": null,
-            "uri": null,
-            "label": null,
-            "valueSubject": {
-              "key": "abc43",
-              "uri": null,
-              "subjectTemplate": {
-                "key": "resourceTemplate:testing:uber4",
-                "uri": "http://localhost:3000/resource/resourceTemplate:testing:uber4",
-                "id": "resourceTemplate:testing:uber4",
-                "class": "http://id.loc.gov/ontologies/bibframe/Uber4",
-                "label": "Uber template4",
-                "author": null,
-                "remark": "Template for testing purposes with single repeatable, required literal.",
-                "date": null,
-                "propertyTemplateKeys": [
-                  "resourceTemplate:testing:uber4 > http://id.loc.gov/ontologies/bibframe/uber/template4/property1"
-                ],
-                "propertyTemplates": [
-                  {
-                    "key": "resourceTemplate:testing:uber4 > http://id.loc.gov/ontologies/bibframe/uber/template4/property1",
-                    "subjectTemplateKey": "resourceTemplate:testing:uber4",
-                    "label": "Uber template4, property1",
-                    "uri": "http://id.loc.gov/ontologies/bibframe/uber/template4/property1",
-                    "required": true,
-                    "repeatable": true,
-                    "ordered": false,
-                    "remark": "A repeatable, required literal",
-                    "remarkUrl": null,
-                    "defaults": [],
-                    "valueSubjectTemplateKeys": [],
-                    "authorities": [],
-                    "type": "literal",
-                    "component": "InputLiteral"
-                  }
-                ]
-              },
-              "properties": [
-                {
-                  "key": "abc49",
-                  "values": [],
-                  "show": true
-                }
-              ]
-            }
-          }
-        ],
-        "show": true
-      },
-      {
-        "key": "abc24",
-        "values": [
-          {
-            "key": "abc60",
+            "key": "abc63",
             "literal": null,
             "lang": null,
             "uri": null,
@@ -1020,6 +989,7 @@
                 "author": null,
                 "remark": "Template for testing purposes with single repeatable, required literal.",
                 "date": null,
+                "suppressible": false,
                 "propertyTemplateKeys": [
                   "resourceTemplate:testing:uber4 > http://id.loc.gov/ontologies/bibframe/uber/template4/property1"
                 ],
@@ -1044,7 +1014,63 @@
               },
               "properties": [
                 {
-                  "key": "abc50",
+                  "key": "abc51",
+                  "values": [],
+                  "show": true
+                }
+              ]
+            }
+          }
+        ],
+        "show": true
+      },
+      {
+        "key": "abc24",
+        "values": [
+          {
+            "key": "abc64",
+            "literal": null,
+            "lang": null,
+            "uri": null,
+            "label": null,
+            "valueSubject": {
+              "key": "abc45",
+              "uri": null,
+              "subjectTemplate": {
+                "key": "resourceTemplate:testing:uber4",
+                "uri": "http://localhost:3000/resource/resourceTemplate:testing:uber4",
+                "id": "resourceTemplate:testing:uber4",
+                "class": "http://id.loc.gov/ontologies/bibframe/Uber4",
+                "label": "Uber template4",
+                "author": null,
+                "remark": "Template for testing purposes with single repeatable, required literal.",
+                "date": null,
+                "suppressible": false,
+                "propertyTemplateKeys": [
+                  "resourceTemplate:testing:uber4 > http://id.loc.gov/ontologies/bibframe/uber/template4/property1"
+                ],
+                "propertyTemplates": [
+                  {
+                    "key": "resourceTemplate:testing:uber4 > http://id.loc.gov/ontologies/bibframe/uber/template4/property1",
+                    "subjectTemplateKey": "resourceTemplate:testing:uber4",
+                    "label": "Uber template4, property1",
+                    "uri": "http://id.loc.gov/ontologies/bibframe/uber/template4/property1",
+                    "required": true,
+                    "repeatable": true,
+                    "ordered": false,
+                    "remark": "A repeatable, required literal",
+                    "remarkUrl": null,
+                    "defaults": [],
+                    "valueSubjectTemplateKeys": [],
+                    "authorities": [],
+                    "type": "literal",
+                    "component": "InputLiteral"
+                  }
+                ]
+              },
+              "properties": [
+                {
+                  "key": "abc52",
                   "values": [],
                   "show": true
                 }
@@ -1083,7 +1109,7 @@
         "key": "abc30",
         "values": [
           {
-            "key": "abc45",
+            "key": "abc46",
             "literal": "Default required literal1",
             "lang": null,
             "uri": null,
@@ -1091,12 +1117,68 @@
             "valueSubject": null
           },
           {
-            "key": "abc46",
+            "key": "abc47",
             "literal": "Default required literal2",
             "lang": null,
             "uri": null,
             "label": null,
             "valueSubject": null
+          }
+        ],
+        "show": true
+      },
+      {
+        "key": "abc33",
+        "values": [
+          {
+            "key": "abc60",
+            "literal": null,
+            "lang": null,
+            "uri": null,
+            "label": null,
+            "valueSubject": {
+              "key": "abc48",
+              "uri": null,
+              "subjectTemplate": {
+                "key": "resourceTemplate:testing:uber5",
+                "uri": "http://localhost:3000/resource/resourceTemplate:testing:uber5",
+                "id": "resourceTemplate:testing:uber5",
+                "class": "http://id.loc.gov/ontologies/bibframe/Uber5",
+                "label": "Uber template5",
+                "author": null,
+                "remark": "Template for testing purposes with suppressed, repeatable URI.",
+                "date": null,
+                "suppressible": true,
+                "propertyTemplateKeys": [
+                  "resourceTemplate:testing:uber5 > http://id.loc.gov/ontologies/bibframe/uber/template5/property1"
+                ],
+                "propertyTemplates": [
+                  {
+                    "key": "resourceTemplate:testing:uber5 > http://id.loc.gov/ontologies/bibframe/uber/template5/property1",
+                    "subjectTemplateKey": "resourceTemplate:testing:uber5",
+                    "label": "Uber template5, property1",
+                    "uri": "http://id.loc.gov/ontologies/bibframe/uber/template5/property1",
+                    "required": false,
+                    "repeatable": true,
+                    "ordered": false,
+                    "remark": "A repeatable URI",
+                    "remarkUrl": null,
+                    "defaults": [],
+                    "valueSubjectTemplateKeys": [],
+                    "authorities": [],
+                    "type": "uri",
+                    "component": "InputURI"
+                  }
+                ]
+              },
+              "properties": [
+                {
+                  "key": "abc53",
+                  "values": null,
+                  "show": false
+                }
+              ]
+            }
           }
         ],
         "show": true

--- a/__tests__/__action_fixtures__/newResourceFromDataset-ADD_SUBJECT.json
+++ b/__tests__/__action_fixtures__/newResourceFromDataset-ADD_SUBJECT.json
@@ -12,6 +12,7 @@
       "author": "Justin Littman",
       "remark": "Template for testing purposes.",
       "date": "2020-07-27",
+      "suppressible": false,
       "propertyTemplateKeys": [
         "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property1",
         "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property2",
@@ -37,7 +38,8 @@
         "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/instanceOf",
         "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/hasItem",
         "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/itemOf",
-        "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property20"
+        "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property20",
+        "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property21"
       ],
       "propertyTemplates": [
         {
@@ -374,8 +376,8 @@
             {
               "uri": "urn:ld4p:sinopia:bibframe:instance",
               "label": "Sinopia BIBFRAME instance resources",
-              "type": "http://id.loc.gov/ontologies/bibframe/Instance",
-              "nonldLookup": false
+              "nonldLookup": false,
+              "type": "http://id.loc.gov/ontologies/bibframe/Instance"
             }
           ],
           "type": "uri",
@@ -397,8 +399,8 @@
             {
               "uri": "urn:ld4p:sinopia:bibframe:instance",
               "label": "Sinopia BIBFRAME instance resources",
-              "type": "http://id.loc.gov/ontologies/bibframe/Instance",
-              "nonldLookup": false
+              "nonldLookup": false,
+              "type": "http://id.loc.gov/ontologies/bibframe/Instance"
             }
           ],
           "type": "uri",
@@ -456,8 +458,8 @@
             {
               "uri": "urn:ld4p:sinopia:bibframe:adminMetadata",
               "label": "Sinopia BIBFRAME admin metadata resources",
-              "type": "http://id.loc.gov/ontologies/bibframe/AdminMetadata",
-              "nonldLookup": false
+              "nonldLookup": false,
+              "type": "http://id.loc.gov/ontologies/bibframe/AdminMetadata"
             }
           ],
           "type": "uri",
@@ -479,8 +481,8 @@
             {
               "uri": "urn:ld4p:sinopia:bibframe:instance",
               "label": "Sinopia BIBFRAME instance resources",
-              "type": "http://id.loc.gov/ontologies/bibframe/Instance",
-              "nonldLookup": false
+              "nonldLookup": false,
+              "type": "http://id.loc.gov/ontologies/bibframe/Instance"
             }
           ],
           "type": "uri",
@@ -502,8 +504,8 @@
             {
               "uri": "urn:ld4p:sinopia:bibframe:work",
               "label": "Sinopia BIBFRAME work resources",
-              "type": "http://id.loc.gov/ontologies/bibframe/Work",
-              "nonldLookup": false
+              "nonldLookup": false,
+              "type": "http://id.loc.gov/ontologies/bibframe/Work"
             }
           ],
           "type": "uri",
@@ -525,8 +527,8 @@
             {
               "uri": "urn:ld4p:sinopia:bibframe:item",
               "label": "Sinopia BIBFRAME item resources",
-              "type": "http://id.loc.gov/ontologies/bibframe/Item",
-              "nonldLookup": false
+              "nonldLookup": false,
+              "type": "http://id.loc.gov/ontologies/bibframe/Item"
             }
           ],
           "type": "uri",
@@ -548,8 +550,8 @@
             {
               "uri": "urn:ld4p:sinopia:bibframe:instance",
               "label": "Sinopia BIBFRAME instance resources",
-              "type": "http://id.loc.gov/ontologies/bibframe/Instance",
-              "nonldLookup": false
+              "nonldLookup": false,
+              "type": "http://id.loc.gov/ontologies/bibframe/Instance"
             }
           ],
           "type": "uri",
@@ -579,6 +581,24 @@
           "authorities": [],
           "type": "literal",
           "component": "InputLiteral"
+        },
+        {
+          "key": "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property21",
+          "subjectTemplateKey": "resourceTemplate:testing:uber1",
+          "label": "Uber template1, property21",
+          "uri": "http://id.loc.gov/ontologies/bibframe/uber/template1/property21",
+          "required": false,
+          "repeatable": true,
+          "ordered": false,
+          "remark": "Nested, repeatable, suppressible resource template.",
+          "remarkUrl": null,
+          "defaults": [],
+          "valueSubjectTemplateKeys": [
+            "resourceTemplate:testing:uber5"
+          ],
+          "authorities": [],
+          "type": "resource",
+          "component": "NestedResource"
         }
       ]
     },
@@ -587,13 +607,13 @@
         "key": "abc1",
         "values": [
           {
-            "key": "abc45",
+            "key": "abc49",
             "literal": null,
             "lang": null,
             "uri": null,
             "label": null,
             "valueSubject": {
-              "key": "abc34",
+              "key": "abc35",
               "uri": null,
               "subjectTemplate": {
                 "key": "resourceTemplate:testing:uber2",
@@ -604,6 +624,7 @@
                 "author": null,
                 "remark": "Template for testing purposes with single repeatable literal.",
                 "date": null,
+                "suppressible": false,
                 "propertyTemplateKeys": [
                   "resourceTemplate:testing:uber2 > http://id.loc.gov/ontologies/bibframe/uber/template2/property1"
                 ],
@@ -628,10 +649,10 @@
               },
               "properties": [
                 {
-                  "key": "abc38",
+                  "key": "abc40",
                   "values": [
                     {
-                      "key": "abc42",
+                      "key": "abc45",
                       "literal": "Uber template2, property1",
                       "lang": "eng",
                       "uri": null,
@@ -645,20 +666,20 @@
             }
           },
           {
-            "key": "abc46",
+            "key": "abc50",
             "literal": null,
             "lang": null,
             "uri": null,
             "label": null,
             "valueSubject": {
-              "key": "abc35",
+              "key": "abc36",
               "uri": null,
               "properties": [
                 {
-                  "key": "abc39",
+                  "key": "abc41",
                   "values": [
                     {
-                      "key": "abc43",
+                      "key": "abc46",
                       "literal": "Uber template2, property1b",
                       "lang": "eng",
                       "uri": null,
@@ -672,13 +693,13 @@
             }
           },
           {
-            "key": "abc44",
+            "key": "abc48",
             "literal": null,
             "lang": null,
             "uri": null,
             "label": null,
             "valueSubject": {
-              "key": "abc33",
+              "key": "abc34",
               "uri": null,
               "subjectTemplate": {
                 "key": "resourceTemplate:testing:uber3",
@@ -689,6 +710,7 @@
                 "author": null,
                 "remark": "Template for testing purposes with multiple literal.",
                 "date": null,
+                "suppressible": false,
                 "propertyTemplateKeys": [
                   "resourceTemplate:testing:uber3 > http://id.loc.gov/ontologies/bibframe/uber/template3/property1",
                   "resourceTemplate:testing:uber3 > http://id.loc.gov/ontologies/bibframe/uber/template3/property2"
@@ -730,10 +752,10 @@
               },
               "properties": [
                 {
-                  "key": "abc36",
+                  "key": "abc38",
                   "values": [
                     {
-                      "key": "abc40",
+                      "key": "abc43",
                       "literal": "Uber template3, property1",
                       "lang": "eng",
                       "uri": null,
@@ -744,10 +766,10 @@
                   "show": false
                 },
                 {
-                  "key": "abc37",
+                  "key": "abc39",
                   "values": [
                     {
-                      "key": "abc41",
+                      "key": "abc44",
                       "literal": "Uber template3, property2",
                       "lang": "eng",
                       "uri": null,
@@ -767,7 +789,7 @@
         "key": "abc2",
         "values": [
           {
-            "key": "abc29",
+            "key": "abc30",
             "literal": "Uber template1, property2",
             "lang": "eng",
             "uri": null,
@@ -786,7 +808,7 @@
         "key": "abc4",
         "values": [
           {
-            "key": "abc30",
+            "key": "abc31",
             "literal": "Uber template1, property4",
             "lang": "eng",
             "uri": null,
@@ -800,7 +822,7 @@
         "key": "abc5",
         "values": [
           {
-            "key": "abc31",
+            "key": "abc32",
             "literal": null,
             "lang": null,
             "uri": "ubertemplate1:property5",
@@ -814,7 +836,7 @@
         "key": "abc6",
         "values": [
           {
-            "key": "abc32",
+            "key": "abc33",
             "literal": null,
             "lang": null,
             "uri": "ubertemplate1:property6",
@@ -883,7 +905,7 @@
         "key": "abc18",
         "values": [
           {
-            "key": "abc28",
+            "key": "abc29",
             "literal": null,
             "lang": null,
             "uri": null,
@@ -900,6 +922,7 @@
                 "author": null,
                 "remark": "Template for testing purposes with single repeatable, required literal.",
                 "date": null,
+                "suppressible": false,
                 "propertyTemplateKeys": [
                   "resourceTemplate:testing:uber4 > http://id.loc.gov/ontologies/bibframe/uber/template4/property1"
                 ],
@@ -924,7 +947,7 @@
               },
               "properties": [
                 {
-                  "key": "abc27",
+                  "key": "abc28",
                   "values": [],
                   "show": true
                 }
@@ -968,6 +991,71 @@
         "key": "abc26",
         "values": [],
         "show": true
+      },
+      {
+        "key": "abc27",
+        "values": [
+          {
+            "key": "abc51",
+            "literal": null,
+            "lang": null,
+            "uri": null,
+            "label": null,
+            "valueSubject": {
+              "key": "abc37",
+              "uri": null,
+              "subjectTemplate": {
+                "key": "resourceTemplate:testing:uber5",
+                "uri": "http://localhost:3000/resource/resourceTemplate:testing:uber5",
+                "id": "resourceTemplate:testing:uber5",
+                "class": "http://id.loc.gov/ontologies/bibframe/Uber5",
+                "label": "Uber template5",
+                "author": null,
+                "remark": "Template for testing purposes with suppressed, repeatable URI.",
+                "date": null,
+                "suppressible": true,
+                "propertyTemplateKeys": [
+                  "resourceTemplate:testing:uber5 > http://id.loc.gov/ontologies/bibframe/uber/template5/property1"
+                ],
+                "propertyTemplates": [
+                  {
+                    "key": "resourceTemplate:testing:uber5 > http://id.loc.gov/ontologies/bibframe/uber/template5/property1",
+                    "subjectTemplateKey": "resourceTemplate:testing:uber5",
+                    "label": "Uber template5, property1",
+                    "uri": "http://id.loc.gov/ontologies/bibframe/uber/template5/property1",
+                    "required": false,
+                    "repeatable": true,
+                    "ordered": false,
+                    "remark": "A repeatable URI",
+                    "remarkUrl": null,
+                    "defaults": [],
+                    "valueSubjectTemplateKeys": [],
+                    "authorities": [],
+                    "type": "uri",
+                    "component": "InputURI"
+                  }
+                ]
+              },
+              "properties": [
+                {
+                  "key": "abc42",
+                  "values": [
+                    {
+                      "key": "abc47",
+                      "literal": null,
+                      "lang": null,
+                      "uri": "http://sinopia.io/ubertemplate5/property1",
+                      "label": "http://sinopia.io/ubertemplate5/property1",
+                      "valueSubject": null
+                    }
+                  ],
+                  "show": false
+                }
+              ]
+            }
+          }
+        ],
+        "show": false
       }
     ]
   }

--- a/__tests__/__template_fixtures__/uber_template1.json
+++ b/__tests__/__template_fixtures__/uber_template1.json
@@ -1086,6 +1086,53 @@
     ]
   },
   {
+    "@id": "_:b72",
+    "@type": [
+      "http://sinopia.io/vocabulary/PropertyTemplate"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Uber template1, property21"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasRemark": [
+      {
+        "@value": "Nested, repeatable, suppressible resource template."
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyUri": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/uber/template1/property21"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyAttribute": [
+      {
+        "@id": "http://sinopia.io/vocabulary/propertyAttribute/repeatable"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyType": [
+      {
+        "@id": "http://sinopia.io/vocabulary/propertyType/resource"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasResourceAttributes": [
+      {
+        "@id": "_:b73"
+      }
+    ]
+  },
+  {
+    "@id": "_:b73",
+    "@type": [
+      "http://sinopia.io/vocabulary/ResourcePropertyTemplate"
+    ],
+    "http://sinopia.io/vocabulary/hasResourceTemplateId": [
+      {
+        "@id": "resourceTemplate:testing:uber5"
+      }
+    ]
+  },
+  {
     "@id": "_:b8",
     "@type": [
       "http://sinopia.io/vocabulary/PropertyTemplate"
@@ -1247,6 +1294,9 @@
           },
           {
             "@id": "_:b70"
+          },
+          {
+            "@id": "_:b72"
           }
         ]
       }

--- a/__tests__/__template_fixtures__/uber_template5.json
+++ b/__tests__/__template_fixtures__/uber_template5.json
@@ -1,0 +1,78 @@
+[
+  {
+    "@id": "_:b2",
+    "@type": [
+      "http://sinopia.io/vocabulary/PropertyTemplate"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Uber template5, property1"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasRemark": [
+      {
+        "@value": "A repeatable URI"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyUri": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/uber/template5/property1"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyAttribute": [
+      {
+        "@id": "http://sinopia.io/vocabulary/propertyAttribute/repeatable"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyType": [
+      {
+        "@id": "http://sinopia.io/vocabulary/propertyType/uri"
+      }
+    ]
+  },
+  {
+    "@id": "http://localhost:3000/resource/resourceTemplate:testing:uber5",
+    "http://sinopia.io/vocabulary/hasResourceTemplate": [
+      {
+        "@value": "sinopia:template:resource"
+      }
+    ],
+    "@type": [
+      "http://sinopia.io/vocabulary/ResourceTemplate"
+    ],
+    "http://sinopia.io/vocabulary/hasResourceId": [
+      {
+        "@value": "resourceTemplate:testing:uber5"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasClass": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/Uber5"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Uber template5"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasRemark": [
+      {
+        "@value": "Template for testing purposes with suppressed, repeatable URI."
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasResourceAttribute": [
+      {
+        "@id": "http://sinopia.io/vocabulary/resourceAttribute/suppressible"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyTemplate": [
+      {
+        "@list": [
+          {
+            "@id": "_:b2"
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/__tests__/actionCreators/templateValidationHelpers.test.js
+++ b/__tests__/actionCreators/templateValidationHelpers.test.js
@@ -444,4 +444,127 @@ describe('validateTemplates()', () => {
       expect(store.getActions()).toHaveAction('ADD_ERROR', payload)
     })
   })
+
+  describe('a valid suppressible template', () => {
+    const subjectTemplate = {
+      key: 'pcc:bf2:Agent:Person',
+      uri: 'http://localhost:3000/resource/pcc:bf2:Agent:Person',
+      id: 'pcc:bf2:Agent:Person',
+      class: 'http://id.loc.gov/ontologies/bibframe/Person',
+      label: 'Agent--Person',
+      author: 'PCC',
+      remark: null,
+      date: '2020-09-20',
+      suppressible: true,
+      propertyTemplateKeys: [
+        'pcc:bf2:Agent:Person > http://www.w3.org/1999/02/22-rdf-syntax-ns#value',
+      ],
+      propertyTemplates: [
+        {
+          key: 'pcc:bf2:Agent:Person > http://www.w3.org/1999/02/22-rdf-syntax-ns#value',
+          subjectTemplateKey: 'pcc:bf2:Agent:Person',
+          label: 'Name of Person',
+          uri: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#value',
+          required: false,
+          repeatable: true,
+          ordered: false,
+          remark: null,
+          remarkUrl: null,
+          defaults: [],
+          valueSubjectTemplateKeys: [],
+          authorities: [
+            {
+              uri: 'urn:ld4p:qa:names',
+              label: 'LOC all names (QA)',
+              authority: 'locnames_ld4l_cache',
+              subauthority: '',
+              nonldLookup: false,
+            },
+          ],
+          type: 'uri',
+          component: 'InputLookup',
+        },
+      ],
+    }
+
+    it('returns no errors', async () => {
+      const store = mockStore(createState())
+
+      expect(await store.dispatch(validateTemplates(subjectTemplate, {}, 'testerrorkey'))).toBe(true)
+      expect(store.getActions()).not.toHaveAction('ADD_ERROR')
+    })
+  })
+
+  describe('a suppressible template with wrong number of property templates', () => {
+    const subjectTemplate = {
+      key: 'pcc:bf2:Agent:Person',
+      uri: 'http://localhost:3000/resource/pcc:bf2:Agent:Person',
+      id: 'pcc:bf2:Agent:Person',
+      class: 'http://id.loc.gov/ontologies/bibframe/Person',
+      label: 'Agent--Person',
+      author: 'PCC',
+      remark: null,
+      date: '2020-09-20',
+      suppressible: true,
+      propertyTemplateKeys: [],
+      propertyTemplates: [],
+    }
+
+    it('returns error', async () => {
+      const store = mockStore(createState())
+
+      expect(await store.dispatch(validateTemplates(subjectTemplate, {}, 'testerrorkey'))).toBe(false)
+      const payload = {
+        errorKey: 'testerrorkey',
+        error: 'A suppressible template must have one property template.',
+      }
+      expect(store.getActions()).toHaveAction('ADD_ERROR', payload)
+    })
+  })
+
+  describe('a suppressible template with wrong type of property', () => {
+    const subjectTemplate = {
+      key: 'pcc:bf2:Agent:Person',
+      uri: 'http://localhost:3000/resource/pcc:bf2:Agent:Person',
+      id: 'pcc:bf2:Agent:Person',
+      class: 'http://id.loc.gov/ontologies/bibframe/Person',
+      label: 'Agent--Person',
+      author: 'PCC',
+      remark: null,
+      date: '2020-09-20',
+      suppressible: true,
+      propertyTemplateKeys: [
+        'pcc:bf2:Agent:Person > http://www.w3.org/1999/02/22-rdf-syntax-ns#value',
+      ],
+      propertyTemplates: [
+        {
+          key: 'pcc:bf2:Agent:Person > http://www.w3.org/1999/02/22-rdf-syntax-ns#value',
+          subjectTemplateKey: 'pcc:bf2:Agent:Person',
+          label: 'Name of Person',
+          uri: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#value',
+          required: false,
+          repeatable: true,
+          ordered: false,
+          remark: null,
+          remarkUrl: null,
+          defaults: [],
+          valueSubjectTemplateKeys: [],
+          authorities: [],
+          type: 'literal',
+          component: 'InputLiteral',
+        },
+      ],
+    }
+
+    it('returns error', async () => {
+      const store = mockStore(createState())
+
+      expect(await store.dispatch(validateTemplates(subjectTemplate, {}, 'testerrorkey'))).toBe(false)
+      const payload = {
+        errorKey: 'testerrorkey',
+        error: 'The property for a suppressible template must be a URI or lookup.',
+      }
+      expect(store.getActions()).toHaveAction('ADD_ERROR', payload)
+    })
+  })
 })

--- a/__tests__/testUtilities/fixtureLoaderHelper.js
+++ b/__tests__/testUtilities/fixtureLoaderHelper.js
@@ -27,6 +27,7 @@ const templateFilenames = {
   'resourceTemplate:testing:uber2': 'uber_template2.json',
   'resourceTemplate:testing:uber3': 'uber_template3.json',
   'resourceTemplate:testing:uber4': 'uber_template4.json',
+  'resourceTemplate:testing:uber5': 'uber_template5.json',
   'sinopia:template:resource': 'ResourceTemplate.json',
 }
 

--- a/src/TemplatesBuilder.js
+++ b/src/TemplatesBuilder.js
@@ -20,6 +20,7 @@ export default class TemplatesBuilder {
   }
 
   buildSubjectTemplate() {
+    const resourceAttrValues = this.valuesFor(this.resourceTerm, 'http://sinopia.io/vocabulary/hasResourceAttribute')
     this.subjectTemplate = {
       // This key will be unique for resource templates
       key: this.valueFor(this.resourceTerm, 'http://sinopia.io/vocabulary/hasResourceId'),
@@ -30,6 +31,7 @@ export default class TemplatesBuilder {
       author: this.valueFor(this.resourceTerm, 'http://sinopia.io/vocabulary/hasAuthor'),
       remark: this.valueFor(this.resourceTerm, 'http://sinopia.io/vocabulary/hasRemark'),
       date: this.valueFor(this.resourceTerm, 'http://sinopia.io/vocabulary/hasDate'),
+      suppressible: resourceAttrValues.includes('http://sinopia.io/vocabulary/resourceAttribute/suppressible'),
       propertyTemplateKeys: [],
       propertyTemplates: [],
     }

--- a/src/actionCreators/templateValidationHelpers.js
+++ b/src/actionCreators/templateValidationHelpers.js
@@ -13,6 +13,7 @@ import { loadResourceTemplateWithoutValidation } from './templates'
  */
 export const validateTemplates = (subjectTemplate, resourceTemplatePromises, errorKey) => (dispatch) => Promise.all([
   Promise.resolve(validateSubjectTemplate(subjectTemplate)),
+  Promise.resolve(validateSuppressible(subjectTemplate)),
   Promise.resolve(validatePropertyTemplates(subjectTemplate.propertyTemplates)),
   Promise.resolve(validateRepeatedPropertyTemplates(subjectTemplate.propertyTemplates)),
   dispatch(validateAllRefResourceTemplatesExist(subjectTemplate.propertyTemplates, resourceTemplatePromises)),
@@ -30,6 +31,14 @@ const validateSubjectTemplate = (template) => {
   if (!template.class) errors.push('Resource template class is missing from resource template.')
   if (!template.label) errors.push('Resource template label is missing from resource template.')
   return errors
+}
+
+const validateSuppressible = (template) => {
+  if (!template.suppressible) return []
+
+  if (template.propertyTemplates.length !== 1) return ['A suppressible template must have one property template.']
+  if (template.propertyTemplates[0].type !== 'uri') return ['The property for a suppressible template must be a URI or lookup.']
+  return []
 }
 
 const validatePropertyTemplates = (propertyTemplates) => {

--- a/src/components/vocabulary/Vocab.js
+++ b/src/components/vocabulary/Vocab.js
@@ -19,6 +19,10 @@ const vocabulary = {
     description: 'Date associated with the template',
     url: 'http://sinopia.io/vocabulary/hasDate',
   },
+  hasPropertyAttribute: {
+    description: 'Attributes specific to a property (e.g., repeatable)',
+    url: 'http://sinopia.io/vocabulary/hasPropertyAttribute',
+  },
   hasPropertyTemplate: {
     description: 'Property template used by the resource template',
     url: 'http://sinopia.io/vocabulary/hasPropertyTemplate',
@@ -35,9 +39,9 @@ const vocabulary = {
     description: 'Comment or guiding statement intended to be presented as supplementary information in user display',
     url: 'https://sinopia.io/vocabulary/hasRemark',
   },
-  hasResourceAttributes: {
-    description: '',
-    url: 'http://sinopia.io/vocabulary/hasResourceAttributes',
+  hasResourceAttribute: {
+    description: 'Attributes specific to a resource (e.g., suppressible)',
+    url: 'http://sinopia.io/vocabulary/hasResourceAttribute',
   },
   hasResourceTemplate: {
     description: 'The template used in creating, editing, or updating a resource',

--- a/static/authorityConfig.json
+++ b/static/authorityConfig.json
@@ -1918,5 +1918,10 @@
     "label": "authorities",
     "uri": "file:/authorityConfig.json",
     "component": "list"
+  },
+  {
+    "label": "resourceAttribute",
+    "uri": "file:/resourceAttribute.json",
+    "component": "list"
   }
 ]

--- a/static/resourceAttribute.json
+++ b/static/resourceAttribute.json
@@ -1,0 +1,6 @@
+[
+  {
+    "uri": "http://sinopia.io/vocabulary/resourceAttribute/suppressible",
+    "label": "suppressible"
+  }
+]


### PR DESCRIPTION
refs #2787

## Why was this change made?
To produce/load RDF that avoids blank nodes.


## How was this change tested?
Unit, dev


## Which documentation and/or configurations were updated?
README


