### PR TITLE
add group column to recent/current resource templates

### DIFF
--- a/src/components/templates/ResourceTemplateRow.jsx
+++ b/src/components/templates/ResourceTemplateRow.jsx
@@ -1,18 +1,21 @@
 // Copyright 2019 Stanford University see LICENSE for license
 
 import React from "react"
+import { useSelector } from "react-redux"
 import PropTypes from "prop-types"
 import { Link } from "react-router-dom"
 import LongDate from "components/LongDate"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { faCopy, faEdit } from "@fortawesome/free-solid-svg-icons"
 import usePermissions from "hooks/usePermissions"
+import { selectGroupMap } from "selectors/groups"
 
 /**
  * This is the list view of all the templates
  */
 const ResourceTemplateRow = ({ row, handleClick, handleCopy, handleEdit }) => {
   const { canCreate, canEdit } = usePermissions()
+  const groupMap = useSelector((state) => selectGroupMap(state))
 
   return (
     <tr key={row.id}>
@@ -32,6 +35,9 @@ const ResourceTemplateRow = ({ row, handleClick, handleCopy, handleEdit }) => {
       </td>
       <td style={{ wordBreak: "break-all" }}>{row.resourceURI}</td>
       <td style={{ wordBreak: "break-all" }}>{row.author}</td>
+      <td style={{ wordBreak: "break-all" }}>
+        {groupMap[row.group] || "Unknown"}
+      </td>
       <td>
         <LongDate datetime={row.date} timeZone="UTC" />
       </td>

--- a/src/components/templates/ResourceTemplateSearchResult.jsx
+++ b/src/components/templates/ResourceTemplateSearchResult.jsx
@@ -25,11 +25,12 @@ const ResourceTemplateSearchResult = (props) => {
         <table className="table table-bordered resource-template-list">
           <thead>
             <tr>
-              <th style={{ width: "30%" }}>Label / ID</th>
-              <th style={{ width: "20%" }}>Resource URI</th>
-              <th style={{ width: "12%" }}>Author</th>
+              <th style={{ width: "28%" }}>Label / ID</th>
+              <th style={{ width: "18%" }}>Resource URI</th>
+              <th style={{ width: "10%" }}>Author</th>
+              <th style={{ width: "8%" }}>Group</th>
               <th style={{ width: "10%" }}>Date</th>
-              <th style={{ width: "24%" }}>Guiding statement</th>
+              <th style={{ width: "22%" }}>Guiding statement</th>
               <th style={{ width: "4%" }} data-testid="action-col-header"></th>
             </tr>
           </thead>


### PR DESCRIPTION
## Why was this change made?

Fixes #3029 - add a column showing the group to resource lists (dashboard and recent)

## How was this change tested?

Localhost

## Which documentation and/or configurations were updated?



