### PR TITLE
set property as changed when updating language to enable save button

### DIFF
--- a/__tests__/reducers/languages.test.js
+++ b/__tests__/reducers/languages.test.js
@@ -48,6 +48,9 @@ describe("languagesReceived()", () => {
 describe("setLanguage", () => {
   it("sets value language", () => {
     const oldState = createState({ hasResourceWithLiteral: true })
+    const subjectKey = oldState.entities.properties["JQEtq-vmq8"].subjectKey
+    expect(oldState.entities.subjects[subjectKey].changed).toBeFalsy
+
     const action = {
       type: "LANGUAGE_SELECTED",
       payload: {
@@ -58,5 +61,6 @@ describe("setLanguage", () => {
 
     const newState = reducer(oldState.entities, action)
     expect(newState.values.CxGx7WMh2.lang).toBe("spa")
+    expect(newState.subjects[subjectKey].changed).toBeTruthy
   })
 })

--- a/src/reducers/languages.js
+++ b/src/reducers/languages.js
@@ -1,15 +1,22 @@
 // Copyright 2020 Stanford University see LICENSE for license
+import { setSubjectChanged } from "reducers/resources"
 
-export const setLanguage = (state, action) => ({
-  ...state,
-  values: {
-    ...state.values,
-    [action.payload.valueKey]: {
-      ...state.values[action.payload.valueKey],
-      lang: action.payload.lang,
+export const setLanguage = (state, action) => {
+  const valueKey = action.payload.valueKey
+  const value = state.values[valueKey]
+  const property = state.properties[value.propertyKey]
+  const newState = setSubjectChanged(state, property.subjectKey, true)
+  return {
+    ...newState,
+    values: {
+      ...newState.values,
+      [valueKey]: {
+        ...newState.values[valueKey],
+        lang: action.payload.lang,
+      },
     },
-  },
-})
+  }
+}
 
 export const languagesReceived = (state, action) => {
   const options = createOptions(action.payload)

--- a/src/reducers/resources.js
+++ b/src/reducers/resources.js
@@ -612,7 +612,7 @@ const stateWithNewValue = (state, valueKey) => ({
   },
 })
 
-const setSubjectChanged = (state, subjectKey, changed) => {
+export const setSubjectChanged = (state, subjectKey, changed) => {
   const newState = stateWithNewSubject(state, subjectKey)
   newState.subjects[subjectKey].changed = changed
 


### PR DESCRIPTION
## Why was this change made?

Fixes #3037 - enable the save button when a language is changed.  Similar fix to what happened in #2991

## How was this change tested?

Localhost browser

## Which documentation and/or configurations were updated?



