### PR TITLE
version bump for dependency updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sinopia_editor",
-  "version": "3.6.0",
+  "version": "3.6.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "editor",
     "rdf"
   ],
-  "version": "3.6.0",
+  "version": "3.6.2",
   "homepage": "http://github.com/LD4P/sinopia_editor/",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Why was this change made?

note: skipping from 3.6.0 to 3.6.2 because i mistakenly tagged a 3.6.1 release without doing some previous steps


## How was this change tested?



## Which documentation and/or configurations were updated?



