### PR TITLE
editor header: Sinopia logo links to homepage

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -22,7 +22,9 @@ const Header = (props) => {
       <div className="editor-navbar">
         <div className="row">
           <div className="col-6">
-            <h1 className="editor-logo">Sinopia{`${Config.sinopiaEnv}`}</h1>
+            <a href="/">
+              <h1 className="editor-logo">Sinopia{`${Config.sinopiaEnv}`}</h1>
+            </a>
           </div>
           <div className="col-6">
             <ul className="nav pull-right">


### PR DESCRIPTION
## Why was this change made?

Fixes #3145 

The Sinopia logo now links to the homepage.  The gifs below shows that when you hover over it, it looks like a link, too:

Plain:

![image](https://user-images.githubusercontent.com/96775/136858037-765029aa-4b31-42c3-bdac-8500b7a4c45e.png)

Hovering Over:

![image](https://user-images.githubusercontent.com/96775/136858057-1ce57258-9637-4baf-afff-25bea0749191.png)

Where it Goes when you click on it:

![image](https://user-images.githubusercontent.com/96775/136858115-d5dd0b66-c558-458a-ae32-70108a11d760.png)


## How was this change tested?

locally

## Which documentation and/or configurations were updated?



