### PR TITLE
rename search and dashboard headers from institution to group

### DIFF
--- a/__tests__/components/search/SinopiaSearchResults.test.js
+++ b/__tests__/components/search/SinopiaSearchResults.test.js
@@ -54,7 +54,7 @@ describe('<SinopiaSearchResults />', () => {
       // Search table headers
       screen.queryByText('Label / ID')
       screen.queryByText('Class')
-      screen.queryByText('Institution')
+      screen.queryByText('Group')
       screen.getByText('Modified', { selector: 'th' })
 
       // It has a sort button

--- a/src/components/dashboard/ResourceList.jsx
+++ b/src/components/dashboard/ResourceList.jsx
@@ -30,7 +30,7 @@ const ResourceList = (props) => {
                   Class
                 </th>
                 <th style={{ width: '20%' }}>
-                  Institution
+                  Group
                 </th>
                 <th style={{ width: '10%' }}>
                   Modified

--- a/src/components/search/SinopiaSearchResults.jsx
+++ b/src/components/search/SinopiaSearchResults.jsx
@@ -48,7 +48,7 @@ const SinopiaSearchResults = () => {
                   Class
                 </th>
                 <th style={{ width: '20%' }}>
-                  Institution
+                  Group
                 </th>
                 <th style={{ width: '10%' }}>
                   Modified


### PR DESCRIPTION
## Why was this change made?

Fixes #2995 -- rename search table header from "Institution" to "Group" to follow on from work done in #2870.  Also, renamed a similar table header on the Dashboard.

## How was this change tested?

Updated tests

## Which documentation and/or configurations were updated?



