### PR TITLE
Adds other group

### DIFF
--- a/src/Config.js
+++ b/src/Config.js
@@ -148,6 +148,7 @@ class Config {
       mla: 'Music Library Association',
       nlm: 'National Library of Medicine',
       northwestern: 'Northwestern University',
+      other: 'Other',
       pcc: 'PCC',
       penn: 'University of Pennsylvania',
       princeton: 'Princeton University',


### PR DESCRIPTION
## Why was this change made?
Add the `other` group to Sinopia intended for people experimenting with Sinopia who aren't associated with any of existing groups.

FIXES #2856

## How was this change tested?
Unit tests


## Which documentation and/or configurations were updated?
Yes, `src/Config.js`

