### PR TITLE
Enable the asset module to load images

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -52,8 +52,9 @@ module.exports = {
         ],
       },
       {
-        test: /\.(png|jpg|gif)$/,
-        use: ["file-loader"],
+        test: /\.(png|jpe?g|gif|svg|eot|ttf|woff|woff2)$/i,
+        // More information here https://webpack.js.org/guides/asset-modules/
+        type: "asset",
       },
     ],
   },


### PR DESCRIPTION
## Why was this change made?

Because images stopped loading.


## How was this change tested?



## Which documentation and/or configurations were updated?



