### PR TITLE
remove old RDF loading instructions below fields

### DIFF
--- a/src/components/load/LoadByRDFForm.jsx
+++ b/src/components/load/LoadByRDFForm.jsx
@@ -112,10 +112,7 @@ const LoadByRDFForm = () => {
             onChange={(event) => changeRdf(event)}
             placeholder={rdfPlaceHolder}
           ></textarea>
-          <p className="text-muted">
-            Accepts JSON-LD, Turtle, TriG, N-Triples, N-Quads, and Notation3
-            (N3).
-          </p>
+          <p />
         </div>
         <div className="form-group">
           <label htmlFor="uriInput">
@@ -129,9 +126,7 @@ const LoadByRDFForm = () => {
             onChange={(event) => setBaseURI(event.target.value)}
             placeholder={baseURIPlaceholder}
           />
-          <p className="text-muted">
-            Omit brackets. If base URI is &lt;&gt;, leave blank.
-          </p>
+          <p />
         </div>
         <p className="text-muted">
           Clicking &ldquo;Submit&rdquo; will create a new resource that can be


### PR DESCRIPTION
## Why was this change made?

Fixes #3114 - remove now duplicated text under input fields (it is now above input fields)

### After

![image](https://user-images.githubusercontent.com/96775/136284381-34e430ef-3ca9-4a53-bf14-0e2e0179ebc3.png)

### Before

![image](https://user-images.githubusercontent.com/96775/136284461-fca1816c-0883-46b0-b661-09a297e79ed9.png)


## How was this change tested?



## Which documentation and/or configurations were updated?



