### PR TITLE
root resource subject state can have rdfs label assigned

### DIFF
--- a/__tests__/__action_fixtures__/loadResource-ADD_SUBJECT.json
+++ b/__tests__/__action_fixtures__/loadResource-ADD_SUBJECT.json
@@ -17,7 +17,35 @@
         "cornell"
       ],        
 			"suppressible": false,
-			"propertyTemplateKeys": ["resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property1", "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property2", "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property3", "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property4", "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property5", "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property6", "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property7", "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property8", "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property9", "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property10", "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property11", "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property12", "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property13", "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property14", "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property15", "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property16", "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property17", "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property18", "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property19", "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/adminMetadata", "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/hasInstance", "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/instanceOf", "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/hasItem", "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/itemOf", "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property20", "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property21"],
+			"propertyTemplateKeys": [
+				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property1", 
+				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property2", 
+				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property3", 
+				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property4", 
+				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property5", 
+				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property6", 
+				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property7", 
+				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property8", 
+				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property9", 
+				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property10", 
+				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property11", 
+				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property12", 
+				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property13", 
+				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property14", 
+				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property15", 
+				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property16",
+				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property17",
+				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property18",
+				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property19", 
+				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/adminMetadata", 
+				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/hasInstance", 
+				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/instanceOf", 
+				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/hasItem", 
+				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/itemOf", 
+				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property20", 
+				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property21", 
+				"resourceTemplate:testing:uber1 > http://www.w3.org/2000/01/rdf-schema#label"
+			],
 			"propertyTemplates": [{
 				"key": "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property1",
 				"subjectTemplateKey": "resourceTemplate:testing:uber1",
@@ -501,18 +529,33 @@
 				"authorities": [],
 				"type": "resource",
 				"component": "NestedResource"
+			}, {
+				"key": "resourceTemplate:testing:uber1 > http://www.w3.org/2000/01/rdf-schema#label",
+				"subjectTemplateKey": "resourceTemplate:testing:uber1",
+				"label": "rdfs label",
+				"uri": "http://www.w3.org/2000/01/rdf-schema#label",
+				"required": false,
+				"repeatable": false,
+				"ordered": false,
+				"remark": "rdfs label",
+				"remarkUrl": null,
+				"defaults": [],
+				"valueSubjectTemplateKeys": [],
+				"authorities": [],
+				"type": "literal",
+				"component": "InputLiteral"
 			}]
 		},
 		"properties": [{
 			"key": "abc1",
 			"values": [{
-				"key": "abc65",
+				"key": "abc67",
 				"literal": null,
 				"lang": null,
 				"uri": null,
 				"label": null,
 				"valueSubject": {
-					"key": "abc44",
+					"key": "abc46",
 					"uri": null,
 					"subjectTemplate": {
 						"key": "resourceTemplate:testing:uber2",
@@ -547,10 +590,32 @@
 						}]
 					},
 					"properties": [{
-						"key": "abc51",
+						"key": "abc53",
 						"values": [{
-							"key": "abc59",
+							"key": "abc61",
 							"literal": "Uber template2, property1",
+							"lang": "eng",
+							"uri": null,
+							"label": null,
+							"valueSubject": null
+						}],
+						"show": false
+					}]
+				}
+			}, {
+				"key": "abc68",
+				"literal": null,
+				"lang": null,
+				"uri": null,
+				"label": null,
+				"valueSubject": {
+					"key": "abc47",
+					"uri": null,
+					"properties": [{
+						"key": "abc54",
+						"values": [{
+							"key": "abc62",
+							"literal": "Uber template2, property1b",
 							"lang": "eng",
 							"uri": null,
 							"label": null,
@@ -567,28 +632,6 @@
 				"label": null,
 				"valueSubject": {
 					"key": "abc45",
-					"uri": null,
-					"properties": [{
-						"key": "abc52",
-						"values": [{
-							"key": "abc60",
-							"literal": "Uber template2, property1b",
-							"lang": "eng",
-							"uri": null,
-							"label": null,
-							"valueSubject": null
-						}],
-						"show": false
-					}]
-				}
-			}, {
-				"key": "abc64",
-				"literal": null,
-				"lang": null,
-				"uri": null,
-				"label": null,
-				"valueSubject": {
-					"key": "abc43",
 					"uri": null,
 					"subjectTemplate": {
 						"key": "resourceTemplate:testing:uber3",
@@ -638,9 +681,9 @@
 						}]
 					},
 					"properties": [{
-						"key": "abc49",
+						"key": "abc51",
 						"values": [{
-							"key": "abc56",
+							"key": "abc58",
 							"literal": "Uber template3, property1",
 							"lang": "eng",
 							"uri": null,
@@ -649,16 +692,16 @@
 						}],
 						"show": false
 					}, {
-						"key": "abc50",
+						"key": "abc52",
 						"values": [{
-							"key": "abc57",
+							"key": "abc59",
 							"literal": "Uber template3, property2, value1",
 							"lang": "eng",
 							"uri": null,
 							"label": null,
 							"valueSubject": null
 						}, {
-							"key": "abc58",
+							"key": "abc60",
 							"literal": "Uber template3, property2, value2",
 							"lang": "eng",
 							"uri": null,
@@ -673,7 +716,7 @@
 		}, {
 			"key": "abc2",
 			"values": [{
-				"key": "abc30",
+				"key": "abc31",
 				"literal": "Uber template1, property2",
 				"lang": "eng",
 				"uri": null,
@@ -688,7 +731,7 @@
 		}, {
 			"key": "abc4",
 			"values": [{
-				"key": "abc31",
+				"key": "abc32",
 				"literal": "Uber template1, property4",
 				"lang": "eng",
 				"uri": null,
@@ -699,7 +742,7 @@
 		}, {
 			"key": "abc5",
 			"values": [{
-				"key": "abc32",
+				"key": "abc33",
 				"literal": null,
 				"lang": "eng",
 				"uri": "http://example.edu/ubertemplate1:property5",
@@ -710,7 +753,7 @@
 		}, {
 			"key": "abc6",
 			"values": [{
-				"key": "abc33",
+				"key": "abc34",
 				"literal": null,
 				"lang": null,
 				"uri": "ubertemplate1:property6",
@@ -729,7 +772,7 @@
 		}, {
 			"key": "abc9",
 			"values": [{
-				"key": "abc34",
+				"key": "abc35",
 				"literal": "Uber template1, property9",
 				"lang": "eng",
 				"uri": null,
@@ -740,7 +783,7 @@
 		}, {
 			"key": "abc10",
 			"values": [{
-				"key": "abc35",
+				"key": "abc36",
 				"literal": null,
 				"lang": null,
 				"uri": "http://id.loc.gov/vocabulary/mrectype/analog",
@@ -751,7 +794,7 @@
 		}, {
 			"key": "abc11",
 			"values": [{
-				"key": "abc36",
+				"key": "abc37",
 				"literal": null,
 				"lang": null,
 				"uri": "http://id.loc.gov/vocabulary/mrectype/digital",
@@ -762,7 +805,7 @@
 		}, {
 			"key": "abc12",
 			"values": [{
-				"key": "abc37",
+				"key": "abc38",
 				"literal": null,
 				"lang": null,
 				"uri": "http://id.loc.gov/vocabulary/mrecmedium/mag",
@@ -773,7 +816,7 @@
 		}, {
 			"key": "abc13",
 			"values": [{
-				"key": "abc38",
+				"key": "abc39",
 				"literal": null,
 				"lang": null,
 				"uri": "http://aims.fao.org/aos/agrovoc/c_35856",
@@ -784,7 +827,7 @@
 		}, {
 			"key": "abc14",
 			"values": [{
-				"key": "abc39",
+				"key": "abc40",
 				"literal": null,
 				"lang": null,
 				"uri": "http://aims.fao.org/aos/agrovoc/c_331388",
@@ -795,7 +838,7 @@
 		}, {
 			"key": "abc15",
 			"values": [{
-				"key": "abc40",
+				"key": "abc41",
 				"literal": null,
 				"lang": null,
 				"uri": "http://sws.geonames.org/5098279/",
@@ -806,7 +849,7 @@
 		}, {
 			"key": "abc16",
 			"values": [{
-				"key": "abc41",
+				"key": "abc42",
 				"literal": null,
 				"lang": null,
 				"uri": "http://localhost:3000/resource/c7db5404-7d7d-40ac-b38e-c821d2c3ae3f",
@@ -817,7 +860,7 @@
 		}, {
 			"key": "abc17",
 			"values": [{
-				"key": "abc42",
+				"key": "abc43",
 				"literal": null,
 				"lang": null,
 				"uri": "http://localhost:3000/resource/c7db5404-7d7d-40ac-b38e-c821d2c3ae3f",
@@ -828,13 +871,13 @@
 		}, {
 			"key": "abc18",
 			"values": [{
-				"key": "abc67",
+				"key": "abc69",
 				"literal": null,
 				"lang": null,
 				"uri": null,
 				"label": null,
 				"valueSubject": {
-					"key": "abc46",
+					"key": "abc48",
 					"uri": null,
 					"subjectTemplate": {
 						"key": "resourceTemplate:testing:uber4",
@@ -869,9 +912,9 @@
 						}]
 					},
 					"properties": [{
-						"key": "abc53",
+						"key": "abc55",
 						"values": [{
-							"key": "abc61",
+							"key": "abc63",
 							"literal": "Uber template4, property1",
 							"lang": "eng",
 							"uri": null,
@@ -886,18 +929,18 @@
 		}, {
 			"key": "abc20",
 			"values": [{
-				"key": "abc68",
+				"key": "abc70",
 				"literal": null,
 				"lang": null,
 				"uri": null,
 				"label": null,
 				"valueSubject": {
-					"key": "abc47",
+					"key": "abc49",
 					"uri": null,
 					"properties": [{
-						"key": "abc54",
+						"key": "abc56",
 						"values": [{
-							"key": "abc62",
+							"key": "abc64",
 							"literal": "Uber template4, property1, first",
 							"lang": "eng",
 							"uri": null,
@@ -908,18 +951,18 @@
 					}]
 				}
 			}, {
-				"key": "abc69",
+				"key": "abc71",
 				"literal": null,
 				"lang": null,
 				"uri": null,
 				"label": null,
 				"valueSubject": {
-					"key": "abc48",
+					"key": "abc50",
 					"uri": null,
 					"properties": [{
-						"key": "abc55",
+						"key": "abc57",
 						"values": [{
-							"key": "abc63",
+							"key": "abc65",
 							"literal": "Uber template4, property1, second",
 							"lang": "eng",
 							"uri": null,
@@ -959,6 +1002,17 @@
 			"key": "abc27",
 			"values": null,
 			"show": false
+		}, {
+			"key": "abc28",
+			"show": false,
+			"values": [{
+				"key": "abc44",
+				"literal": "foo",
+				"label": null,
+				"lang": "",
+				"uri": null,
+				"valueSubject": null
+			}]
 		}],
 		"group": "stanford",
 		"editGroups": ["cornell"]

--- a/__tests__/__action_fixtures__/loadResourceNestedResource-ADD_SUBJECT.json
+++ b/__tests__/__action_fixtures__/loadResourceNestedResource-ADD_SUBJECT.json
@@ -41,7 +41,8 @@
         "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/hasItem",
         "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/itemOf",
         "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property20",
-        "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property21"
+        "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property21",
+        "resourceTemplate:testing:uber1 > http://www.w3.org/2000/01/rdf-schema#label"
       ],
       "propertyTemplates": [
         {
@@ -601,6 +602,22 @@
           "authorities": [],
           "type": "resource",
           "component": "NestedResource"
+        },
+        {
+          "key": "resourceTemplate:testing:uber1 > http://www.w3.org/2000/01/rdf-schema#label",
+          "subjectTemplateKey": "resourceTemplate:testing:uber1",
+          "label": "rdfs label",
+          "uri": "http://www.w3.org/2000/01/rdf-schema#label",
+          "required": false,
+          "repeatable": false,
+          "ordered": false,
+          "remark": "rdfs label",
+          "remarkUrl": null,
+          "defaults": [],
+          "valueSubjectTemplateKeys": [],
+          "authorities": [],
+          "type": "literal",
+          "component": "InputLiteral"
         }
       ]
     },
@@ -609,13 +626,13 @@
         "key": "abc1",
         "values": [
           {
-            "key": "abc41",
+            "key": "abc42",
             "literal": null,
             "lang": null,
             "uri": null,
             "label": null,
             "valueSubject": {
-              "key": "abc36",
+              "key": "abc37",
               "uri": null,
               "subjectTemplate": {
                 "key": "resourceTemplate:testing:uber2",
@@ -653,7 +670,7 @@
               },
               "properties": [
                 {
-                  "key": "abc38",
+                  "key": "abc39",
                   "values": null,
                   "show": false
                 }
@@ -661,13 +678,13 @@
             }
           },
           {
-            "key": "abc35",
+            "key": "abc36",
             "literal": null,
             "lang": null,
             "uri": null,
             "label": null,
             "valueSubject": {
-              "key": "abc30",
+              "key": "abc31",
               "uri": null,
               "subjectTemplate": {
                 "key": "resourceTemplate:testing:uber3",
@@ -722,10 +739,10 @@
               },
               "properties": [
                 {
-                  "key": "abc31",
+                  "key": "abc32",
                   "values": [
                     {
-                      "key": "abc33",
+                      "key": "abc34",
                       "literal": "Uber template3, property1",
                       "lang": "eng",
                       "uri": null,
@@ -736,10 +753,10 @@
                   "show": false
                 },
                 {
-                  "key": "abc32",
+                  "key": "abc33",
                   "values": [
                     {
-                      "key": "abc34",
+                      "key": "abc35",
                       "literal": "Uber template3, property2",
                       "lang": "eng",
                       "uri": null,
@@ -839,7 +856,7 @@
         "key": "abc18",
         "values": [
           {
-            "key": "abc29",
+            "key": "abc30",
             "literal": null,
             "lang": null,
             "uri": null,
@@ -883,7 +900,7 @@
               },
               "properties": [
                 {
-                  "key": "abc28",
+                  "key": "abc29",
                   "values": [],
                   "show": true
                 }
@@ -930,6 +947,11 @@
       },
       {
         "key": "abc27",
+        "values": null,
+        "show": false
+      },
+      {
+        "key": "abc28",
         "values": null,
         "show": false
       }

--- a/__tests__/__action_fixtures__/newResource-ADD_SUBJECT.json
+++ b/__tests__/__action_fixtures__/newResource-ADD_SUBJECT.json
@@ -41,7 +41,8 @@
         "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/hasItem",
         "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/itemOf",
         "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property20",
-        "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property21"
+        "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property21",
+        "resourceTemplate:testing:uber1 > http://www.w3.org/2000/01/rdf-schema#label"
       ],
       "propertyTemplates": [
         {
@@ -601,6 +602,22 @@
           "authorities": [],
           "type": "resource",
           "component": "NestedResource"
+        },
+        {
+          "key": "resourceTemplate:testing:uber1 > http://www.w3.org/2000/01/rdf-schema#label",
+          "subjectTemplateKey": "resourceTemplate:testing:uber1",
+          "label": "rdfs label",
+          "uri": "http://www.w3.org/2000/01/rdf-schema#label",
+          "required": false,
+          "repeatable": false,
+          "ordered": false,
+          "remark": "rdfs label",
+          "remarkUrl": null,
+          "defaults": [],
+          "valueSubjectTemplateKeys": [],
+          "authorities": [],
+          "type": "literal",
+          "component": "InputLiteral"
         }
       ]
     },
@@ -609,150 +626,13 @@
         "key": "abc1",
         "values": [
           {
-            "key": "abc58",
-            "literal": null,
-            "lang": null,
-            "uri": null,
-            "label": null,
-            "valueSubject": {
-              "key": "abc36",
-              "uri": null,
-              "subjectTemplate": {
-                "key": "resourceTemplate:testing:uber2",
-                "uri": "http://localhost:3000/resource/resourceTemplate:testing:uber2",
-                "id": "resourceTemplate:testing:uber2",
-                "class": "http://id.loc.gov/ontologies/bibframe/Uber2",
-                "label": "Uber template2",
-                "author": null,
-                "remark": "Template for testing purposes with single repeatable literal.",
-                "date": null,
-                "group": "stanford",
-                "editGroups": ["cornell"],
-                "suppressible": false,
-                "propertyTemplateKeys": [
-                  "resourceTemplate:testing:uber2 > http://id.loc.gov/ontologies/bibframe/uber/template2/property1"
-                ],
-                "propertyTemplates": [
-                  {
-                    "key": "resourceTemplate:testing:uber2 > http://id.loc.gov/ontologies/bibframe/uber/template2/property1",
-                    "subjectTemplateKey": "resourceTemplate:testing:uber2",
-                    "label": "Uber template2, property1",
-                    "uri": "http://id.loc.gov/ontologies/bibframe/uber/template2/property1",
-                    "required": false,
-                    "repeatable": true,
-                    "ordered": false,
-                    "remark": "A repeatable literal",
-                    "remarkUrl": null,
-                    "defaults": [],
-                    "valueSubjectTemplateKeys": [],
-                    "authorities": [],
-                    "type": "literal",
-                    "component": "InputLiteral"
-                  }
-                ]
-              },
-              "properties": [
-                {
-                  "key": "abc49",
-                  "values": null,
-                  "show": false
-                }
-              ]
-            }
-          },
-          {
-            "key": "abc61",
-            "literal": null,
-            "lang": null,
-            "uri": null,
-            "label": null,
-            "valueSubject": {
-              "key": "abc37",
-              "uri": null,
-              "subjectTemplate": {
-                "key": "resourceTemplate:testing:uber3",
-                "uri": "http://localhost:3000/resource/resourceTemplate:testing:uber3",
-                "id": "resourceTemplate:testing:uber3",
-                "class": "http://id.loc.gov/ontologies/bibframe/Uber3",
-                "label": "Uber template3",
-                "author": null,
-                "remark": "Template for testing purposes with multiple literal.",
-                "date": null,
-                "group": "stanford",
-                "editGroups": ["cornell"],
-                "suppressible": false,
-                "propertyTemplateKeys": [
-                  "resourceTemplate:testing:uber3 > http://id.loc.gov/ontologies/bibframe/uber/template3/property1",
-                  "resourceTemplate:testing:uber3 > http://id.loc.gov/ontologies/bibframe/uber/template3/property2"
-                ],
-                "propertyTemplates": [
-                  {
-                    "key": "resourceTemplate:testing:uber3 > http://id.loc.gov/ontologies/bibframe/uber/template3/property1",
-                    "subjectTemplateKey": "resourceTemplate:testing:uber3",
-                    "label": "Uber template3, property1",
-                    "uri": "http://id.loc.gov/ontologies/bibframe/uber/template3/property1",
-                    "required": false,
-                    "repeatable": true,
-                    "ordered": false,
-                    "remark": "A literal",
-                    "remarkUrl": null,
-                    "defaults": [],
-                    "valueSubjectTemplateKeys": [],
-                    "authorities": [],
-                    "type": "literal",
-                    "component": "InputLiteral"
-                  },
-                  {
-                    "key": "resourceTemplate:testing:uber3 > http://id.loc.gov/ontologies/bibframe/uber/template3/property2",
-                    "subjectTemplateKey": "resourceTemplate:testing:uber3",
-                    "label": "Uber template3, property2",
-                    "uri": "http://id.loc.gov/ontologies/bibframe/uber/template3/property2",
-                    "required": false,
-                    "repeatable": true,
-                    "ordered": false,
-                    "remark": null,
-                    "remarkUrl": "http://access.rdatoolkit.org/1.0.html",
-                    "defaults": [],
-                    "valueSubjectTemplateKeys": [],
-                    "authorities": [],
-                    "type": "literal",
-                    "component": "InputLiteral"
-                  }
-                ]
-              },
-              "properties": [
-                {
-                  "key": "abc54",
-                  "values": null,
-                  "show": false
-                },
-                {
-                  "key": "abc55",
-                  "values": null,
-                  "show": false
-                }
-              ]
-            }
-          }
-        ],
-        "show": true
-      },
-      {
-        "key": "abc2",
-        "values": [],
-        "show": true
-      },
-      {
-        "key": "abc3",
-        "values": [
-          {
             "key": "abc59",
             "literal": null,
             "lang": null,
             "uri": null,
             "label": null,
             "valueSubject": {
-              "key": "abc38",
+              "key": "abc37",
               "uri": null,
               "subjectTemplate": {
                 "key": "resourceTemplate:testing:uber2",
@@ -804,7 +684,7 @@
             "uri": null,
             "label": null,
             "valueSubject": {
-              "key": "abc39",
+              "key": "abc38",
               "uri": null,
               "subjectTemplate": {
                 "key": "resourceTemplate:testing:uber3",
@@ -859,12 +739,149 @@
               },
               "properties": [
                 {
-                  "key": "abc56",
+                  "key": "abc55",
                   "values": null,
                   "show": false
                 },
                 {
+                  "key": "abc56",
+                  "values": null,
+                  "show": false
+                }
+              ]
+            }
+          }
+        ],
+        "show": true
+      },
+      {
+        "key": "abc2",
+        "values": [],
+        "show": true
+      },
+      {
+        "key": "abc3",
+        "values": [
+          {
+            "key": "abc60",
+            "literal": null,
+            "lang": null,
+            "uri": null,
+            "label": null,
+            "valueSubject": {
+              "key": "abc39",
+              "uri": null,
+              "subjectTemplate": {
+                "key": "resourceTemplate:testing:uber2",
+                "uri": "http://localhost:3000/resource/resourceTemplate:testing:uber2",
+                "id": "resourceTemplate:testing:uber2",
+                "class": "http://id.loc.gov/ontologies/bibframe/Uber2",
+                "label": "Uber template2",
+                "author": null,
+                "remark": "Template for testing purposes with single repeatable literal.",
+                "date": null,
+                "group": "stanford",
+                "editGroups": ["cornell"],
+                "suppressible": false,
+                "propertyTemplateKeys": [
+                  "resourceTemplate:testing:uber2 > http://id.loc.gov/ontologies/bibframe/uber/template2/property1"
+                ],
+                "propertyTemplates": [
+                  {
+                    "key": "resourceTemplate:testing:uber2 > http://id.loc.gov/ontologies/bibframe/uber/template2/property1",
+                    "subjectTemplateKey": "resourceTemplate:testing:uber2",
+                    "label": "Uber template2, property1",
+                    "uri": "http://id.loc.gov/ontologies/bibframe/uber/template2/property1",
+                    "required": false,
+                    "repeatable": true,
+                    "ordered": false,
+                    "remark": "A repeatable literal",
+                    "remarkUrl": null,
+                    "defaults": [],
+                    "valueSubjectTemplateKeys": [],
+                    "authorities": [],
+                    "type": "literal",
+                    "component": "InputLiteral"
+                  }
+                ]
+              },
+              "properties": [
+                {
+                  "key": "abc51",
+                  "values": null,
+                  "show": false
+                }
+              ]
+            }
+          },
+          {
+            "key": "abc63",
+            "literal": null,
+            "lang": null,
+            "uri": null,
+            "label": null,
+            "valueSubject": {
+              "key": "abc40",
+              "uri": null,
+              "subjectTemplate": {
+                "key": "resourceTemplate:testing:uber3",
+                "uri": "http://localhost:3000/resource/resourceTemplate:testing:uber3",
+                "id": "resourceTemplate:testing:uber3",
+                "class": "http://id.loc.gov/ontologies/bibframe/Uber3",
+                "label": "Uber template3",
+                "author": null,
+                "remark": "Template for testing purposes with multiple literal.",
+                "date": null,
+                "group": "stanford",
+                "editGroups": ["cornell"],
+                "suppressible": false,
+                "propertyTemplateKeys": [
+                  "resourceTemplate:testing:uber3 > http://id.loc.gov/ontologies/bibframe/uber/template3/property1",
+                  "resourceTemplate:testing:uber3 > http://id.loc.gov/ontologies/bibframe/uber/template3/property2"
+                ],
+                "propertyTemplates": [
+                  {
+                    "key": "resourceTemplate:testing:uber3 > http://id.loc.gov/ontologies/bibframe/uber/template3/property1",
+                    "subjectTemplateKey": "resourceTemplate:testing:uber3",
+                    "label": "Uber template3, property1",
+                    "uri": "http://id.loc.gov/ontologies/bibframe/uber/template3/property1",
+                    "required": false,
+                    "repeatable": true,
+                    "ordered": false,
+                    "remark": "A literal",
+                    "remarkUrl": null,
+                    "defaults": [],
+                    "valueSubjectTemplateKeys": [],
+                    "authorities": [],
+                    "type": "literal",
+                    "component": "InputLiteral"
+                  },
+                  {
+                    "key": "resourceTemplate:testing:uber3 > http://id.loc.gov/ontologies/bibframe/uber/template3/property2",
+                    "subjectTemplateKey": "resourceTemplate:testing:uber3",
+                    "label": "Uber template3, property2",
+                    "uri": "http://id.loc.gov/ontologies/bibframe/uber/template3/property2",
+                    "required": false,
+                    "repeatable": true,
+                    "ordered": false,
+                    "remark": null,
+                    "remarkUrl": "http://access.rdatoolkit.org/1.0.html",
+                    "defaults": [],
+                    "valueSubjectTemplateKeys": [],
+                    "authorities": [],
+                    "type": "literal",
+                    "component": "InputLiteral"
+                  }
+                ]
+              },
+              "properties": [
+                {
                   "key": "abc57",
+                  "values": null,
+                  "show": false
+                },
+                {
+                  "key": "abc58",
                   "values": null,
                   "show": false
                 }
@@ -893,7 +910,7 @@
         "key": "abc7",
         "values": [
           {
-            "key": "abc40",
+            "key": "abc41",
             "literal": "Default literal1",
             "lang": null,
             "uri": null,
@@ -901,7 +918,7 @@
             "valueSubject": null
           },
           {
-            "key": "abc41",
+            "key": "abc42",
             "literal": "Default literal2",
             "lang": null,
             "uri": null,
@@ -915,7 +932,7 @@
         "key": "abc10",
         "values": [
           {
-            "key": "abc42",
+            "key": "abc43",
             "literal": null,
             "lang": "eng",
             "uri": "http://sinopia.io/defaultURI1",
@@ -923,7 +940,7 @@
             "valueSubject": null
           },
           {
-            "key": "abc43",
+            "key": "abc44",
             "literal": null,
             "lang": "eng",
             "uri": "http://sinopia.io/defaultURI2",
@@ -982,64 +999,6 @@
         "key": "abc22",
         "values": [
           {
-            "key": "abc63",
-            "literal": null,
-            "lang": null,
-            "uri": null,
-            "label": null,
-            "valueSubject": {
-              "key": "abc44",
-              "uri": null,
-              "subjectTemplate": {
-                "key": "resourceTemplate:testing:uber4",
-                "uri": "http://localhost:3000/resource/resourceTemplate:testing:uber4",
-                "id": "resourceTemplate:testing:uber4",
-                "class": "http://id.loc.gov/ontologies/bibframe/Uber4",
-                "label": "Uber template4",
-                "author": null,
-                "remark": "Template for testing purposes with single repeatable, required literal.",
-                "date": null,
-                "group": "stanford",
-                "editGroups": ["cornell"],
-                "suppressible": false,
-                "propertyTemplateKeys": [
-                  "resourceTemplate:testing:uber4 > http://id.loc.gov/ontologies/bibframe/uber/template4/property1"
-                ],
-                "propertyTemplates": [
-                  {
-                    "key": "resourceTemplate:testing:uber4 > http://id.loc.gov/ontologies/bibframe/uber/template4/property1",
-                    "subjectTemplateKey": "resourceTemplate:testing:uber4",
-                    "label": "Uber template4, property1",
-                    "uri": "http://id.loc.gov/ontologies/bibframe/uber/template4/property1",
-                    "required": true,
-                    "repeatable": true,
-                    "ordered": false,
-                    "remark": "A repeatable, required literal",
-                    "remarkUrl": null,
-                    "defaults": [],
-                    "valueSubjectTemplateKeys": [],
-                    "authorities": [],
-                    "type": "literal",
-                    "component": "InputLiteral"
-                  }
-                ]
-              },
-              "properties": [
-                {
-                  "key": "abc51",
-                  "values": [],
-                  "show": true
-                }
-              ]
-            }
-          }
-        ],
-        "show": true
-      },
-      {
-        "key": "abc24",
-        "values": [
-          {
             "key": "abc64",
             "literal": null,
             "lang": null,
@@ -1095,6 +1054,64 @@
         "show": true
       },
       {
+        "key": "abc24",
+        "values": [
+          {
+            "key": "abc65",
+            "literal": null,
+            "lang": null,
+            "uri": null,
+            "label": null,
+            "valueSubject": {
+              "key": "abc46",
+              "uri": null,
+              "subjectTemplate": {
+                "key": "resourceTemplate:testing:uber4",
+                "uri": "http://localhost:3000/resource/resourceTemplate:testing:uber4",
+                "id": "resourceTemplate:testing:uber4",
+                "class": "http://id.loc.gov/ontologies/bibframe/Uber4",
+                "label": "Uber template4",
+                "author": null,
+                "remark": "Template for testing purposes with single repeatable, required literal.",
+                "date": null,
+                "group": "stanford",
+                "editGroups": ["cornell"],
+                "suppressible": false,
+                "propertyTemplateKeys": [
+                  "resourceTemplate:testing:uber4 > http://id.loc.gov/ontologies/bibframe/uber/template4/property1"
+                ],
+                "propertyTemplates": [
+                  {
+                    "key": "resourceTemplate:testing:uber4 > http://id.loc.gov/ontologies/bibframe/uber/template4/property1",
+                    "subjectTemplateKey": "resourceTemplate:testing:uber4",
+                    "label": "Uber template4, property1",
+                    "uri": "http://id.loc.gov/ontologies/bibframe/uber/template4/property1",
+                    "required": true,
+                    "repeatable": true,
+                    "ordered": false,
+                    "remark": "A repeatable, required literal",
+                    "remarkUrl": null,
+                    "defaults": [],
+                    "valueSubjectTemplateKeys": [],
+                    "authorities": [],
+                    "type": "literal",
+                    "component": "InputLiteral"
+                  }
+                ]
+              },
+              "properties": [
+                {
+                  "key": "abc53",
+                  "values": [],
+                  "show": true
+                }
+              ]
+            }
+          }
+        ],
+        "show": true
+      },
+      {
         "key": "abc25",
         "values": [],
         "show": true
@@ -1123,7 +1140,7 @@
         "key": "abc30",
         "values": [
           {
-            "key": "abc46",
+            "key": "abc47",
             "literal": "Default required literal1",
             "lang": null,
             "uri": null,
@@ -1131,7 +1148,7 @@
             "valueSubject": null
           },
           {
-            "key": "abc47",
+            "key": "abc48",
             "literal": "Default required literal2",
             "lang": null,
             "uri": null,
@@ -1145,13 +1162,13 @@
         "key": "abc33",
         "values": [
           {
-            "key": "abc60",
+            "key": "abc61",
             "literal": null,
             "lang": null,
             "uri": null,
             "label": null,
             "valueSubject": {
-              "key": "abc48",
+              "key": "abc49",
               "uri": null,
               "subjectTemplate": {
                 "key": "resourceTemplate:testing:uber5",
@@ -1189,7 +1206,7 @@
               },
               "properties": [
                 {
-                  "key": "abc53",
+                  "key": "abc54",
                   "values": null,
                   "show": false
                 }
@@ -1197,6 +1214,11 @@
             }
           }
         ],
+        "show": true
+      },
+      {
+        "key": "abc34",
+        "values": [],
         "show": true
       }
     ]

--- a/__tests__/__action_fixtures__/newResourceFromDataset-ADD_SUBJECT.json
+++ b/__tests__/__action_fixtures__/newResourceFromDataset-ADD_SUBJECT.json
@@ -41,7 +41,8 @@
         "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/hasItem",
         "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/itemOf",
         "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property20",
-        "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property21"
+        "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property21",
+        "resourceTemplate:testing:uber1 > http://www.w3.org/2000/01/rdf-schema#label"
       ],
       "propertyTemplates": [
         {
@@ -601,6 +602,22 @@
           "authorities": [],
           "type": "resource",
           "component": "NestedResource"
+        },
+        {
+          "key": "resourceTemplate:testing:uber1 > http://www.w3.org/2000/01/rdf-schema#label",
+          "subjectTemplateKey": "resourceTemplate:testing:uber1",
+          "label": "rdfs label",
+          "uri": "http://www.w3.org/2000/01/rdf-schema#label",
+          "required": false,
+          "repeatable": false,
+          "ordered": false,
+          "remark": "rdfs label",
+          "remarkUrl": null,
+          "defaults": [],
+          "valueSubjectTemplateKeys": [],
+          "authorities": [],
+          "type": "literal",
+          "component": "InputLiteral"
         }
       ]
     },
@@ -609,13 +626,13 @@
         "key": "abc1",
         "values": [
           {
-            "key": "abc49",
+            "key": "abc50",
             "literal": null,
             "lang": null,
             "uri": null,
             "label": null,
             "valueSubject": {
-              "key": "abc35",
+              "key": "abc36",
               "uri": null,
               "subjectTemplate": {
                 "key": "resourceTemplate:testing:uber2",
@@ -653,10 +670,10 @@
               },
               "properties": [
                 {
-                  "key": "abc40",
+                  "key": "abc41",
                   "values": [
                     {
-                      "key": "abc45",
+                      "key": "abc46",
                       "literal": "Uber template2, property1",
                       "lang": "eng",
                       "uri": null,
@@ -670,20 +687,20 @@
             }
           },
           {
-            "key": "abc50",
+            "key": "abc51",
             "literal": null,
             "lang": null,
             "uri": null,
             "label": null,
             "valueSubject": {
-              "key": "abc36",
+              "key": "abc37",
               "uri": null,
               "properties": [
                 {
-                  "key": "abc41",
+                  "key": "abc42",
                   "values": [
                     {
-                      "key": "abc46",
+                      "key": "abc47",
                       "literal": "Uber template2, property1b",
                       "lang": "eng",
                       "uri": null,
@@ -697,13 +714,13 @@
             }
           },
           {
-            "key": "abc48",
+            "key": "abc49",
             "literal": null,
             "lang": null,
             "uri": null,
             "label": null,
             "valueSubject": {
-              "key": "abc34",
+              "key": "abc35",
               "uri": null,
               "subjectTemplate": {
                 "key": "resourceTemplate:testing:uber3",
@@ -758,10 +775,10 @@
               },
               "properties": [
                 {
-                  "key": "abc38",
+                  "key": "abc39",
                   "values": [
                     {
-                      "key": "abc43",
+                      "key": "abc44",
                       "literal": "Uber template3, property1",
                       "lang": "eng",
                       "uri": null,
@@ -772,10 +789,10 @@
                   "show": false
                 },
                 {
-                  "key": "abc39",
+                  "key": "abc40",
                   "values": [
                     {
-                      "key": "abc44",
+                      "key": "abc45",
                       "literal": "Uber template3, property2",
                       "lang": "eng",
                       "uri": null,
@@ -795,7 +812,7 @@
         "key": "abc2",
         "values": [
           {
-            "key": "abc30",
+            "key": "abc31",
             "literal": "Uber template1, property2",
             "lang": "eng",
             "uri": null,
@@ -814,7 +831,7 @@
         "key": "abc4",
         "values": [
           {
-            "key": "abc31",
+            "key": "abc32",
             "literal": "Uber template1, property4",
             "lang": "eng",
             "uri": null,
@@ -828,7 +845,7 @@
         "key": "abc5",
         "values": [
           {
-            "key": "abc32",
+            "key": "abc33",
             "literal": null,
             "lang": null,
             "uri": "ubertemplate1:property5",
@@ -842,7 +859,7 @@
         "key": "abc6",
         "values": [
           {
-            "key": "abc33",
+            "key": "abc34",
             "literal": null,
             "lang": null,
             "uri": "ubertemplate1:property6",
@@ -911,7 +928,7 @@
         "key": "abc18",
         "values": [
           {
-            "key": "abc29",
+            "key": "abc30",
             "literal": null,
             "lang": null,
             "uri": null,
@@ -955,7 +972,7 @@
               },
               "properties": [
                 {
-                  "key": "abc28",
+                  "key": "abc29",
                   "values": [],
                   "show": true
                 }
@@ -1004,13 +1021,13 @@
         "key": "abc27",
         "values": [
           {
-            "key": "abc51",
+            "key": "abc52",
             "literal": null,
             "lang": null,
             "uri": null,
             "label": null,
             "valueSubject": {
-              "key": "abc37",
+              "key": "abc38",
               "uri": null,
               "subjectTemplate": {
                 "key": "resourceTemplate:testing:uber5",
@@ -1048,10 +1065,10 @@
               },
               "properties": [
                 {
-                  "key": "abc42",
+                  "key": "abc43",
                   "values": [
                     {
-                      "key": "abc47",
+                      "key": "abc48",
                       "literal": null,
                       "lang": null,
                       "uri": "http://sinopia.io/ubertemplate5/property1",
@@ -1065,6 +1082,11 @@
             }
           }
         ],
+        "show": false
+      },
+      {
+        "key": "abc28",
+        "values": null,
         "show": false
       }
     ]

--- a/__tests__/__template_fixtures__/uber_template1.json
+++ b/__tests__/__template_fixtures__/uber_template1.json
@@ -1139,7 +1139,7 @@
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "Uber template1, property22 (rdfs label)"
+        "@value": "rdfs label"
       }
     ],
     "http://sinopia.io/vocabulary/hasRemark": [
@@ -1149,7 +1149,7 @@
     ],
     "http://sinopia.io/vocabulary/hasPropertyUri": [
       {
-        "@id": "http://id.loc.gov/ontologies/bibframe/uber/template1/property22"
+        "@id": "http://www.w3.org/2000/01/rdf-schema#label"
       }
     ],
     "http://sinopia.io/vocabulary/hasPropertyType": [

--- a/__tests__/__template_fixtures__/uber_template1.json
+++ b/__tests__/__template_fixtures__/uber_template1.json
@@ -1133,6 +1133,32 @@
     ]
   },
   {
+    "@id": "_:b74",
+    "@type": [
+      "http://sinopia.io/vocabulary/PropertyTemplate"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Uber template1, property22 (rdfs label)"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasRemark": [
+      {
+        "@value": "rdfs label"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyUri": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe/uber/template1/property22"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyType": [
+      {
+        "@id": "http://sinopia.io/vocabulary/propertyType/literal"
+      }
+    ]
+  },
+  {
     "@id": "_:b8",
     "@type": [
       "http://sinopia.io/vocabulary/PropertyTemplate"
@@ -1297,6 +1323,9 @@
           },
           {
             "@id": "_:b72"
+          },
+          {
+            "@id": "_:b74"
           }
         ]
       }

--- a/__tests__/reducers/resources.test.js
+++ b/__tests__/reducers/resources.test.js
@@ -528,6 +528,66 @@ describe("addValue()", () => {
     })
   })
 
+  describe("new rdfs label value for resource subject", () => {
+    it("updates state", () => {
+      const oldState = createState({ hasResourceWithLiteral: true })
+
+      // change propertyTemplate to be one for rdfs label
+      oldState.entities.propertyTemplates = {
+        "resourceTemplate:testing:uber1 > http://www.w3.org/2000/01/rdf-schema#label":
+          {
+            key: "resourceTemplate:testing:uber1 > http://www.w3.org/2000/01/rdf-schema#label",
+            subjectTemplateKey: "resourceTemplate:testing:uber1",
+            label: "rdfs label",
+            uri: "http://www.w3.org/2000/01/rdf-schema#label",
+            required: false,
+            repeatable: false,
+            defaults: [],
+            remarkUrl: null,
+            type: "literal",
+            component: "InputLiteral",
+            authorities: [],
+          },
+      }
+      oldState.entities.properties["JQEtq-vmq8"].propertyTemplateKey =
+        "resourceTemplate:testing:uber1 > http://www.w3.org/2000/01/rdf-schema#label"
+
+      const labelValue = "resource root subject label value!"
+      const action = {
+        type: "ADD_VALUE",
+        payload: {
+          value: {
+            key: "DxGx7WMh3",
+            property: { key: "JQEtq-vmq8" },
+            literal: labelValue,
+            lang: "eng",
+            uri: null,
+            label: null,
+            valueSubjectKey: null,
+          },
+        },
+      }
+
+      const newState = reducer(oldState.entities, action)
+
+      expect(newState.values.DxGx7WMh3).toStrictEqual({
+        key: "DxGx7WMh3",
+        propertyKey: "JQEtq-vmq8",
+        rootSubjectKey: "t9zVwg2zO",
+        rootPropertyKey: "JQEtq-vmq8",
+        literal: labelValue,
+        lang: "eng",
+        uri: null,
+        label: null,
+        valueSubjectKey: null,
+        errors: [],
+      })
+      expect(newState.properties["JQEtq-vmq8"].valueKeys).toContain("DxGx7WMh3")
+      expect(newState.properties["JQEtq-vmq8"].show).toBe(true)
+      expect(newState.subjects.t9zVwg2zO.label).toEqual(labelValue)
+    })
+  })
+
   describe("existing nested resource value", () => {
     it("updates state", () => {
       const oldState = createState({ hasResourceWithNestedResource: true })
@@ -1089,6 +1149,59 @@ describe("updateValue()", () => {
       expect(newState.subjects.t9zVwg2zO.descWithErrorPropertyKeys).toContain(
         "JQEtq-vmq8"
       )
+    })
+  })
+
+  describe("update rdfs label value for resource subject", () => {
+    it("updates state", () => {
+      const oldState = createState({ hasResourceWithLiteral: true })
+
+      // change propertyTemplate to be one for rdfs label
+      oldState.entities.propertyTemplates = {
+        "resourceTemplate:testing:uber1 > http://www.w3.org/2000/01/rdf-schema#label":
+          {
+            key: "resourceTemplate:testing:uber1 > http://www.w3.org/2000/01/rdf-schema#label",
+            subjectTemplateKey: "resourceTemplate:testing:uber1",
+            label: "rdfs label",
+            uri: "http://www.w3.org/2000/01/rdf-schema#label",
+            required: false,
+            repeatable: false,
+            defaults: [],
+            remarkUrl: null,
+            type: "literal",
+            component: "InputLiteral",
+            authorities: [],
+          },
+      }
+      oldState.entities.properties["JQEtq-vmq8"].propertyTemplateKey =
+        "resourceTemplate:testing:uber1 > http://www.w3.org/2000/01/rdf-schema#label"
+
+      const newLabelValue = "resource root subject NEW label value!"
+      const action = {
+        type: "UPDATE_VALUE",
+        payload: {
+          valueKey: "CxGx7WMh2",
+          literal: newLabelValue,
+          lang: null,
+        },
+      }
+
+      const newState = reducer(oldState.entities, action)
+
+      expect(newState.values.CxGx7WMh2).toStrictEqual({
+        key: "CxGx7WMh2",
+        propertyKey: "JQEtq-vmq8",
+        rootSubjectKey: "t9zVwg2zO",
+        rootPropertyKey: "JQEtq-vmq8",
+        literal: newLabelValue,
+        lang: null,
+        uri: null,
+        label: null,
+        valueSubjectKey: null,
+        errors: [],
+      })
+      expect(newState.properties["JQEtq-vmq8"].valueKeys).toContain("CxGx7WMh2")
+      expect(newState.subjects.t9zVwg2zO.label).toEqual(newLabelValue)
     })
   })
 

--- a/src/reducers/resources.js
+++ b/src/reducers/resources.js
@@ -282,6 +282,8 @@ const addValueToNewState = (
   newValue.rootSubjectKey = newProperty.rootSubjectKey
   newValue.rootPropertyKey = newProperty.rootPropertyKey
 
+  newState = updateResourceLabel(newState, newValue)
+
   // Remove existing value subject
   const oldValue = state.values[newValue.key]
   if (oldValue?.valueSubjectKey) {
@@ -368,6 +370,8 @@ export const updateValue = (state, action) => {
   const newProperty = newState.properties[newValue.propertyKey]
   newState = updateBibframeRefs(newState, newValue, newProperty)
 
+  newState = updateResourceLabel(newState, newValue)
+
   // If changed, then set resource as changed.
   newValue = newState.values[newValue.key]
   if (!_.isEqual(newValue, oldValue)) {
@@ -375,6 +379,25 @@ export const updateValue = (state, action) => {
   }
 
   return newState
+}
+
+// add rdfs:label to root resource if it's present
+const updateResourceLabel = (state, value) => {
+  const possibleLabelProperty = state.properties[value.propertyKey]
+  const propertyTemplate =
+    state.propertyTemplates[possibleLabelProperty.propertyTemplateKey]
+  const rootSubjectKey = possibleLabelProperty.rootSubjectKey
+  if (
+    propertyTemplate.uri === "http://www.w3.org/2000/01/rdf-schema#label" &&
+    possibleLabelProperty.subjectKey === rootSubjectKey
+  ) {
+    const labelValue = value.literal || "Unlabeled"
+    const newState = stateWithNewSubject(state, rootSubjectKey)
+    const newResourceSubject = newState.subjects[rootSubjectKey]
+    newResourceSubject.label = labelValue
+    return newState
+  }
+  return state
 }
 
 const updateBibframeRefs = (state, value, property) => {


### PR DESCRIPTION
## Why was this change made?

Fixes #3025 - allowing an rdfs label for the root resource subject to be stored in state.

Part of this sprint stretch goal:  "enable use of rdfs:label for labelling resources in search results and tab headers and Editor heading"

## How was this change tested?

test code and running locally and confirming with redux

## Which documentation and/or configurations were updated?



