### PR TITLE
re-enable save button on property re-order

### DIFF
--- a/__tests__/reducers/resources.test.js
+++ b/__tests__/reducers/resources.test.js
@@ -810,7 +810,8 @@ describe('setValueOrder()', () => {
     const oldState = createState({ hasResourceWithTwoNestedResources: true })
 
     expect(oldState.entities.properties.v1o90QO1Qx.valueKeys).toEqual(['VDOeQCnFA8', 'VDOeQCnFA9'])
-
+    const subjectKey = oldState.entities.properties.v1o90QO1Qx.subjectKey
+    expect(oldState.entities.subjects[subjectKey].changed).toBeFalsy
     const action = {
       type: 'SET_VALUE_ORDER',
       payload: {
@@ -820,6 +821,7 @@ describe('setValueOrder()', () => {
     }
 
     const newState = reducer(oldState.entities, action)
+    expect(newState.subjects[subjectKey].changed).toBeTruthy
 
     expect(newState.properties.v1o90QO1Qx.valueKeys).toEqual(['VDOeQCnFA9', 'VDOeQCnFA8'])
   })

--- a/src/reducers/resources.js
+++ b/src/reducers/resources.js
@@ -494,8 +494,11 @@ export const setValueOrder = (state, action) => {
   const valueKey = action.payload.valueKey
   const value = state.values[valueKey]
 
-  const newState = stateWithNewProperty(state, value.propertyKey)
+  let newState = stateWithNewProperty(state, value.propertyKey)
   const newProperty = newState.properties[value.propertyKey]
+
+  // Set resource as changed if order changed (this enables the save button)
+  newState = setSubjectChanged(newState, newProperty.subjectKey, true)
 
   const index = action.payload.index
   const filterValueKeys = newProperty.valueKeys.filter((key) => key !== valueKey)


### PR DESCRIPTION
## Why was this change made?

Fixes #2784 - save button needs to be enabled if the user changes the ordering of properties


## How was this change tested?

In browser (localhost) and updated unit test


## Which documentation and/or configurations were updated?



