### PR TITLE
Remove unused styles

### DIFF
--- a/src/styles/lookupContext.scss
+++ b/src/styles/lookupContext.scss
@@ -1,20 +1,4 @@
 .lookup-search-results {
-  .nav-tabs {
-    margin-bottom: 1em;
-    border: 0;
-  }
-  .nav-tabs .nav-link {
-    border: 0;
-    font-size: larger;
-    font-weight: bold;
-    padding: 0 0.15em;
-    text-decoration: none;
-    &.active {
-      background-color: transparent;
-      border-bottom: 2px solid $gray-600;
-    }
-  }
-
   .btn.search-result {
     background-color: $pampas;
     border-radius: 0;


### PR DESCRIPTION
The lookup search results uses nav-pills not nav-tabs
See a8ecb820822a3f2a206fa157a433d9876bb5d738

## Why was this change made?



## How was this change tested?



## Which documentation and/or configurations were updated?



