### PR TITLE
Omit empty properties in preview.

### DIFF
--- a/__tests__/feature/searchAndViewResource.test.js
+++ b/__tests__/feature/searchAndViewResource.test.js
@@ -83,6 +83,12 @@ describe("searching and viewing a resource", () => {
       selector: "p",
     })
 
+    // Only properties with values are displayed.
+    screen.getByText("Uber template1, property9")
+    expect(
+      screen.queryByText("Uber template1, property7")
+    ).not.toBeInTheDocument()
+
     // Edit controls are disabled in view modal
     expect(screen.getByTestId("Remove analog")).toBeDisabled()
     screen.getAllByTestId(/Submit lookup/).forEach((lookupValueControl) => {

--- a/src/components/editor/property/PanelProperty.jsx
+++ b/src/components/editor/property/PanelProperty.jsx
@@ -19,6 +19,7 @@ import {
 import { selectPropertyTemplate } from "selectors/templates"
 import useNavigableComponent from "hooks/useNavigableComponent"
 import { nanoid } from "nanoid"
+import _ from "lodash"
 
 const PanelProperty = (props) => {
   // Null values indicates that can be added.
@@ -43,6 +44,10 @@ const PanelProperty = (props) => {
 
   // used to associate the PropertyComponent field to be labeled with the PropertyLabel
   const propertyLabelId = `labelled-by-${nanoid()}`
+
+  // On preview, don't display empty properties.
+  if (readOnly && _.isEmpty(props.property.descUriOrLiteralValueKeys))
+    return null
 
   // onClick is to support left navigation, so ignoring jsx-ally seems reasonable.
   /* eslint-disable jsx-a11y/click-events-have-key-events */


### PR DESCRIPTION
closes #3054

## Why was this change made?
Empty headers aren't very helpful in a preview.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?



