### PR TITLE
actionCreators/resources: saveNewResource: tweak error message prefix

### DIFF
--- a/__tests__/actionCreators/resources.test.js
+++ b/__tests__/actionCreators/resources.test.js
@@ -750,7 +750,7 @@ describe("saveNewResource", () => {
 
     expect(actions).toHaveAction("ADD_ERROR", {
       errorKey: "testerror",
-      error: "Error saving: Messed-up",
+      error: "Error saving new resource: Messed-up",
     })
   })
 })

--- a/src/actionCreators/resources.js
+++ b/src/actionCreators/resources.js
@@ -250,7 +250,9 @@ export const saveNewResource =
       })
       .catch((err) => {
         console.error(err)
-        dispatch(addError(errorKey, `Error saving: ${err.message || err}`))
+        dispatch(
+          addError(errorKey, `Error saving new resource: ${err.message || err}`)
+        )
       })
   }
 


### PR DESCRIPTION
## Why was this change made?

connects to #2457 

Along with LD4P/sinopia_api/pull/199, gives clearer error message for Sinopia Editor users.

## How was this change tested?

## Which documentation and/or configurations were updated?



