### PR TITLE
when displaying Marc, use bdi tag for correct right-to-left text

### DIFF
--- a/src/components/editor/actions/MarcButton.jsx
+++ b/src/components/editor/actions/MarcButton.jsx
@@ -128,7 +128,7 @@ const MarcButton = () => {
                 maxWidth: "750px",
               }}
             >
-              {marcs.current[resourceKey].marc}
+              <bdi>{marcs.current[resourceKey].marc}</bdi>
             </pre>
           </React.Fragment>
         )}


### PR DESCRIPTION
## Why was this change made?

The `<bdi>` tag will do its best to autodetect the correct direction for text display.  It empirically seems to work fine for this case.   Thanks to @justinlittman  for the link to https://www.w3.org/International/articles/inline-bidi-markup/ in the issue.  See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/bdi for more about bdi tag.

Fixes #3057

## How was this change tested?

I tested it locally by using the example resource from the ticket in my browser and then editing the html displayed via the inspector webtools.  JLitt did a similar test by adding spurious display of marc from the record in the Sinopia editor and adding the `<bdi>` tag inside the `<pre>` tag for displaying the marc.

## Which documentation and/or configurations were updated?



