### PR TITLE
Update NewsItem.jsx

### DIFF
--- a/src/components/home/NewsItem.jsx
+++ b/src/components/home/NewsItem.jsx
@@ -5,7 +5,8 @@ import Package from "../../../package.json"
 
 const NewsItem = () => (
   <div className="news-item" data-testid="news-item">
-    <h3>Sinopia Version {Package.version} highlights</h3>
+  <h3>Latest News</h3>  
+  <h4>Sinopia Version {Package.version} highlights</h4>
     <p>
       <i>
         For complete release notes see the{" "}

--- a/src/components/home/NewsItem.jsx
+++ b/src/components/home/NewsItem.jsx
@@ -5,8 +5,7 @@ import Package from "../../../package.json"
 
 const NewsItem = () => (
   <div className="news-item" data-testid="news-item">
-    <h3>Latest news</h3>
-    <h4>Sinopia Version {Package.version} highlights</h4>
+    <h3>Sinopia Version {Package.version} highlights</h3>
     <p>
       <i>
         For complete release notes see the{" "}
@@ -17,7 +16,7 @@ const NewsItem = () => (
       </i>
     </p>
     <ul>
-      <li>Improved input experience for literal, lookup, and URI fields. .</li>
+      <li>Improved input experience for literal, lookup, and URI fields.</li>
     </ul>
   </div>
 )


### PR DESCRIPTION
remove "Latest News" line since there isn't any; remove extra space and period in bulleted item

## Why was this change made?



## How was this change tested?



## Which documentation and/or configurations were updated?



