### PR TITLE
rename filter by institution button to filter by group

### DIFF
--- a/__tests__/components/search/GroupFilter.test.js
+++ b/__tests__/components/search/GroupFilter.test.js
@@ -42,7 +42,7 @@ describe('<GroupFilter />', () => {
   it('does not render when no facet results', () => {
     renderComponent(<GroupFilter />)
 
-    expect(screen.queryByText('Filter by institution')).not.toBeInTheDocument()
+    expect(screen.queryByText('Filter by group')).not.toBeInTheDocument()
   })
 
   it('renders when results', () => {
@@ -52,7 +52,7 @@ describe('<GroupFilter />', () => {
     const store = createStore(createInitialState())
     const { container } = renderComponent(<GroupFilter />, store)
 
-    expect(screen.getByText('Filter by institution')).toBeInTheDocument()
+    expect(screen.getByText('Filter by group')).toBeInTheDocument()
     expect(screen.getByText('Stanford University (5)')).toBeInTheDocument()
     expect(screen.getByText('Princeton University (1)')).toBeInTheDocument()
 
@@ -68,7 +68,7 @@ describe('<GroupFilter />', () => {
     const { container } = renderComponent(<GroupFilter />, store)
 
     expect(container.querySelector('div.show')).not.toBeInTheDocument()
-    fireEvent.click(screen.getByText('Filter by institution'))
+    fireEvent.click(screen.getByText('Filter by group'))
     expect(container.querySelector('div.show')).toBeInTheDocument()
     fireEvent.click(screen.getByText('Stanford University (5)'))
 
@@ -100,7 +100,7 @@ describe('<GroupFilter />', () => {
     const store = createStore(createInitialState())
     const { container } = renderComponent(<GroupFilter />, store)
 
-    fireEvent.click(screen.getByText('Filter by institution'))
+    fireEvent.click(screen.getByText('Filter by group'))
     fireEvent.click(screen.getAllByText('Only')[0])
 
     // 3 checked
@@ -128,7 +128,7 @@ describe('<GroupFilter />', () => {
 
     const store = createStore(createInitialState())
     const { container } = renderComponent(<GroupFilter />, store)
-    fireEvent.click(screen.getByText('Filter by institution'))
+    fireEvent.click(screen.getByText('Filter by group'))
     fireEvent.click(screen.getByText('Stanford University (5)'))
 
     // 3 checked
@@ -139,7 +139,7 @@ describe('<GroupFilter />', () => {
 
     await waitFor(() => expect(container.querySelector('div.show')).not.toBeInTheDocument())
 
-    fireEvent.click(screen.getByText('Filter by institution'))
+    fireEvent.click(screen.getByText('Filter by group'))
     fireEvent.click(screen.getByText('Clear filter'))
 
     expect(mockGetSearchResults).toHaveBeenLastCalledWith('twain', {

--- a/__tests__/components/search/SinopiaSearchResults.test.js
+++ b/__tests__/components/search/SinopiaSearchResults.test.js
@@ -62,7 +62,7 @@ describe('<SinopiaSearchResults />', () => {
 
       // It has filters
       screen.getByText('Filter by class')
-      screen.getByText('Filter by institution')
+      screen.getByText('Filter by group')
 
       // First row of search results
       screen.queryByText(/An item title/)

--- a/__tests__/feature/search.test.js
+++ b/__tests__/feature/search.test.js
@@ -165,7 +165,7 @@ describe('sinopia resource search', () => {
 
     // TODO: why don't filtering options show up in test UI? -- https://github.com/LD4P/sinopia_editor/issues/2499
     // screen.debug()
-    // fireEvent.click(screen.getByText(/Filter by institution/, { selector: 'button' }))
+    // fireEvent.click(screen.getByText(/Filter by group/, { selector: 'button' }))
     // fireEvent.click(screen.getByText('Cornell University'))
   })
 

--- a/src/components/search/GroupFilter.jsx
+++ b/src/components/search/GroupFilter.jsx
@@ -71,7 +71,7 @@ const GroupFilter = () => {
   const dropDownMenuClasses = ['dropdown-menu']
   if (groupFilterShowDropdown) dropDownMenuClasses.push('show')
   return (
-    <div className="btn-group" role="group" aria-label="Filter by institution" style={{ marginLeft: '10px' }}>
+    <div className="btn-group" role="group" aria-label="Filter by group" style={{ marginLeft: '10px' }}>
       <div className="btn-group" role="group">
         <div className="dropdown">
           <button className="btn btn-secondary"
@@ -80,7 +80,7 @@ const GroupFilter = () => {
                   aria-haspopup="true"
                   aria-expanded={groupFilterShowDropdown}
                   onClick={() => setGroupFilterShowDropdown(!groupFilterShowDropdown)} >
-            Filter by institution
+            Filter by group
           </button>
           <div className={dropDownMenuClasses.join(' ')} aria-labelledby="groupFilterDropdownButton">
             {searchOptions.groupFilter


### PR DESCRIPTION
## Why was this change made?

Fixes #2870 - rename a button in the search tab

## How was this change tested?

Updated test

## Which documentation and/or configurations were updated?



