### PR TITLE
use icon for creating resource instead of linking resource template name

### DIFF
--- a/__tests__/feature/dashboard.test.js
+++ b/__tests__/feature/dashboard.test.js
@@ -28,7 +28,7 @@ describe("viewing the dashboard", () => {
       await screen.findByText(/Uber template1/)
 
       // Click the resource template
-      fireEvent.click(screen.getByText("Uber template1", { selector: "a" }))
+      fireEvent.click(screen.getByTestId("createResource-Uber template1"))
       await waitFor(() =>
         expect(
           screen.getAllByText("Uber template1", { selector: "h3" })

--- a/__tests__/feature/dashboard.test.js
+++ b/__tests__/feature/dashboard.test.js
@@ -28,7 +28,7 @@ describe("viewing the dashboard", () => {
       await screen.findByText(/Uber template1/)
 
       // Click the resource template
-      fireEvent.click(screen.getByTestId("createResource-Uber template1"))
+      fireEvent.click(screen.getByTitle("Create resource for Uber template1"))
       await waitFor(() =>
         expect(
           screen.getAllByText("Uber template1", { selector: "h3" })

--- a/__tests__/feature/invalidTemplate.test.js
+++ b/__tests__/feature/invalidTemplate.test.js
@@ -45,9 +45,9 @@ describe("an invalid resource template", () => {
     await fireEvent.change(input, { target: { value: "Not found" } })
 
     // try to open the template
-    const link = await screen.findByText("Not found value template refs", {
-      selector: "a",
-    })
+    const link = await screen.findByTestId(
+      "createResource-Not found value template refs"
+    )
     fireEvent.click(link)
 
     // wait for the resource template to be loaded into the list of recently used templates

--- a/__tests__/feature/invalidTemplate.test.js
+++ b/__tests__/feature/invalidTemplate.test.js
@@ -45,8 +45,8 @@ describe("an invalid resource template", () => {
     await fireEvent.change(input, { target: { value: "Not found" } })
 
     // try to open the template
-    const link = await screen.findByTestId(
-      "createResource-Not found value template refs"
+    const link = await screen.findByTitle(
+      "Create resource for Not found value template refs"
     )
     fireEvent.click(link)
 

--- a/__tests__/feature/loadNewResource.test.js
+++ b/__tests__/feature/loadNewResource.test.js
@@ -19,7 +19,7 @@ describe("loading new resource", () => {
     screen.getByText("Jul 27, 2020")
 
     // Click the resource template
-    fireEvent.click(screen.getByTestId("createResource-Uber template1"))
+    fireEvent.click(screen.getByTitle("Create resource for Uber template1"))
     await waitFor(() =>
       expect(
         screen.getAllByText("Uber template1", { selector: "h3" })

--- a/__tests__/feature/loadNewResource.test.js
+++ b/__tests__/feature/loadNewResource.test.js
@@ -19,7 +19,7 @@ describe("loading new resource", () => {
     screen.getByText("Jul 27, 2020")
 
     // Click the resource template
-    fireEvent.click(screen.getByText("Uber template1", { selector: "a" }))
+    fireEvent.click(screen.getByTestId("createResource-Uber template1"))
     await waitFor(() =>
       expect(
         screen.getAllByText("Uber template1", { selector: "h3" })

--- a/__tests__/feature/previewRdf.test.js
+++ b/__tests__/feature/previewRdf.test.js
@@ -23,7 +23,12 @@ describe("preview RDF after editing", () => {
     fireEvent.click(screen.getByText("Resource Templates", { selector: "a" }))
 
     // Click an existing resource template
-    fireEvent.click(await screen.findByTestId("createResource-Uber template1"))
+    await screen.findByText(/Uber template1/)
+    fireEvent.click(
+      screen.getByTitle("Create resource for Uber template1", {
+        selector: "a",
+      })
+    )
 
     // Click on the Preview RDF Button
     await screen.findByText(/Uber template1/)

--- a/__tests__/feature/previewRdf.test.js
+++ b/__tests__/feature/previewRdf.test.js
@@ -23,9 +23,7 @@ describe("preview RDF after editing", () => {
     fireEvent.click(screen.getByText("Resource Templates", { selector: "a" }))
 
     // Click an existing resource template
-    fireEvent.click(
-      await screen.findByText(/Uber template1/, { selector: "a" })
-    )
+    fireEvent.click(await screen.findByTestId("createResource-Uber template1"))
 
     // Click on the Preview RDF Button
     await screen.findByText(/Uber template1/)

--- a/__tests__/feature/searchAndOpenTemplate.test.js
+++ b/__tests__/feature/searchAndOpenTemplate.test.js
@@ -52,7 +52,7 @@ describe("searching and opening a resource", () => {
     await screen.findByText("resourceTemplate:bf2:Title:Note")
 
     // open the template
-    const link = await screen.findByText("Title note", { selector: "a" })
+    const link = await screen.findByTestId("createResource-Title note")
     fireEvent.click(link)
     await act(() => promise)
 
@@ -83,7 +83,7 @@ describe("searching and opening a resource", () => {
     expect(rtHeaders).toHaveLength(2)
 
     // open the recenly used RTs and click
-    const rtLinks = screen.getAllByText("Title note", { selector: "a" })
+    const rtLinks = screen.getAllByTestId("createResource-Title note")
     expect(rtLinks).toHaveLength(2)
     fireEvent.click(rtLinks[0])
     await screen.findByText("Title note", { selector: "h3" })

--- a/__tests__/feature/searchAndOpenTemplate.test.js
+++ b/__tests__/feature/searchAndOpenTemplate.test.js
@@ -52,7 +52,7 @@ describe("searching and opening a resource", () => {
     await screen.findByText("resourceTemplate:bf2:Title:Note")
 
     // open the template
-    const link = await screen.findByTestId("createResource-Title note")
+    const link = await screen.findByTitle("Create resource for Title note")
     fireEvent.click(link)
     await act(() => promise)
 
@@ -83,7 +83,7 @@ describe("searching and opening a resource", () => {
     expect(rtHeaders).toHaveLength(2)
 
     // open the recenly used RTs and click
-    const rtLinks = screen.getAllByTestId("createResource-Title note")
+    const rtLinks = screen.getAllByTitle("Create resource for Title note")
     expect(rtLinks).toHaveLength(2)
     fireEvent.click(rtLinks[0])
     await screen.findByText("Title note", { selector: "h3" })

--- a/__tests__/feature/searchAndViewResource.test.js
+++ b/__tests__/feature/searchAndViewResource.test.js
@@ -129,7 +129,7 @@ describe("searching and viewing a resource", () => {
 
     // Make sure nav panel didn't disappear
     fireEvent.click(screen.getByText("Resource Templates", { selector: "a" }))
-    fireEvent.click(await screen.findByTestId("createResource-Title note"))
+    fireEvent.click(await screen.findByTitle("Create resource for Title note"))
     expect(
       await screen.findByTestId("Go to Note Text", { selector: "button" })
     ).toBeInTheDocument()

--- a/__tests__/feature/searchAndViewResource.test.js
+++ b/__tests__/feature/searchAndViewResource.test.js
@@ -129,7 +129,7 @@ describe("searching and viewing a resource", () => {
 
     // Make sure nav panel didn't disappear
     fireEvent.click(screen.getByText("Resource Templates", { selector: "a" }))
-    fireEvent.click(await screen.findByText("Title note", { selector: "a" }))
+    fireEvent.click(await screen.findByTestId("createResource-Title note"))
     expect(
       await screen.findByTestId("Go to Note Text", { selector: "button" })
     ).toBeInTheDocument()

--- a/__tests__/feature/userPermissions.test.js
+++ b/__tests__/feature/userPermissions.test.js
@@ -77,7 +77,7 @@ describe("user permissions", () => {
     await screen.findByText("New template")
 
     // Templates are linked
-    screen.getByTestId("createResource-Uber template1", { selector: "a" })
+    screen.getByTitle("Create resource for Uber template1", { selector: "a" })
 
     // Can copy a template
     screen.getByRole("button", { name: "Copy Uber template1" })
@@ -118,7 +118,7 @@ describe("user permissions", () => {
     await screen.findByText("New template")
 
     // Templates are linked
-    screen.getByTestId("createResource-Uber template1", { selector: "a" })
+    screen.getByTitle("Create resource for Uber template1", { selector: "a" })
 
     // Can copy a template
     screen.getByRole("button", { name: "Copy Uber template1" })

--- a/__tests__/feature/userPermissions.test.js
+++ b/__tests__/feature/userPermissions.test.js
@@ -77,7 +77,7 @@ describe("user permissions", () => {
     await screen.findByText("New template")
 
     // Templates are linked
-    screen.getByText("Uber template1", { selector: "a" })
+    screen.getByTestId("createResource-Uber template1", { selector: "a" })
 
     // Can copy a template
     screen.getByRole("button", { name: "Copy Uber template1" })
@@ -118,7 +118,7 @@ describe("user permissions", () => {
     await screen.findByText("New template")
 
     // Templates are linked
-    screen.getByText("Uber template1", { selector: "a" })
+    screen.getByTestId("createResource-Uber template1", { selector: "a" })
 
     // Can copy a template
     screen.getByRole("button", { name: "Copy Uber template1" })

--- a/cypress/integration/end2end.spec.js
+++ b/cypress/integration/end2end.spec.js
@@ -142,7 +142,7 @@ describe("End-to-end test", () => {
   })
 
   it("Open existing resource in editor", () => {
-    cy.get('button[title="Edit template"]').click()
+    cy.get("button[title=Edit]").click()
     cy.url().should("include", "/editor")
 
     cy.contains("h3", "Work Title")
@@ -170,7 +170,8 @@ describe("End-to-end test", () => {
     cy.url().should("include", "/dashboard")
 
     cy.contains("h2", "Recent templates")
-    cy.contains('a[data-testid="createResource-Work Title"]')
+    cy.get('a[data-testid="createResource-Work Title"]')
+    //    cy.contains('a[data-testid="createResource-Work Title"]')
 
     cy.contains("h2", "Recent searches")
     cy.contains("table.search-list td", title)

--- a/cypress/integration/end2end.spec.js
+++ b/cypress/integration/end2end.spec.js
@@ -87,7 +87,7 @@ describe("End-to-end test", () => {
   })
 
   it("Opens a resource template", () => {
-    cy.get('a[data-testid="createResource-Work Title"]').click()
+    cy.get('a[title="Create resource for Work Title"]').click()
     cy.url().should("include", "/editor")
   })
 
@@ -170,8 +170,7 @@ describe("End-to-end test", () => {
     cy.url().should("include", "/dashboard")
 
     cy.contains("h2", "Recent templates")
-    cy.get('a[data-testid="createResource-Work Title"]')
-    //    cy.contains('a[data-testid="createResource-Work Title"]')
+    cy.get('a[title="Create resource for Work Title"]')
 
     cy.contains("h2", "Recent searches")
     cy.contains("table.search-list td", title)

--- a/cypress/integration/end2end.spec.js
+++ b/cypress/integration/end2end.spec.js
@@ -87,7 +87,7 @@ describe("End-to-end test", () => {
   })
 
   it("Opens a resource template", () => {
-    cy.contains("a:visible", /^Work Title$/).click()
+    cy.get('a[data-testid="createResource-Work Title"]').click()
     cy.url().should("include", "/editor")
   })
 
@@ -142,7 +142,7 @@ describe("End-to-end test", () => {
   })
 
   it("Open existing resource in editor", () => {
-    cy.get("button[title=Edit]").click()
+    cy.get('button[title="Edit template"]').click()
     cy.url().should("include", "/editor")
 
     cy.contains("h3", "Work Title")
@@ -170,7 +170,7 @@ describe("End-to-end test", () => {
     cy.url().should("include", "/dashboard")
 
     cy.contains("h2", "Recent templates")
-    cy.contains("a", "Work Title")
+    cy.contains('a[data-testid="createResource-Work Title"]')
 
     cy.contains("h2", "Recent searches")
     cy.contains("table.search-list td", title)

--- a/cypress/integration/leftNav.spec.js
+++ b/cypress/integration/leftNav.spec.js
@@ -75,7 +75,7 @@ describe("Left-nav test", () => {
   })
 
   it("Opens a resource template", () => {
-    cy.contains("a:visible", /^Uber template1$/)
+    cy.get('a[data-testid="createResource-Uber template1"]')
       .scrollIntoView()
       .click()
     // eslint-disable-next-line cypress/no-unnecessary-waiting

--- a/cypress/integration/leftNav.spec.js
+++ b/cypress/integration/leftNav.spec.js
@@ -75,7 +75,7 @@ describe("Left-nav test", () => {
   })
 
   it("Opens a resource template", () => {
-    cy.get('a[data-testid="createResource-Uber template1"]')
+    cy.get('a[title="Create resource for Uber template1"]')
       .scrollIntoView()
       .click()
     // eslint-disable-next-line cypress/no-unnecessary-waiting

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "process": "^0.11.10",
         "rdf-ext": "^1.3.5",
         "react": "^16.14.0",
+        "react-bootstrap-icons": "^1.5.0",
         "react-bootstrap-typeahead": "^5.2.0",
         "react-dom": "^16.14.0",
         "react-helmet-async": "^1.1.2",
@@ -19604,6 +19605,17 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-bootstrap-icons": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/react-bootstrap-icons/-/react-bootstrap-icons-1.5.0.tgz",
+      "integrity": "sha512-QC5q4meHQG0cO9RJzeDLSqZ1gbVa9jxFCpONCE3GYl2FkbAKSyJAEsONlzTApbZ8/oG87gPWq0xAyn5SZ/Jafw==",
+      "dependencies": {
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": "^16.8.6 || ^17"
       }
     },
     "node_modules/react-bootstrap-typeahead": {
@@ -39423,6 +39435,14 @@
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2"
+      }
+    },
+    "react-bootstrap-icons": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/react-bootstrap-icons/-/react-bootstrap-icons-1.5.0.tgz",
+      "integrity": "sha512-QC5q4meHQG0cO9RJzeDLSqZ1gbVa9jxFCpONCE3GYl2FkbAKSyJAEsONlzTApbZ8/oG87gPWq0xAyn5SZ/Jafw==",
+      "requires": {
+        "prop-types": "^15.7.2"
       }
     },
     "react-bootstrap-typeahead": {

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "process": "^0.11.10",
     "rdf-ext": "^1.3.5",
     "react": "^16.14.0",
+    "react-bootstrap-icons": "^1.5.0",
     "react-bootstrap-typeahead": "^5.2.0",
     "react-dom": "^16.14.0",
     "react-helmet-async": "^1.1.2",
@@ -192,7 +193,12 @@
       "lcov"
     ],
     "reporters": [
-      ["jest-summarizing-reporter", {"diffs": true}]
+      [
+        "jest-summarizing-reporter",
+        {
+          "diffs": true
+        }
+      ]
     ]
   },
   "optionalDependencies": {

--- a/src/components/templates/ResourceTemplateRow.jsx
+++ b/src/components/templates/ResourceTemplateRow.jsx
@@ -38,10 +38,10 @@ const ResourceTemplateRow = ({ row, handleClick, handleCopy, handleEdit }) => {
         <div className="btn-group" role="group" aria-label="Result Actions">
           {canCreate && (
             <Link
-              data-testid={`createResource-${row.resourceLabel}`}
               to={{ pathname: "/editor", state: {} }}
               onClick={(e) => handleClick(row.id, e)}
-              title="Create resource"
+              title={`Create resource for ${row.resourceLabel}`}
+              aria-label={`Create resource for ${row.resourceLabel}`}
             >
               <FileEarmarkPlusFill style={{ paddingRight: "10px" }} size={32} />
             </Link>
@@ -50,7 +50,7 @@ const ResourceTemplateRow = ({ row, handleClick, handleCopy, handleEdit }) => {
             <button
               type="button"
               className="btn btn-link"
-              title="Edit template"
+              title={`Edit ${row.resourceLabel}`}
               aria-label={`Edit ${row.resourceLabel}`}
               data-testid={`Edit ${row.resourceLabel}`}
               onClick={(e) => handleEdit(row.uri, e)}
@@ -63,7 +63,7 @@ const ResourceTemplateRow = ({ row, handleClick, handleCopy, handleEdit }) => {
               type="button"
               className="btn btn-link"
               onClick={() => handleCopy(row.uri)}
-              title="Copy template"
+              title={`Copy template ${row.resourceLabel}`}
               data-testid={`Copy ${row.resourceLabel}`}
               aria-label={`Copy ${row.resourceLabel}`}
             >

--- a/src/components/templates/ResourceTemplateRow.jsx
+++ b/src/components/templates/ResourceTemplateRow.jsx
@@ -6,9 +6,10 @@ import PropTypes from "prop-types"
 import { Link } from "react-router-dom"
 import LongDate from "components/LongDate"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
-import { faCopy, faEdit } from "@fortawesome/free-solid-svg-icons"
+import { faCopy, faPencilAlt } from "@fortawesome/free-solid-svg-icons"
 import usePermissions from "hooks/usePermissions"
 import { selectGroupMap } from "selectors/groups"
+import { FileEarmarkPlusFill } from "react-bootstrap-icons"
 
 /**
  * This is the list view of all the templates
@@ -20,16 +21,7 @@ const ResourceTemplateRow = ({ row, handleClick, handleCopy, handleEdit }) => {
   return (
     <tr key={row.id}>
       <td style={{ wordBreak: "break-all" }} data-testid="name">
-        {canCreate ? (
-          <Link
-            to={{ pathname: "/editor", state: {} }}
-            onClick={(e) => handleClick(row.id, e)}
-          >
-            {row.resourceLabel}
-          </Link>
-        ) : (
-          <span>{row.resourceLabel}</span>
-        )}
+        <span>{row.resourceLabel}</span>
         <br />
         {row.id}
       </td>
@@ -44,16 +36,26 @@ const ResourceTemplateRow = ({ row, handleClick, handleCopy, handleEdit }) => {
       <td style={{ wordBreak: "break-all" }}>{row.remark}</td>
       <td>
         <div className="btn-group" role="group" aria-label="Result Actions">
+          {canCreate && (
+            <Link
+              data-testid={`createResource-${row.resourceLabel}`}
+              to={{ pathname: "/editor", state: {} }}
+              onClick={(e) => handleClick(row.id, e)}
+              title="Create resource"
+            >
+              <FileEarmarkPlusFill style={{ paddingRight: "10px" }} size={32} />
+            </Link>
+          )}
           {canEdit(row) && (
             <button
               type="button"
               className="btn btn-link"
-              title="Edit"
+              title="Edit template"
               aria-label={`Edit ${row.resourceLabel}`}
               data-testid={`Edit ${row.resourceLabel}`}
               onClick={(e) => handleEdit(row.uri, e)}
             >
-              <FontAwesomeIcon icon={faEdit} className="icon-lg" />
+              <FontAwesomeIcon icon={faPencilAlt} className="icon-lg" />
             </button>
           )}
           {canCreate && (
@@ -61,7 +63,7 @@ const ResourceTemplateRow = ({ row, handleClick, handleCopy, handleEdit }) => {
               type="button"
               className="btn btn-link"
               onClick={() => handleCopy(row.uri)}
-              title="Copy"
+              title="Copy template"
               data-testid={`Copy ${row.resourceLabel}`}
               aria-label={`Copy ${row.resourceLabel}`}
             >

--- a/src/components/templates/ResourceTemplateSearchResult.jsx
+++ b/src/components/templates/ResourceTemplateSearchResult.jsx
@@ -31,7 +31,9 @@ const ResourceTemplateSearchResult = (props) => {
               <th style={{ width: "8%" }}>Group</th>
               <th style={{ width: "10%" }}>Date</th>
               <th style={{ width: "22%" }}>Guiding statement</th>
-              <th style={{ width: "4%" }} data-testid="action-col-header"></th>
+              <th style={{ width: "4%" }} data-testid="action-col-header">
+                Actions
+              </th>
             </tr>
           </thead>
           <tbody>{rows}</tbody>


### PR DESCRIPTION
## Why was this change made?

Fixes #2853:
- unlink resource template name as a way of creating a resource
- add the react-bootstrap icon module since we are now using it
- label column on dashboard with "Actions"
- add a new icon for create a resource to the Actions column
- change edit template icon to better match style shown in mockup
- add/adjust hover text for all icons
- fix the tests so they can find the new linking style of creating resources

Example for how it looks now:
![Screen Shot 2021-10-01 at 3 45 51 PM](https://user-images.githubusercontent.com/47137/135693558-d620b1ce-4cd4-48c0-8d36-01ff186706a5.png)

## How was this change tested?

Existing tests

## Which documentation and/or configurations were updated?



