### PR TITLE
Fix edit permissions on Dashboard.

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,10 @@ The following are only in the resource subject (that is, the base subject).
   remark: <remark>,
   date: <date>,
   suppressible: <true | false>,
-  propertyKeys: [key of property templates, ...]
+  propertyKeys: [key of property templates, ...],
+  group: <group that that template belongs to>,
+  editGroups: [groups that can edit the template],
+
 }
 ```
 

--- a/__tests__/TemplatesBuilder.test.js
+++ b/__tests__/TemplatesBuilder.test.js
@@ -14,7 +14,9 @@ describe("TemplatesBuilder", () => {
 <> <http://sinopia.io/vocabulary/hasResourceAttribute> <http://sinopia.io/vocabulary/resourceAttribute/suppressible> .`
 
     const dataset = await datasetFromN3(rdf)
-    const subjectTemplate = new TemplatesBuilder(dataset, "").build()
+    const subjectTemplate = new TemplatesBuilder(dataset, "", "stanford", [
+      "cornell",
+    ]).build()
     expect(subjectTemplate).toStrictEqual({
       key: "resourceTemplate:testing:uber1",
       id: "resourceTemplate:testing:uber1",
@@ -27,6 +29,8 @@ describe("TemplatesBuilder", () => {
       propertyTemplateKeys: [],
       propertyTemplates: [],
       suppressible: true,
+      group: "stanford",
+      editGroups: ["cornell"],
     })
   })
 

--- a/__tests__/__action_fixtures__/addSiblingValueSubject-ADD_VALUE.json
+++ b/__tests__/__action_fixtures__/addSiblingValueSubject-ADD_VALUE.json
@@ -49,6 +49,8 @@
               "class": "http://id.loc.gov/ontologies/bibframe/Uber2",
               "label": "Uber template2",
               "remark": "Template for testing purposes with single repeatable literal.",
+              "group": "stanford",
+              "editGroups": ["cornell"],
               "propertyTemplateKeys": [
                 "resourceTemplate:testing:uber2 > http://id.loc.gov/ontologies/bibframe/uber/template2/property1"
               ],

--- a/__tests__/__action_fixtures__/expandProperty-ADD_PROPERTY.json
+++ b/__tests__/__action_fixtures__/expandProperty-ADD_PROPERTY.json
@@ -37,6 +37,8 @@
             "label": "Abbreviated Title",
             "author": "LD4P",
             "date": "2019-08-19",
+            "group": "stanford",
+            "editGroups": ["cornell"],
             "propertyTemplateKeys": [
               "ld4p:RT:bf2:Title:AbbrTitle > http://id.loc.gov/ontologies/bibframe/mainTitle"
             ]

--- a/__tests__/__action_fixtures__/expandProperty-ADD_VALUE.json
+++ b/__tests__/__action_fixtures__/expandProperty-ADD_VALUE.json
@@ -39,6 +39,8 @@
             "class": "http://id.loc.gov/ontologies/bibframe/Uber1",
             "label": "Uber template1",
             "remark": "Template for testing purposes.",
+            "group": "stanford",
+            "editGroups": ["cornell"],
             "propertyTemplateKeys": [
               "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property1"
             ]
@@ -79,6 +81,8 @@
           "author": null,
           "remark": "Template for testing purposes with single repeatable literal.",
           "date": null,
+          "group": "stanford",
+          "editGroups": ["cornell"],
           "suppressible": false,
           "propertyTemplateKeys": [
             "resourceTemplate:testing:uber2 > http://id.loc.gov/ontologies/bibframe/uber/template2/property1"

--- a/__tests__/__action_fixtures__/loadResource-ADD_SUBJECT.json
+++ b/__tests__/__action_fixtures__/loadResource-ADD_SUBJECT.json
@@ -12,6 +12,8 @@
       "author": "Justin Littman",
       "remark": "Template for testing purposes.",
       "date": "2020-07-27",
+			"group": "stanford",
+			"editGroups": ["cornell"],
       "suppressible": false,
       "propertyTemplateKeys": [
         "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property1",
@@ -624,6 +626,8 @@
                 "author": null,
                 "remark": "Template for testing purposes with single repeatable literal.",
                 "date": null,
+								"group": "stanford",
+								"editGroups": ["cornell"],
                 "suppressible": false,
                 "propertyTemplateKeys": [
                   "resourceTemplate:testing:uber2 > http://id.loc.gov/ontologies/bibframe/uber/template2/property1"
@@ -710,6 +714,8 @@
                 "author": null,
                 "remark": "Template for testing purposes with multiple literal.",
                 "date": null,
+								"group": "stanford",
+								"editGroups": ["cornell"],
                 "suppressible": false,
                 "propertyTemplateKeys": [
                   "resourceTemplate:testing:uber3 > http://id.loc.gov/ontologies/bibframe/uber/template3/property1",
@@ -1003,6 +1009,8 @@
                 "author": null,
                 "remark": "Template for testing purposes with single repeatable, required literal.",
                 "date": null,
+								"group": "stanford",
+								"editGroups": ["cornell"],
                 "suppressible": false,
                 "propertyTemplateKeys": [
                   "resourceTemplate:testing:uber4 > http://id.loc.gov/ontologies/bibframe/uber/template4/property1"

--- a/__tests__/__action_fixtures__/loadResourceNestedResource-ADD_SUBJECT.json
+++ b/__tests__/__action_fixtures__/loadResourceNestedResource-ADD_SUBJECT.json
@@ -12,6 +12,8 @@
       "author": "Justin Littman",
       "remark": "Template for testing purposes.",
       "date": "2020-07-27",
+      "group": "stanford",
+      "editGroups": ["cornell"],
       "suppressible": false,
       "propertyTemplateKeys": [
         "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property1",
@@ -624,6 +626,8 @@
                 "author": null,
                 "remark": "Template for testing purposes with single repeatable literal.",
                 "date": null,
+                "group": "stanford",
+                "editGroups": ["cornell"],
                 "suppressible": false,
                 "propertyTemplateKeys": [
                   "resourceTemplate:testing:uber2 > http://id.loc.gov/ontologies/bibframe/uber/template2/property1"
@@ -674,6 +678,8 @@
                 "author": null,
                 "remark": "Template for testing purposes with multiple literal.",
                 "date": null,
+                "group": "stanford",
+                "editGroups": ["cornell"],
                 "suppressible": false,
                 "propertyTemplateKeys": [
                   "resourceTemplate:testing:uber3 > http://id.loc.gov/ontologies/bibframe/uber/template3/property1",
@@ -850,6 +856,8 @@
                 "author": null,
                 "remark": "Template for testing purposes with single repeatable, required literal.",
                 "date": null,
+                "group": "stanford",
+                "editGroups": ["cornell"],
                 "suppressible": false,
                 "propertyTemplateKeys": [
                   "resourceTemplate:testing:uber4 > http://id.loc.gov/ontologies/bibframe/uber/template4/property1"

--- a/__tests__/__action_fixtures__/newResource-ADD_SUBJECT.json
+++ b/__tests__/__action_fixtures__/newResource-ADD_SUBJECT.json
@@ -12,6 +12,8 @@
       "author": "Justin Littman",
       "remark": "Template for testing purposes.",
       "date": "2020-07-27",
+      "group": "stanford",
+      "editGroups": ["cornell"],
       "suppressible": false,
       "propertyTemplateKeys": [
         "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property1",
@@ -624,6 +626,8 @@
                 "author": null,
                 "remark": "Template for testing purposes with single repeatable literal.",
                 "date": null,
+                "group": "stanford",
+                "editGroups": ["cornell"],
                 "suppressible": false,
                 "propertyTemplateKeys": [
                   "resourceTemplate:testing:uber2 > http://id.loc.gov/ontologies/bibframe/uber/template2/property1"
@@ -674,6 +678,8 @@
                 "author": null,
                 "remark": "Template for testing purposes with multiple literal.",
                 "date": null,
+                "group": "stanford",
+                "editGroups": ["cornell"],
                 "suppressible": false,
                 "propertyTemplateKeys": [
                   "resourceTemplate:testing:uber3 > http://id.loc.gov/ontologies/bibframe/uber/template3/property1",
@@ -757,6 +763,8 @@
                 "author": null,
                 "remark": "Template for testing purposes with single repeatable literal.",
                 "date": null,
+                "group": "stanford",
+                "editGroups": ["cornell"],
                 "suppressible": false,
                 "propertyTemplateKeys": [
                   "resourceTemplate:testing:uber2 > http://id.loc.gov/ontologies/bibframe/uber/template2/property1"
@@ -807,6 +815,8 @@
                 "author": null,
                 "remark": "Template for testing purposes with multiple literal.",
                 "date": null,
+                "group": "stanford",
+                "editGroups": ["cornell"],
                 "suppressible": false,
                 "propertyTemplateKeys": [
                   "resourceTemplate:testing:uber3 > http://id.loc.gov/ontologies/bibframe/uber/template3/property1",
@@ -989,6 +999,8 @@
                 "author": null,
                 "remark": "Template for testing purposes with single repeatable, required literal.",
                 "date": null,
+                "group": "stanford",
+                "editGroups": ["cornell"],
                 "suppressible": false,
                 "propertyTemplateKeys": [
                   "resourceTemplate:testing:uber4 > http://id.loc.gov/ontologies/bibframe/uber/template4/property1"
@@ -1045,6 +1057,8 @@
                 "author": null,
                 "remark": "Template for testing purposes with single repeatable, required literal.",
                 "date": null,
+                "group": "stanford",
+                "editGroups": ["cornell"],
                 "suppressible": false,
                 "propertyTemplateKeys": [
                   "resourceTemplate:testing:uber4 > http://id.loc.gov/ontologies/bibframe/uber/template4/property1"
@@ -1148,6 +1162,8 @@
                 "author": null,
                 "remark": "Template for testing purposes with suppressed, repeatable URI.",
                 "date": null,
+                "group": "stanford",
+                "editGroups": ["cornell"],
                 "suppressible": true,
                 "propertyTemplateKeys": [
                   "resourceTemplate:testing:uber5 > http://id.loc.gov/ontologies/bibframe/uber/template5/property1"

--- a/__tests__/__action_fixtures__/newResourceCopy-ADD_SUBJECT.json
+++ b/__tests__/__action_fixtures__/newResourceCopy-ADD_SUBJECT.json
@@ -25,6 +25,8 @@
           "label": "Abbreviated Title",
           "author": "LD4P",
           "date": "2019-08-19",
+          "group": "stanford",
+          "editGroups": ["cornell"],
           "propertyTemplateKeys": [
             "ld4p:RT:bf2:Title:AbbrTitle > http://id.loc.gov/ontologies/bibframe/mainTitle"
           ]

--- a/__tests__/__action_fixtures__/newResourceFromDataset-ADD_SUBJECT.json
+++ b/__tests__/__action_fixtures__/newResourceFromDataset-ADD_SUBJECT.json
@@ -12,6 +12,8 @@
       "author": "Justin Littman",
       "remark": "Template for testing purposes.",
       "date": "2020-07-27",
+      "group": "stanford",
+      "editGroups": ["cornell"],
       "suppressible": false,
       "propertyTemplateKeys": [
         "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property1",
@@ -624,6 +626,8 @@
                 "author": null,
                 "remark": "Template for testing purposes with single repeatable literal.",
                 "date": null,
+                "group": "stanford",
+                "editGroups": ["cornell"],
                 "suppressible": false,
                 "propertyTemplateKeys": [
                   "resourceTemplate:testing:uber2 > http://id.loc.gov/ontologies/bibframe/uber/template2/property1"
@@ -710,6 +714,8 @@
                 "author": null,
                 "remark": "Template for testing purposes with multiple literal.",
                 "date": null,
+                "group": "stanford",
+                "editGroups": ["cornell"],
                 "suppressible": false,
                 "propertyTemplateKeys": [
                   "resourceTemplate:testing:uber3 > http://id.loc.gov/ontologies/bibframe/uber/template3/property1",
@@ -922,6 +928,8 @@
                 "author": null,
                 "remark": "Template for testing purposes with single repeatable, required literal.",
                 "date": null,
+                "group": "stanford",
+                "editGroups": ["cornell"],
                 "suppressible": false,
                 "propertyTemplateKeys": [
                   "resourceTemplate:testing:uber4 > http://id.loc.gov/ontologies/bibframe/uber/template4/property1"
@@ -1013,6 +1021,8 @@
                 "author": null,
                 "remark": "Template for testing purposes with suppressed, repeatable URI.",
                 "date": null,
+                "group": "stanford",
+                "editGroups": ["cornell"],
                 "suppressible": true,
                 "propertyTemplateKeys": [
                   "resourceTemplate:testing:uber5 > http://id.loc.gov/ontologies/bibframe/uber/template5/property1"

--- a/__tests__/reducers/history.test.js
+++ b/__tests__/reducers/history.test.js
@@ -20,6 +20,8 @@ describe("addTemplateHistory", () => {
     author: "LD4P",
     remark: "Library of Congress Card Number",
     date: "2019-08-19",
+    group: "stanford",
+    editGroups: ["cornell"],
   }
 
   it("transforms to a result", () => {
@@ -35,6 +37,8 @@ describe("addTemplateHistory", () => {
         resourceLabel: "LCCN",
         resourceURI: "http://id.loc.gov/ontologies/bibframe/Lccn",
         uri: "http://localhost:3000/resource/ld4p:RT:bf2:Identifiers:LCCN",
+        group: "stanford",
+        editGroups: ["cornell"],
       },
     ])
   })
@@ -104,6 +108,8 @@ describe("addTemplateHistoryByResult", () => {
     resourceLabel: "LCCN",
     resourceURI: "http://id.loc.gov/ontologies/bibframe/Lccn",
     uri: "http://localhost:3000/resource/ld4p:RT:bf2:Identifiers:LCCN",
+    group: "stanford",
+    editGroups: ["cornell"],
   }
 
   it("adds to historical templates", () => {
@@ -137,6 +143,7 @@ describe("addResourceHistoryByResult", () => {
     type: ["http://id.loc.gov/ontologies/bibframe/TableOfContents"],
     modified: "2020-10-05T14:31:16.612Z",
     group: "stanford",
+    editGroups: ["cornell"],
   }
 
   it("adds to historical resources", () => {
@@ -154,7 +161,8 @@ describe("addResourceHistory", () => {
     resourceUri:
       "http://localhost:3000/resource/f383bfff-5364-47a3-a081-8c9e2d79f43f",
     type: "http://id.loc.gov/ontologies/bibframe/TableOfContents",
-    group: "cornell",
+    group: "stanford",
+    editGroups: ["cornell"],
     modified: "2020-10-05T14:38:19.704Z",
   }
 
@@ -169,7 +177,8 @@ describe("addResourceHistory", () => {
           "http://localhost:3000/resource/f383bfff-5364-47a3-a081-8c9e2d79f43f",
         type: ["http://id.loc.gov/ontologies/bibframe/TableOfContents"],
         modified: "2020-10-05T14:38:19.704Z",
-        group: "cornell",
+        group: "stanford",
+        editGroups: ["cornell"],
       },
     ])
   })

--- a/__tests__/testUtilities/stateUtils.js
+++ b/__tests__/testUtilities/stateUtils.js
@@ -106,6 +106,8 @@ const buildTemplateWithLiteral = (state, options) => {
       author: null,
       remark: null,
       date: null,
+      group: "stanford",
+      editGroups: ["cornell"],
       propertyTemplateKeys: [
         "sinopia:template:resource > http://www.w3.org/2000/01/rdf-schema#label",
       ],
@@ -199,6 +201,8 @@ const buildResourceWithLiteral = (state, options) => {
       label: "Abbreviated Title",
       author: "LD4P",
       date: "2019-08-19",
+      group: "stanford",
+      editGroups: ["cornell"],
       propertyTemplateKeys: [
         "ld4p:RT:bf2:Title:AbbrTitle > http://id.loc.gov/ontologies/bibframe/mainTitle",
       ],
@@ -283,6 +287,8 @@ const buildTwoLiteralResources = (state, options) => {
       label: "Abbreviated Title",
       author: "LD4P",
       date: "2019-08-19",
+      group: "stanford",
+      editGroups: ["cornell"],
       propertyTemplateKeys: [
         "ld4p:RT:bf2:Title:AbbrTitle > http://id.loc.gov/ontologies/bibframe/mainTitle",
       ],
@@ -294,6 +300,8 @@ const buildTwoLiteralResources = (state, options) => {
       label: "Note",
       author: "LD4P",
       date: "2019-08-19",
+      group: "stanford",
+      editGroups: ["cornell"],
       propertyTemplateKeys: [
         "ld4p:RT:bf2:Note > http://id.loc.gov/ontologies/bibframe/note",
       ],
@@ -426,6 +434,8 @@ const buildResourceWithUri = (state, options) => {
       author: null,
       remark: "This hits elasticsearch",
       date: null,
+      group: "stanford",
+      editGroups: ["cornell"],
       propertyTemplateKeys: [
         "test:resource:SinopiaLookup > http://id.loc.gov/ontologies/bibframe/instanceOf",
       ],
@@ -526,6 +536,8 @@ const buildResourceWithContractedLiteral = (state, options) => {
       label: "Abbreviated Title",
       author: "LD4P",
       date: "2019-08-19",
+      group: "stanford",
+      editGroups: ["cornell"],
       propertyTemplateKeys: [
         "ld4p:RT:bf2:Title:AbbrTitle > http://id.loc.gov/ontologies/bibframe/mainTitle",
       ],
@@ -597,6 +609,8 @@ const buildResourceWithNestedResource = (state, options) => {
       class: "http://id.loc.gov/ontologies/bibframe/Uber1",
       label: "Uber template1",
       remark: "Template for testing purposes.",
+      group: "stanford",
+      editGroups: ["cornell"],
       propertyTemplateKeys: [
         "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property1",
       ],
@@ -607,6 +621,8 @@ const buildResourceWithNestedResource = (state, options) => {
       class: "http://id.loc.gov/ontologies/bibframe/Uber2",
       label: "Uber template2",
       remark: "Template for testing purposes with single repeatable literal.",
+      group: "stanford",
+      editGroups: ["cornell"],
       propertyTemplateKeys: [
         "resourceTemplate:testing:uber2 > http://id.loc.gov/ontologies/bibframe/uber/template2/property1",
       ],
@@ -742,6 +758,8 @@ const buildResourceWithContractedNestedResource = (state, options) => {
       class: "http://id.loc.gov/ontologies/bibframe/Uber1",
       label: "Uber template1",
       remark: "Template for testing purposes.",
+      group: "stanford",
+      editGroups: ["cornell"],
       propertyTemplateKeys: [
         "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property1",
       ],
@@ -851,6 +869,8 @@ const buildResourceWithTwoNestedResources = (state, options) => {
       class: "http://id.loc.gov/ontologies/bibframe/Uber1",
       label: "Uber template1",
       remark: "Template for testing purposes.",
+      group: "stanford",
+      editGroups: ["cornell"],
       propertyTemplateKeys: [
         "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property1",
       ],
@@ -861,6 +881,8 @@ const buildResourceWithTwoNestedResources = (state, options) => {
       class: "http://id.loc.gov/ontologies/bibframe/Uber2",
       label: "Uber template2",
       remark: "Template for testing purposes with single repeatable literal.",
+      group: "stanford",
+      editGroups: ["cornell"],
       propertyTemplateKeys: [
         "resourceTemplate:testing:uber2 > http://id.loc.gov/ontologies/bibframe/uber/template2/property1",
       ],

--- a/src/TemplatesBuilder.js
+++ b/src/TemplatesBuilder.js
@@ -3,11 +3,13 @@ import { findAuthorityConfig } from "utilities/authorityConfig"
 import rdf from "rdf-ext"
 
 export default class TemplatesBuilder {
-  constructor(dataset, uri) {
+  constructor(dataset, uri, group = null, editGroups = []) {
     this.dataset = dataset
     this.uri = uri
     this.resourceTerm = rdf.namedNode(uri)
     this.subjectTemplate = null
+    this.group = group
+    this.editGroups = editGroups
   }
 
   /**
@@ -60,6 +62,8 @@ export default class TemplatesBuilder {
       ),
       propertyTemplateKeys: [],
       propertyTemplates: [],
+      group: this.group,
+      editGroups: this.editGroups,
     }
   }
 

--- a/src/actionCreators/templates.js
+++ b/src/actionCreators/templates.js
@@ -62,10 +62,12 @@ export const loadResourceTemplateWithoutValidation =
     const templateUri = `${Config.sinopiaApiBase}/resource/${resourceTemplateId}`
 
     const newResourceTemplatePromise = fetchResource(templateUri, true).then(
-      ([dataset]) => {
+      ([dataset, response]) => {
         const subjectTemplate = new TemplatesBuilder(
           dataset,
-          templateUri
+          templateUri,
+          response.group,
+          response.editGroups
         ).build()
         dispatch(addTemplates(subjectTemplate))
         return subjectTemplate

--- a/src/reducers/history.js
+++ b/src/reducers/history.js
@@ -16,6 +16,8 @@ export const addTemplateHistory = (state, action) => {
     author: template.author,
     remark: template.remark,
     date: template.date,
+    group: template.group,
+    editGroups: template.editGroups,
   }
   return addTemplateResult(state, result)
 }
@@ -53,6 +55,7 @@ export const addResourceHistory = (state, action) => {
     type: [action.payload.type],
     modified: action.payload.modified,
     group: action.payload.group,
+    editGroups: action.payload.editGroups,
   }
   return addResourceResult(state, result)
 }


### PR DESCRIPTION
closes #3038

## Why was this change made?
The permissions on the dashboard should be consistent with rest of app.


## How was this change tested?
Unit, local


## Which documentation and/or configurations were updated?
README


