### PR TITLE
change link styles

### DIFF
--- a/src/styles/bootstrap-override.scss
+++ b/src/styles/bootstrap-override.scss
@@ -18,6 +18,10 @@ $primary-disabled: lighten(map-get($theme-colors, "secondary"), 20%);
 }
 
 .btn-link {
+  text-decoration: none;
+}
+
+.btn-link:hover {
   text-decoration: underline;
 }
 
@@ -27,6 +31,10 @@ body {
 }
 
 a {
+  text-decoration: none;
+}
+
+a:hover {
   text-decoration: underline;
 }
 

--- a/src/styles/header.scss
+++ b/src/styles/header.scss
@@ -16,6 +16,10 @@
     text-decoration: underline;
   }
 
+  a.nav-link:hover {
+    color: #2f2424;
+  }
+
   .hover {
     background-color: transparent;
   }


### PR DESCRIPTION
## Why was this change made?

Fixes #2851 - change link styles to blue, no underline, and then underline when hovered over.

Exceptions: 
- main nav links in header (e.g. "Dashboard", "Editor", "Resource Templates") are black, current page is bold and underlined
- icons that are links do not get underlined or change on hover

Of note, this changes the in template nav links on the editor page and the links to language modals.  See some examples below:

**Language modal links are no longer underlined, except on hover:**
 
![Screen Shot 2021-10-08 at 3 40 30 PM](https://user-images.githubusercontent.com/47137/136632070-d965c32b-d48f-4c03-b2e5-6d31dfa3c614.png)

**Language modal links on hover:** 

![Screen Shot 2021-10-08 at 3 40 37 PM](https://user-images.githubusercontent.com/47137/136632103-a640bf53-7730-4b90-ae7c-548c270efccb.png)

**Header links (when on "Editor", hovering over "Resource Templates):**

![Screen Shot 2021-10-08 at 3 40 44 PM](https://user-images.githubusercontent.com/47137/136632132-cb21c819-eb2d-482f-ae1d-9704cea861ea.png)

**Footer (hovering on first link):**

![Screen Shot 2021-10-08 at 3 40 57 PM](https://user-images.githubusercontent.com/47137/136632200-ae17f538-819b-48d4-90cb-5e803643c506.png)

**Editor left-nav (on Field 1, hovering on Field 2, if there was a Field 3 it would not be underlined):**

![Screen Shot 2021-10-08 at 3 47 42 PM](https://user-images.githubusercontent.com/47137/136632238-9fb60f27-1856-4ebd-afaa-d2821bf68d05.png)

## How was this change tested?

Localhost browser


## Which documentation and/or configurations were updated?



