### PR TITLE
patch-level version bump for weekly dependency updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sinopia_editor",
-  "version": "3.5.31",
+  "version": "3.5.32",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "editor",
     "rdf"
   ],
-  "version": "3.5.31",
+  "version": "3.5.32",
   "homepage": "http://github.com/LD4P/sinopia_editor/",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Why was this change made?

version and deploy for weekly dependency updates

## How was this change tested?

unit

## Which documentation and/or configurations were updated?

version in `package.json` and `package-lock.json`