### PR TITLE
show marc button on preview modal

### DIFF
--- a/src/components/ViewResourceModal.jsx
+++ b/src/components/ViewResourceModal.jsx
@@ -18,6 +18,7 @@ import {
 } from "selectors/resources"
 import ResourceComponent from "./editor/ResourceComponent"
 import usePermissions from "hooks/usePermissions"
+import MarcButton from "./editor/actions/MarcButton"
 
 const ViewResourceModal = (props) => {
   const dispatch = useDispatch()
@@ -85,6 +86,7 @@ const ViewResourceModal = (props) => {
             {currentResource && <ResourceComponent />}
           </div>
           <div className="modal-footer">
+            <MarcButton />
             {canEdit(currentResource) && (
               <button
                 className="btn btn-primary btn-view-resource"

--- a/src/components/editor/actions/MarcButton.jsx
+++ b/src/components/editor/actions/MarcButton.jsx
@@ -85,7 +85,7 @@ const MarcButton = () => {
   const dropDownItemBtnClasses = ["btn", "btn-secondary", "dropdown-item"]
 
   return (
-    <div className="btn-group dropstart">
+    <div className="view-resource-buttons btn-group dropstart">
       <button
         type="button"
         id="marcBtn"


### PR DESCRIPTION
## Why was this change made?

Fixes #3015 - show MARC button on the preview modal

Note: this uses the `<MarcButton>` component, which means the MARC button will only be shown for resources with templates of type `http://id.loc.gov/ontologies/bibframe/Instance`.  


## How was this change tested?

Localhost browser (at least verifying the button is shown).  Unclear to verify button operation works as expected.  Should we add another test?


## Which documentation and/or configurations were updated?



