### PR TITLE
Removes special handling of ld4p group.

### DIFF
--- a/src/components/editor/GroupChoiceModal.jsx
+++ b/src/components/editor/GroupChoiceModal.jsx
@@ -19,10 +19,9 @@ import { selectGroups } from "selectors/authenticate"
 import { selectGroupMap } from "selectors/groups"
 import usePermissions from "hooks/usePermissions"
 
-// The ld4p group is only for templates
 const groupsToGroupValues = (groupIds, groupMap, ownerGroupId = null) =>
   groupIds
-    .filter((groupId) => ![ownerGroupId, "ld4p"].includes(groupId))
+    .filter((groupId) => ownerGroupId !== groupId)
     .sort((groupId1, groupId2) =>
       groupMap[groupId1].localeCompare(groupMap[groupId2])
     )


### PR DESCRIPTION
closes #3047

## Why was this change made?
Now it is just like every other group.


## How was this change tested?



## Which documentation and/or configurations were updated?



