### PR TITLE
Update the close button for Bootstrap 5

### DIFF
--- a/__tests__/components/ModalWrapper.test.js
+++ b/__tests__/components/ModalWrapper.test.js
@@ -15,9 +15,11 @@ const testModal = () => {
         <div className="modal-content">
           <div className="modal-header">
             <h5 className="modal-title">Modal title</h5>
-            <button type="button" className="close" aria-label="Close">
-              <span aria-hidden="true">&times;</span>
-            </button>
+            <button
+              type="button"
+              className="btn-close"
+              aria-label="Close"
+            ></button>
           </div>
           <div className="modal-body">
             <p>Modal body text goes here.</p>

--- a/src/components/Alert.jsx
+++ b/src/components/Alert.jsx
@@ -18,9 +18,7 @@ const Alert = (props) => {
             className="btn-close"
             data-bs-dismiss="alert"
             aria-label="Close"
-          >
-            <span aria-hidden="true">&times;</span>
-          </button>
+          ></button>
         </div>
       </div>
     </div>

--- a/src/components/ResourceTemplateChoiceModal.jsx
+++ b/src/components/ResourceTemplateChoiceModal.jsx
@@ -70,12 +70,10 @@ const ResourceTemplateChoiceModal = (props) => {
             <h4 className="modal-title">Choose resource template</h4>
             <button
               type="button"
-              className="close"
+              className="btn-close"
               onClick={close}
               aria-label="Close"
-            >
-              <span aria-hidden="true">&times;</span>
-            </button>
+            ></button>
           </div>
           <form className="group-select-options">
             <div className="modal-body group-panel">

--- a/src/components/ViewResourceModal.jsx
+++ b/src/components/ViewResourceModal.jsx
@@ -74,12 +74,10 @@ const ViewResourceModal = (props) => {
             <div className="view-resource-buttons">
               <button
                 type="button"
-                className="close modal-close"
+                className="btn-close"
                 onClick={close}
                 aria-label="Close"
-              >
-                <span aria-hidden="true">&times;</span>
-              </button>
+              ></button>
             </div>
           </div>
           <div className="modal-body view-resource-modal-content">

--- a/src/components/editor/EditorActions.jsx
+++ b/src/components/editor/EditorActions.jsx
@@ -13,7 +13,7 @@ const EditorActions = () => (
       <MarcButton />
       <CopyToNewButton />
       <PreviewButton />
-      <CloseButton />
+      <CloseButton label={"Close"} />
       <SaveAndPublishButton class="editor-save" />
     </div>
   </div>

--- a/src/components/editor/RDFModal.jsx
+++ b/src/components/editor/RDFModal.jsx
@@ -37,12 +37,10 @@ const RDFModal = (props) => {
             <h4 className="modal-title">RDF Preview</h4>
             <button
               type="button"
-              className="close"
+              className="btn-close"
               onClick={handleClose}
               aria-label="Close"
-            >
-              <span aria-hidden="true">&times;</span>
-            </button>
+            ></button>
           </div>
           <div className="modal-body rdf-modal-content">
             <div className="row" style={{ marginLeft: "0", marginRight: "0" }}>

--- a/src/components/editor/ResourcesNav.jsx
+++ b/src/components/editor/ResourcesNav.jsx
@@ -37,9 +37,7 @@ const ResourcesNav = () => {
     if (active) {
       itemClasses.push("active")
     } else {
-      closeButton = (
-        <CloseButton label={"×"} css={"button"} resourceKey={resourceKey} />
-      )
+      closeButton = <CloseButton css={"btn-close"} resourceKey={resourceKey} />
     }
     return (
       <li className={itemClasses.join(" ")} key={resourceKey}>
@@ -54,11 +52,7 @@ const ResourcesNav = () => {
                 {navLabels[resourceKey]}
               </a>
             </div>
-            {closeButton && (
-              <div className="col-1" style={{ padding: "0px" }}>
-                {closeButton}
-              </div>
-            )}
+            {closeButton}
           </div>
         </div>
       </li>

--- a/src/components/editor/actions/CloseButton.jsx
+++ b/src/components/editor/actions/CloseButton.jsx
@@ -33,7 +33,7 @@ const CloseButton = (props) => {
     event.preventDefault()
   }
   const btnClass = props.css || "btn-primary"
-  const buttonLabel = props.label || "Close"
+  const buttonLabel = props.label
   const buttonClasses = `btn ${btnClass}`
 
   const closeResource = () => {

--- a/src/components/editor/actions/CloseResourceModal.jsx
+++ b/src/components/editor/actions/CloseResourceModal.jsx
@@ -51,12 +51,10 @@ const CloseResourceModal = (props) => {
             </h4>
             <button
               type="button"
-              className="close"
+              className="btn-close"
               onClick={handleClose}
               aria-label="Close"
-            >
-              <span aria-hidden="true">&times;</span>
-            </button>
+            ></button>
           </div>
           <div className="modal-body rdf-modal-content">
             <div className="row">

--- a/src/components/menu/CanvasMenu.jsx
+++ b/src/components/menu/CanvasMenu.jsx
@@ -28,7 +28,7 @@ const CanvasMenu = (props) => {
       <button
         type="button"
         aria-label="Close Help Menu"
-        className="btn btn-link pull-right"
+        className="btn-close pull-right"
         href="#"
         onClick={props.closeHandleMenu}
       >

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -266,10 +266,6 @@ button.btn-add-instance {
   overflow-x: hidden;
 }
 
-.modal-close {
-  opacity: 1;
-}
-
 .lookup-value {
   background-color: $lookup-value-bg;
   font-weight: bold;
@@ -316,10 +312,4 @@ button.btn-add-instance {
 // Async typeahead
 div.rbt div {
   display: block !important;
-}
-
-button.close {
-  padding: 0px;
-  background-color: transparent;
-  border: 0px;
 }


### PR DESCRIPTION
## Why was this change made?

This is the prescribed way https://getbootstrap.com/docs/5.1/components/close-button/

## How was this change tested?

It used to look like this:

<img width="802" alt="Screen Shot 2021-10-04 at 5 10 22 PM" src="https://user-images.githubusercontent.com/92044/135931678-026e74a3-9a7d-4b7d-9954-ef0edd53e77f.png">

Now it looks like:
<img width="1149" alt="Screen Shot 2021-10-04 at 5 11 52 PM" src="https://user-images.githubusercontent.com/92044/135931791-9d5de8ed-2b5f-4678-9ece-1111b4f1ce48.png">
## Which documentation and/or configurations were updated?



