### PR TITLE
Add missing space on homepage.

### DIFF
--- a/src/components/home/DescPanel.jsx
+++ b/src/components/home/DescPanel.jsx
@@ -32,7 +32,7 @@ const DescPanel = () => {
         Sinopia is developed by the{" "}
         <a href="http://www.ld4p.org">
           Linked Data for Production: Pathway to Implementation (LD4P2)
-        </a>
+        </a>{" "}
         project, a collaboration among Cornell University, Harvard University,
         the Library of Congress, Stanford University, the School of Library and
         Information Science at the University of Iowa, and the Program for


### PR DESCRIPTION
## Why was this change made?
the JSX compiler is removing this important space.


## How was this change tested?



## Which documentation and/or configurations were updated?



