### PR TITLE
Revert "Add the group field to the search query"

### DIFF
--- a/__tests__/sinopiaSearch.test.js
+++ b/__tests__/sinopiaSearch.test.js
@@ -107,7 +107,7 @@ describe("getSearchResults", () => {
         bool: {
           must: {
             simple_query_string: {
-              fields: ["title^3", "subtitle^2", "uri^3", "text", "group"],
+              fields: ["title^3", "subtitle^2", "uri^3", "text"],
               default_operator: "AND",
               query: "foo",
             },
@@ -143,7 +143,7 @@ describe("getSearchResults", () => {
         bool: {
           must: {
             simple_query_string: {
-              fields: ["title^3", "subtitle^2", "uri^3", "text", "group"],
+              fields: ["title^3", "subtitle^2", "uri^3", "text"],
               default_operator: "AND",
               query: "foo",
             },
@@ -323,7 +323,7 @@ describe("getSearchResultsWithFacets", () => {
         bool: {
           must: {
             simple_query_string: {
-              fields: ["title^3", "subtitle^2", "uri^3", "text", "group"],
+              fields: ["title^3", "subtitle^2", "uri^3", "text"],
               default_operator: "AND",
               query: "foo",
             },
@@ -372,7 +372,7 @@ describe("getSearchResultsWithFacets", () => {
         bool: {
           must: {
             simple_query_string: {
-              fields: ["title^3", "subtitle^2", "uri^3", "text", "group"],
+              fields: ["title^3", "subtitle^2", "uri^3", "text"],
               default_operator: "AND",
               query: "foo",
             },

--- a/src/sinopiaSearch.js
+++ b/src/sinopiaSearch.js
@@ -37,7 +37,7 @@ export const getSearchResultsWithFacets = async (query, options = {}) => {
       bool: {
         must: {
           simple_query_string: {
-            fields: ["title^3", "subtitle^2", "uri^3", "text", "group"],
+            fields: ["title^3", "subtitle^2", "uri^3", "text"],
             default_operator: "AND",
             query,
           },


### PR DESCRIPTION
This reverts commit 4bf7151f2dff5e162345f584ef146a8342be3023.

## Why was this change made?

It was not the correct change to make: https://github.com/LD4P/sinopia_editor/pull/3108#issuecomment-939082091

## How was this change tested?



## Which documentation and/or configurations were updated?



