### PR TITLE
show warning to a logged in user with no groups

### DIFF
--- a/__tests__/components/home/UserNotifications.test.js
+++ b/__tests__/components/home/UserNotifications.test.js
@@ -1,0 +1,31 @@
+// Copyright 2021 Stanford University see LICENSE for license
+
+import React from "react"
+import { screen } from "@testing-library/react"
+import UserNotifications from "components/home/UserNotifications"
+import { createStore, renderComponent } from "testUtils"
+import { createState } from "stateUtils"
+
+describe("<UserNotifications />", () => {
+  it("shows a warning if a logged in user is not in any groups", async () => {
+    const state = createState({ noGroups: true })
+    const store = createStore(state)
+    const { container } = renderComponent(<UserNotifications />, store)
+    await screen.findByText(/Before you can create/)
+    expect(container).not.toBeNull
+  })
+
+  it("does not show a warning if a logged in user is in at least one group", async () => {
+    const state = createState()
+    const store = createStore(state)
+    const { container } = renderComponent(<UserNotifications />, store)
+    expect(container).toBeNull
+  })
+
+  it("does not show a warning if there is no logged in user", async () => {
+    const state = createState({ notAuthenticated: true })
+    const store = createStore(state)
+    const { container } = renderComponent(<UserNotifications />, store)
+    expect(container).toBeNull
+  })
+})

--- a/src/components/home/NewsPanel.jsx
+++ b/src/components/home/NewsPanel.jsx
@@ -2,11 +2,15 @@
 
 import React from "react"
 import NewsItem from "./NewsItem"
+import UserNotifications from "./UserNotifications"
 import LoginPanel from "./LoginPanel"
 
 const NewsPanel = () => (
   <div className="banner container-fluid py-5">
     <div className="card panel-news">
+      <div className="col-md-12">
+        <UserNotifications />
+      </div>
       <div className="card-body">
         <div className="row">
           <div className="col-md-6">

--- a/src/components/home/UserNotifications.jsx
+++ b/src/components/home/UserNotifications.jsx
@@ -1,0 +1,32 @@
+// Copyright 2021 Stanford University see LICENSE for license
+
+import React from "react"
+import { useSelector } from "react-redux"
+import {
+  hasUser as hasUserSelector,
+  selectGroups,
+} from "selectors/authenticate"
+
+const UserNotifications = () => {
+  const hasUser = useSelector((state) => hasUserSelector(state))
+  const userGroups = useSelector((state) => selectGroups(state))
+
+  if (!hasUser) return null // nothing to show if not logged in
+  if (userGroups.length) return null // nothing to show if the user is logged in but is in at least one group
+
+  if (!userGroups.length) {
+    // show a message if the user is not in any groups
+    return (
+      <div className="alert alert-warning">
+        <strong>Note:</strong> Before you can create new resources or edit
+        existing resources, the Sinopia administrator will need to add you to a
+        permission group. Please contact&nbsp;
+        <a href="mailto:sinopia_admin@stanford.edu">
+          sinopia_admin@stanford.edu
+        </a>
+        &nbsp; to request edit permission.
+      </div>
+    )
+  }
+}
+export default UserNotifications

--- a/src/selectors/authenticate.js
+++ b/src/selectors/authenticate.js
@@ -2,4 +2,4 @@ export const hasUser = (state) => !!state.authenticate.user
 
 export const selectUser = (state) => state.authenticate.user
 
-export const selectGroups = (state) => state.authenticate.user.groups
+export const selectGroups = (state) => state.authenticate.user?.groups


### PR DESCRIPTION
## Why was this change made?

Fixes #3003 - show a warning to a user on the home page when they are not in any groups

## How was this change tested?

- Existing unit tests, and added a test for the new component
- Localhost browser (though had to temporarily fake it in the code to see the warning since I'm not sure how to remove myself from all groups or log in with a user that has no groups)

## Which documentation and/or configurations were updated?

**When a logged in user is in at least one group:** (behavior unchanged)

![Screen Shot 2021-09-23 at 2 59 14 PM](https://user-images.githubusercontent.com/47137/134590054-ad9a8165-5d8d-40fb-b213-a2046b225c81.png)

**When a logged in user is NOT in at least one group:** (new alert)

![Screen Shot 2021-09-23 at 2 58 57 PM](https://user-images.githubusercontent.com/47137/134590080-d562d43e-77d5-4c87-8f22-7b5da6efd882.png)


