### PR TITLE
prevent body from scrolling when language modal is open

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -1,6 +1,6 @@
 // Copyright 2019 Stanford University see LICENSE for license
 
-import React, { useEffect } from "react"
+import React, { useEffect, useLayoutEffect } from "react"
 import { Helmet, HelmetProvider } from "react-helmet-async"
 import Config from "Config"
 import "react-bootstrap-typeahead/css/Typeahead.css"
@@ -26,6 +26,7 @@ import Exports, { exportsErrorKey } from "./exports/Exports"
 import { selectCurrentResourceKey } from "selectors/resources"
 import { authenticate } from "actionCreators/authenticate"
 import { hasUser as hasUserSelector } from "selectors/authenticate"
+import { selectModalType } from "selectors/modals"
 
 const FourOhFour = () => <h1>404</h1>
 
@@ -42,6 +43,21 @@ const App = (props) => {
 
   const hasResource = useSelector((state) => !!selectCurrentResourceKey(state))
   const hasUser = useSelector((state) => hasUserSelector(state))
+  const isModalOpen = useSelector((state) => selectModalType(state))
+
+  // We do not use standard bootstrap modals (i.e. they are not triggered automatically)
+  //  due to complexities in the interaction between JS and React/redux.
+  //  This effect is used to prevent scrolling and dim the background behind the modal
+  //  which is typically done automatically by bootstrap.
+  useLayoutEffect(() => {
+    const bodyRoot = document.getElementsByTagName("body")[0]
+    if (isModalOpen) {
+      // if *any* modals are open, prevent scrolling and dim the background
+      bodyRoot.classList.add("modal-open")
+    } else {
+      bodyRoot.classList.remove("modal-open")
+    }
+  }, [isModalOpen])
 
   const routesWithCurrentUser = (
     <Switch>

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -321,3 +321,11 @@ div.rbt div {
   border-color: $nobel;
   background-color: $solitude;
 }
+
+.modal-open {
+  overflow: hidden;
+}
+
+.modal {
+  background: rgba(0, 0, 0, 0.5);
+}


### PR DESCRIPTION
## Why was this change made?

Fixes #3109 and #2176

We are doing some special sauce opening/closing of modals instead of using the standard Bootstrap way shown here: https://getbootstrap.com/docs/5.0/components/modal/

This means we need to deal with dimming the background and preventing scrolling ourselves via CSS/useLayoutEffect.  This does that.

This is how it looks with a language modal open (note: the main part of the page cannot be scrolled either):

<img width="837" alt="Screen Shot 2021-10-11 at 1 01 29 PM" src="https://user-images.githubusercontent.com/47137/136848914-80b8de30-57d0-4727-8074-3f4ec6375aff.png">

## How was this change tested?

Localhost browser


## Which documentation and/or configurations were updated?



