### PR TITLE
Expand property when necessary.

### DIFF
--- a/__tests__/__action_fixtures__/addSiblingValueSubject-ADD_VALUE.json
+++ b/__tests__/__action_fixtures__/addSiblingValueSubject-ADD_VALUE.json
@@ -78,8 +78,8 @@
             "properties": [
               {
                 "key": "abc1",
-                "values": null,
-                "show": false
+                "values": [],
+                "show": true
               }
             ]
           }

--- a/__tests__/__action_fixtures__/expandProperty-ADD_VALUE.json
+++ b/__tests__/__action_fixtures__/expandProperty-ADD_VALUE.json
@@ -116,8 +116,8 @@
         "properties": [
           {
             "key": "abc1",
-            "values": null,
-            "show": false
+            "values": [],
+            "show": true
           }
         ]
       }

--- a/__tests__/__action_fixtures__/loadResource-ADD_SUBJECT.json
+++ b/__tests__/__action_fixtures__/loadResource-ADD_SUBJECT.json
@@ -12,1044 +12,1419 @@
 			"author": "Justin Littman",
 			"remark": "Template for testing purposes.",
 			"date": "2020-07-27",
-      "group": "stanford",
-      "editGroups": [
-        "cornell"
-      ],        
 			"suppressible": false,
 			"propertyTemplateKeys": [
-				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property1", 
-				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property2", 
-				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property3", 
-				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property4", 
-				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property5", 
-				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property6", 
-				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property7", 
-				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property8", 
-				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property9", 
-				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property10", 
-				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property11", 
-				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property12", 
-				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property13", 
-				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property14", 
-				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property15", 
+				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property1",
+				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property2",
+				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property3",
+				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property4",
+				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property5",
+				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property6",
+				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property7",
+				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property8",
+				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property9",
+				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property10",
+				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property11",
+				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property12",
+				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property13",
+				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property14",
+				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property15",
 				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property16",
 				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property17",
 				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property18",
-				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property19", 
-				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/adminMetadata", 
-				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/hasInstance", 
-				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/instanceOf", 
-				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/hasItem", 
-				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/itemOf", 
-				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property20", 
-				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property21", 
+				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property19",
+				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/adminMetadata",
+				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/hasInstance",
+				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/instanceOf",
+				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/hasItem",
+				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/itemOf",
+				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property20",
+				"resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property21",
 				"resourceTemplate:testing:uber1 > http://www.w3.org/2000/01/rdf-schema#label"
 			],
-			"propertyTemplates": [{
-				"key": "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property1",
-				"subjectTemplateKey": "resourceTemplate:testing:uber1",
-				"label": "Uber template1, property1",
-				"uri": "http://id.loc.gov/ontologies/bibframe/uber/template1/property1",
-				"required": false,
-				"repeatable": true,
-				"ordered": false,
-				"remark": "Multiple nested, repeatable resource templates.",
-				"remarkUrl": null,
-				"defaults": [],
-				"valueSubjectTemplateKeys": ["resourceTemplate:testing:uber2", "resourceTemplate:testing:uber3"],
-				"authorities": [],
-				"type": "resource",
-				"component": "NestedResource"
-			}, {
-				"key": "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property2",
-				"subjectTemplateKey": "resourceTemplate:testing:uber1",
-				"label": "Uber template1, property2",
-				"uri": "http://id.loc.gov/ontologies/bibframe/uber/template1/property2",
-				"required": false,
-				"repeatable": true,
-				"ordered": false,
-				"remark": "A repeatable literal.",
-				"remarkUrl": null,
-				"defaults": [],
-				"valueSubjectTemplateKeys": [],
-				"authorities": [],
-				"type": "literal",
-				"component": "InputLiteral"
-			}, {
-				"key": "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property3",
-				"subjectTemplateKey": "resourceTemplate:testing:uber1",
-				"label": "Uber template1, property3",
-				"uri": "http://id.loc.gov/ontologies/bibframe/uber/template1/property3",
-				"required": false,
-				"repeatable": false,
-				"ordered": false,
-				"remark": "Multiple nested, non-repeatable resource templates.",
-				"remarkUrl": null,
-				"defaults": [],
-				"valueSubjectTemplateKeys": ["resourceTemplate:testing:uber2", "resourceTemplate:testing:uber3"],
-				"authorities": [],
-				"type": "resource",
-				"component": "NestedResource"
-			}, {
-				"key": "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property4",
-				"subjectTemplateKey": "resourceTemplate:testing:uber1",
-				"label": "Uber template1, property4",
-				"uri": "http://id.loc.gov/ontologies/bibframe/uber/template1/property4",
-				"required": true,
-				"repeatable": false,
-				"ordered": false,
-				"remark": "A non-repeatable literal.",
-				"remarkUrl": null,
-				"defaults": [],
-				"valueSubjectTemplateKeys": [],
-				"authorities": [],
-				"type": "literal",
-				"component": "InputLiteral"
-			}, {
-				"key": "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property5",
-				"subjectTemplateKey": "resourceTemplate:testing:uber1",
-				"label": "Uber template1, property5",
-				"uri": "http://id.loc.gov/ontologies/bibframe/uber/template1/property5",
-				"required": true,
-				"repeatable": false,
-				"ordered": false,
-				"remark": "A non-repeatable URI.",
-				"remarkUrl": null,
-				"defaults": [],
-				"valueSubjectTemplateKeys": [],
-				"authorities": [],
-				"type": "uri",
-				"component": "InputURI"
-			}, {
-				"key": "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property6",
-				"subjectTemplateKey": "resourceTemplate:testing:uber1",
-				"label": "Uber template1, property6",
-				"uri": "http://id.loc.gov/ontologies/bibframe/uber/template1/property6",
-				"required": true,
-				"repeatable": true,
-				"ordered": false,
-				"remark": "A repeatable URI.",
-				"remarkUrl": null,
-				"defaults": [],
-				"valueSubjectTemplateKeys": [],
-				"authorities": [],
-				"type": "uri",
-				"component": "InputURI"
-			}, {
-				"key": "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property7",
-				"subjectTemplateKey": "resourceTemplate:testing:uber1",
-				"label": "Uber template1, property7",
-				"uri": "http://id.loc.gov/ontologies/bibframe/uber/template1/property7",
-				"required": false,
-				"repeatable": true,
-				"ordered": false,
-				"remark": "A repeatable literal with defaults.",
-				"remarkUrl": null,
-				"defaults": [{
-					"literal": "Default literal1",
-					"lang": null
-				}, {
-					"literal": "Default literal2",
-					"lang": null
-				}],
-				"valueSubjectTemplateKeys": [],
-				"authorities": [],
-				"type": "literal",
-				"component": "InputLiteral"
-			}, {
-				"key": "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property8",
-				"subjectTemplateKey": "resourceTemplate:testing:uber1",
-				"label": "Uber template1, property8",
-				"uri": "http://id.loc.gov/ontologies/bibframe/uber/template1/property8",
-				"required": false,
-				"repeatable": true,
-				"ordered": false,
-				"remark": "A repeatable URI with defaults.",
-				"remarkUrl": null,
-				"defaults": [{
-					"uri": "http://sinopia.io/defaultURI1",
-					"label": "Default URI1"
-				}, {
-					"uri": "http://sinopia.io/defaultURI2",
-					"label": null
-				}],
-				"valueSubjectTemplateKeys": [],
-				"authorities": [],
-				"type": "uri",
-				"component": "InputURI"
-			}, {
-				"key": "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property9",
-				"subjectTemplateKey": "resourceTemplate:testing:uber1",
-				"label": "Uber template1, property9",
-				"uri": "http://id.loc.gov/ontologies/bibframe/uber/template1/property9",
-				"required": true,
-				"repeatable": false,
-				"ordered": false,
-				"remark": null,
-				"remarkUrl": "http://access.rdatoolkit.org/2.13.html",
-				"defaults": [],
-				"valueSubjectTemplateKeys": [],
-				"authorities": [],
-				"type": "literal",
-				"component": "InputLiteral"
-			}, {
-				"key": "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property10",
-				"subjectTemplateKey": "resourceTemplate:testing:uber1",
-				"label": "Uber template1, property10",
-				"uri": "http://id.loc.gov/ontologies/bibframe/uber/template1/property10",
-				"required": true,
-				"repeatable": false,
-				"ordered": false,
-				"remark": "A non-repeatable LOC lookup.",
-				"remarkUrl": null,
-				"defaults": [],
-				"valueSubjectTemplateKeys": [],
-				"authorities": [{
-					"uri": "https://id.loc.gov/vocabulary/mrectype",
-					"label": "type of recording",
-					"nonldLookup": false
-				}],
-				"type": "uri",
-				"component": "InputList"
-			}, {
-				"key": "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property11",
-				"subjectTemplateKey": "resourceTemplate:testing:uber1",
-				"label": "Uber template1, property11",
-				"uri": "http://id.loc.gov/ontologies/bibframe/uber/template1/property11",
-				"required": true,
-				"repeatable": true,
-				"ordered": false,
-				"remark": "A repeatable LOC lookup.",
-				"remarkUrl": null,
-				"defaults": [],
-				"valueSubjectTemplateKeys": [],
-				"authorities": [{
-					"uri": "https://id.loc.gov/vocabulary/mrectype",
-					"label": "type of recording",
-					"nonldLookup": false
-				}],
-				"type": "uri",
-				"component": "InputList"
-			}, {
-				"key": "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property12",
-				"subjectTemplateKey": "resourceTemplate:testing:uber1",
-				"label": "Uber template1, property12",
-				"uri": "http://id.loc.gov/ontologies/bibframe/uber/template1/property12",
-				"required": true,
-				"repeatable": false,
-				"ordered": false,
-				"remark": "A LOC lookup with multiple authorities.",
-				"remarkUrl": null,
-				"defaults": [],
-				"valueSubjectTemplateKeys": [],
-				"authorities": [{
-					"uri": "https://id.loc.gov/vocabulary/mrectype",
-					"label": "type of recording",
-					"nonldLookup": false
-				}, {
-					"uri": "https://id.loc.gov/vocabulary/mrecmedium",
-					"label": "recording medium",
-					"nonldLookup": false
-				}],
-				"type": "uri",
-				"component": "InputList"
-			}, {
-				"key": "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property13",
-				"subjectTemplateKey": "resourceTemplate:testing:uber1",
-				"label": "Uber template1, property13",
-				"uri": "http://id.loc.gov/ontologies/bibframe/uber/template1/property13",
-				"required": true,
-				"repeatable": false,
-				"ordered": false,
-				"remark": "A non-repeatable QA lookup.",
-				"remarkUrl": null,
-				"defaults": [],
-				"valueSubjectTemplateKeys": [],
-				"authorities": [{
-					"uri": "urn:ld4p:qa:agrovoc",
-					"label": "AGROVOC (QA)",
-					"authority": "agrovoc_ld4l_cache",
-					"subauthority": "",
-					"nonldLookup": false
-				}, {
-					"authority": "getty_aat_ld4l_cache",
-					"label": "GETTY_AAT  (QA)",
-					"nonldLookup": false,
-					"subauthority": "",
-					"uri": "urn:ld4p:qa:gettyaat"
+			"propertyTemplates": [
+				{
+					"key": "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property1",
+					"subjectTemplateKey": "resourceTemplate:testing:uber1",
+					"label": "Uber template1, property1",
+					"uri": "http://id.loc.gov/ontologies/bibframe/uber/template1/property1",
+					"required": false,
+					"repeatable": true,
+					"ordered": false,
+					"remark": "Multiple nested, repeatable resource templates.",
+					"remarkUrl": null,
+					"defaults": [],
+					"valueSubjectTemplateKeys": [
+						"resourceTemplate:testing:uber2",
+						"resourceTemplate:testing:uber3"
+					],
+					"authorities": [],
+					"type": "resource",
+					"component": "NestedResource"
+				},
+				{
+					"key": "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property2",
+					"subjectTemplateKey": "resourceTemplate:testing:uber1",
+					"label": "Uber template1, property2",
+					"uri": "http://id.loc.gov/ontologies/bibframe/uber/template1/property2",
+					"required": false,
+					"repeatable": true,
+					"ordered": false,
+					"remark": "A repeatable literal.",
+					"remarkUrl": null,
+					"defaults": [],
+					"valueSubjectTemplateKeys": [],
+					"authorities": [],
+					"type": "literal",
+					"component": "InputLiteral"
+				},
+				{
+					"key": "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property3",
+					"subjectTemplateKey": "resourceTemplate:testing:uber1",
+					"label": "Uber template1, property3",
+					"uri": "http://id.loc.gov/ontologies/bibframe/uber/template1/property3",
+					"required": false,
+					"repeatable": false,
+					"ordered": false,
+					"remark": "Multiple nested, non-repeatable resource templates.",
+					"remarkUrl": null,
+					"defaults": [],
+					"valueSubjectTemplateKeys": [
+						"resourceTemplate:testing:uber2",
+						"resourceTemplate:testing:uber3"
+					],
+					"authorities": [],
+					"type": "resource",
+					"component": "NestedResource"
+				},
+				{
+					"key": "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property4",
+					"subjectTemplateKey": "resourceTemplate:testing:uber1",
+					"label": "Uber template1, property4",
+					"uri": "http://id.loc.gov/ontologies/bibframe/uber/template1/property4",
+					"required": true,
+					"repeatable": false,
+					"ordered": false,
+					"remark": "A non-repeatable literal.",
+					"remarkUrl": null,
+					"defaults": [],
+					"valueSubjectTemplateKeys": [],
+					"authorities": [],
+					"type": "literal",
+					"component": "InputLiteral"
+				},
+				{
+					"key": "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property5",
+					"subjectTemplateKey": "resourceTemplate:testing:uber1",
+					"label": "Uber template1, property5",
+					"uri": "http://id.loc.gov/ontologies/bibframe/uber/template1/property5",
+					"required": true,
+					"repeatable": false,
+					"ordered": false,
+					"remark": "A non-repeatable URI.",
+					"remarkUrl": null,
+					"defaults": [],
+					"valueSubjectTemplateKeys": [],
+					"authorities": [],
+					"type": "uri",
+					"component": "InputURI"
+				},
+				{
+					"key": "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property6",
+					"subjectTemplateKey": "resourceTemplate:testing:uber1",
+					"label": "Uber template1, property6",
+					"uri": "http://id.loc.gov/ontologies/bibframe/uber/template1/property6",
+					"required": true,
+					"repeatable": true,
+					"ordered": false,
+					"remark": "A repeatable URI.",
+					"remarkUrl": null,
+					"defaults": [],
+					"valueSubjectTemplateKeys": [],
+					"authorities": [],
+					"type": "uri",
+					"component": "InputURI"
+				},
+				{
+					"key": "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property7",
+					"subjectTemplateKey": "resourceTemplate:testing:uber1",
+					"label": "Uber template1, property7",
+					"uri": "http://id.loc.gov/ontologies/bibframe/uber/template1/property7",
+					"required": false,
+					"repeatable": true,
+					"ordered": false,
+					"remark": "A repeatable literal with defaults.",
+					"remarkUrl": null,
+					"defaults": [
+						{
+							"literal": "Default literal1",
+							"lang": null
+						},
+						{
+							"literal": "Default literal2",
+							"lang": null
+						}
+					],
+					"valueSubjectTemplateKeys": [],
+					"authorities": [],
+					"type": "literal",
+					"component": "InputLiteral"
+				},
+				{
+					"key": "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property8",
+					"subjectTemplateKey": "resourceTemplate:testing:uber1",
+					"label": "Uber template1, property8",
+					"uri": "http://id.loc.gov/ontologies/bibframe/uber/template1/property8",
+					"required": false,
+					"repeatable": true,
+					"ordered": false,
+					"remark": "A repeatable URI with defaults.",
+					"remarkUrl": null,
+					"defaults": [
+						{
+							"uri": "http://sinopia.io/defaultURI1",
+							"label": "Default URI1"
+						},
+						{
+							"uri": "http://sinopia.io/defaultURI2",
+							"label": null
+						}
+					],
+					"valueSubjectTemplateKeys": [],
+					"authorities": [],
+					"type": "uri",
+					"component": "InputURI"
+				},
+				{
+					"key": "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property9",
+					"subjectTemplateKey": "resourceTemplate:testing:uber1",
+					"label": "Uber template1, property9",
+					"uri": "http://id.loc.gov/ontologies/bibframe/uber/template1/property9",
+					"required": true,
+					"repeatable": false,
+					"ordered": false,
+					"remark": null,
+					"remarkUrl": "http://access.rdatoolkit.org/2.13.html",
+					"defaults": [],
+					"valueSubjectTemplateKeys": [],
+					"authorities": [],
+					"type": "literal",
+					"component": "InputLiteral"
+				},
+				{
+					"key": "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property10",
+					"subjectTemplateKey": "resourceTemplate:testing:uber1",
+					"label": "Uber template1, property10",
+					"uri": "http://id.loc.gov/ontologies/bibframe/uber/template1/property10",
+					"required": true,
+					"repeatable": false,
+					"ordered": false,
+					"remark": "A non-repeatable LOC lookup.",
+					"remarkUrl": null,
+					"defaults": [],
+					"valueSubjectTemplateKeys": [],
+					"authorities": [
+						{
+							"uri": "https://id.loc.gov/vocabulary/mrectype",
+							"label": "type of recording",
+							"nonldLookup": false
+						}
+					],
+					"type": "uri",
+					"component": "InputList"
+				},
+				{
+					"key": "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property11",
+					"subjectTemplateKey": "resourceTemplate:testing:uber1",
+					"label": "Uber template1, property11",
+					"uri": "http://id.loc.gov/ontologies/bibframe/uber/template1/property11",
+					"required": true,
+					"repeatable": true,
+					"ordered": false,
+					"remark": "A repeatable LOC lookup.",
+					"remarkUrl": null,
+					"defaults": [],
+					"valueSubjectTemplateKeys": [],
+					"authorities": [
+						{
+							"uri": "https://id.loc.gov/vocabulary/mrectype",
+							"label": "type of recording",
+							"nonldLookup": false
+						}
+					],
+					"type": "uri",
+					"component": "InputList"
+				},
+				{
+					"key": "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property12",
+					"subjectTemplateKey": "resourceTemplate:testing:uber1",
+					"label": "Uber template1, property12",
+					"uri": "http://id.loc.gov/ontologies/bibframe/uber/template1/property12",
+					"required": true,
+					"repeatable": false,
+					"ordered": false,
+					"remark": "A LOC lookup with multiple authorities.",
+					"remarkUrl": null,
+					"defaults": [],
+					"valueSubjectTemplateKeys": [],
+					"authorities": [
+						{
+							"uri": "https://id.loc.gov/vocabulary/mrectype",
+							"label": "type of recording",
+							"nonldLookup": false
+						},
+						{
+							"uri": "https://id.loc.gov/vocabulary/mrecmedium",
+							"label": "recording medium",
+							"nonldLookup": false
+						}
+					],
+					"type": "uri",
+					"component": "InputList"
+				},
+				{
+					"key": "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property13",
+					"subjectTemplateKey": "resourceTemplate:testing:uber1",
+					"label": "Uber template1, property13",
+					"uri": "http://id.loc.gov/ontologies/bibframe/uber/template1/property13",
+					"required": true,
+					"repeatable": false,
+					"ordered": false,
+					"remark": "A non-repeatable QA lookup.",
+					"remarkUrl": null,
+					"defaults": [],
+					"valueSubjectTemplateKeys": [],
+					"authorities": [
+						{
+							"uri": "urn:ld4p:qa:agrovoc",
+							"label": "AGROVOC (QA)",
+							"authority": "agrovoc_ld4l_cache",
+							"subauthority": "",
+							"nonldLookup": false
+						},
+						{
+							"uri": "urn:ld4p:qa:gettyaat",
+							"label": "GETTY_AAT  (QA)",
+							"authority": "getty_aat_ld4l_cache",
+							"subauthority": "",
+							"nonldLookup": false
+						}
+					],
+					"type": "uri",
+					"component": "InputLookup"
+				},
+				{
+					"key": "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property14",
+					"subjectTemplateKey": "resourceTemplate:testing:uber1",
+					"label": "Uber template1, property14",
+					"uri": "http://id.loc.gov/ontologies/bibframe/uber/template1/property14",
+					"required": true,
+					"repeatable": true,
+					"ordered": false,
+					"remark": "A repeatable QA lookup.",
+					"remarkUrl": null,
+					"defaults": [],
+					"valueSubjectTemplateKeys": [],
+					"authorities": [
+						{
+							"uri": "urn:ld4p:qa:agrovoc",
+							"label": "AGROVOC (QA)",
+							"authority": "agrovoc_ld4l_cache",
+							"subauthority": "",
+							"nonldLookup": false
+						}
+					],
+					"type": "uri",
+					"component": "InputLookup"
+				},
+				{
+					"key": "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property15",
+					"subjectTemplateKey": "resourceTemplate:testing:uber1",
+					"label": "Uber template1, property15",
+					"uri": "http://id.loc.gov/ontologies/bibframe/uber/template1/property15",
+					"required": true,
+					"repeatable": false,
+					"ordered": false,
+					"remark": "A QA lookup with multiple authorities.",
+					"remarkUrl": null,
+					"defaults": [],
+					"valueSubjectTemplateKeys": [],
+					"authorities": [
+						{
+							"uri": "urn:ld4p:qa:agrovoc",
+							"label": "AGROVOC (QA)",
+							"authority": "agrovoc_ld4l_cache",
+							"subauthority": "",
+							"nonldLookup": false
+						},
+						{
+							"uri": "urn:ld4p:qa:geonames:spot",
+							"label": "GEONAMES spot (QA)",
+							"authority": "geonames_ld4l_cache",
+							"subauthority": "spot",
+							"nonldLookup": false
+						}
+					],
+					"type": "uri",
+					"component": "InputLookup"
+				},
+				{
+					"key": "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property16",
+					"subjectTemplateKey": "resourceTemplate:testing:uber1",
+					"label": "Uber template1, property16",
+					"uri": "http://id.loc.gov/ontologies/bibframe/uber/template1/property16",
+					"required": true,
+					"repeatable": false,
+					"ordered": false,
+					"remark": "A non-repeatable Sinopia lookup.",
+					"remarkUrl": null,
+					"defaults": [],
+					"valueSubjectTemplateKeys": [],
+					"authorities": [
+						{
+							"uri": "urn:ld4p:sinopia:bibframe:instance",
+							"label": "Sinopia BIBFRAME instance resources",
+							"nonldLookup": false,
+							"type": "http://id.loc.gov/ontologies/bibframe/Instance"
+						}
+					],
+					"type": "uri",
+					"component": "InputLookup"
+				},
+				{
+					"key": "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property17",
+					"subjectTemplateKey": "resourceTemplate:testing:uber1",
+					"label": "Uber template1, property17",
+					"uri": "http://id.loc.gov/ontologies/bibframe/uber/template1/property17",
+					"required": true,
+					"repeatable": true,
+					"ordered": false,
+					"remark": "A repeatable Sinopia lookup.",
+					"remarkUrl": null,
+					"defaults": [],
+					"valueSubjectTemplateKeys": [],
+					"authorities": [
+						{
+							"uri": "urn:ld4p:sinopia:bibframe:instance",
+							"label": "Sinopia BIBFRAME instance resources",
+							"nonldLookup": false,
+							"type": "http://id.loc.gov/ontologies/bibframe/Instance"
+						}
+					],
+					"type": "uri",
+					"component": "InputLookup"
+				},
+				{
+					"key": "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property18",
+					"subjectTemplateKey": "resourceTemplate:testing:uber1",
+					"label": "Uber template1, property18",
+					"uri": "http://id.loc.gov/ontologies/bibframe/uber/template1/property18",
+					"required": true,
+					"repeatable": true,
+					"ordered": false,
+					"remark": "Mandatory nested resource templates.",
+					"remarkUrl": null,
+					"defaults": [],
+					"valueSubjectTemplateKeys": [
+						"resourceTemplate:testing:uber4"
+					],
+					"authorities": [],
+					"type": "resource",
+					"component": "NestedResource"
+				},
+				{
+					"key": "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property19",
+					"subjectTemplateKey": "resourceTemplate:testing:uber1",
+					"label": "Uber template1, property19",
+					"uri": "http://id.loc.gov/ontologies/bibframe/uber/template1/property19",
+					"required": false,
+					"repeatable": true,
+					"ordered": true,
+					"remark": "Ordered nested resource templates.",
+					"remarkUrl": null,
+					"defaults": [],
+					"valueSubjectTemplateKeys": [
+						"resourceTemplate:testing:uber4"
+					],
+					"authorities": [],
+					"type": "resource",
+					"component": "NestedResource"
+				},
+				{
+					"key": "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/adminMetadata",
+					"subjectTemplateKey": "resourceTemplate:testing:uber1",
+					"label": "Admin metadata",
+					"uri": "http://id.loc.gov/ontologies/bibframe/adminMetadata",
+					"required": false,
+					"repeatable": false,
+					"ordered": false,
+					"remark": null,
+					"remarkUrl": null,
+					"defaults": [],
+					"valueSubjectTemplateKeys": [],
+					"authorities": [
+						{
+							"uri": "urn:ld4p:sinopia:bibframe:adminMetadata",
+							"label": "Sinopia BIBFRAME admin metadata resources",
+							"nonldLookup": false,
+							"type": "http://id.loc.gov/ontologies/bibframe/AdminMetadata"
+						}
+					],
+					"type": "uri",
+					"component": "InputLookup"
+				},
+				{
+					"key": "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/hasInstance",
+					"subjectTemplateKey": "resourceTemplate:testing:uber1",
+					"label": "Has instance",
+					"uri": "http://id.loc.gov/ontologies/bibframe/hasInstance",
+					"required": false,
+					"repeatable": true,
+					"ordered": false,
+					"remark": null,
+					"remarkUrl": null,
+					"defaults": [],
+					"valueSubjectTemplateKeys": [],
+					"authorities": [
+						{
+							"uri": "urn:ld4p:sinopia:bibframe:instance",
+							"label": "Sinopia BIBFRAME instance resources",
+							"nonldLookup": false,
+							"type": "http://id.loc.gov/ontologies/bibframe/Instance"
+						}
+					],
+					"type": "uri",
+					"component": "InputLookup"
+				},
+				{
+					"key": "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/instanceOf",
+					"subjectTemplateKey": "resourceTemplate:testing:uber1",
+					"label": "Instance of",
+					"uri": "http://id.loc.gov/ontologies/bibframe/instanceOf",
+					"required": false,
+					"repeatable": true,
+					"ordered": false,
+					"remark": null,
+					"remarkUrl": null,
+					"defaults": [],
+					"valueSubjectTemplateKeys": [],
+					"authorities": [
+						{
+							"uri": "urn:ld4p:sinopia:bibframe:work",
+							"label": "Sinopia BIBFRAME work resources",
+							"nonldLookup": false,
+							"type": "http://id.loc.gov/ontologies/bibframe/Work"
+						}
+					],
+					"type": "uri",
+					"component": "InputLookup"
+				},
+				{
+					"key": "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/hasItem",
+					"subjectTemplateKey": "resourceTemplate:testing:uber1",
+					"label": "Has item",
+					"uri": "http://id.loc.gov/ontologies/bibframe/hasItem",
+					"required": false,
+					"repeatable": true,
+					"ordered": false,
+					"remark": null,
+					"remarkUrl": null,
+					"defaults": [],
+					"valueSubjectTemplateKeys": [],
+					"authorities": [
+						{
+							"uri": "urn:ld4p:sinopia:bibframe:item",
+							"label": "Sinopia BIBFRAME item resources",
+							"nonldLookup": false,
+							"type": "http://id.loc.gov/ontologies/bibframe/Item"
+						}
+					],
+					"type": "uri",
+					"component": "InputLookup"
+				},
+				{
+					"key": "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/itemOf",
+					"subjectTemplateKey": "resourceTemplate:testing:uber1",
+					"label": "Item of",
+					"uri": "http://id.loc.gov/ontologies/bibframe/itemOf",
+					"required": false,
+					"repeatable": true,
+					"ordered": false,
+					"remark": null,
+					"remarkUrl": null,
+					"defaults": [],
+					"valueSubjectTemplateKeys": [],
+					"authorities": [
+						{
+							"uri": "urn:ld4p:sinopia:bibframe:instance",
+							"label": "Sinopia BIBFRAME instance resources",
+							"nonldLookup": false,
+							"type": "http://id.loc.gov/ontologies/bibframe/Instance"
+						}
+					],
+					"type": "uri",
+					"component": "InputLookup"
+				},
+				{
+					"key": "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property20",
+					"subjectTemplateKey": "resourceTemplate:testing:uber1",
+					"label": "Uber template1, property20",
+					"uri": "http://id.loc.gov/ontologies/bibframe/uber/template1/property20",
+					"required": true,
+					"repeatable": false,
+					"ordered": false,
+					"remark": "A required, repeatable literal with defaults.",
+					"remarkUrl": null,
+					"defaults": [
+						{
+							"literal": "Default required literal1",
+							"lang": null
+						},
+						{
+							"literal": "Default required literal2",
+							"lang": null
+						}
+					],
+					"valueSubjectTemplateKeys": [],
+					"authorities": [],
+					"type": "literal",
+					"component": "InputLiteral"
+				},
+				{
+					"key": "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property21",
+					"subjectTemplateKey": "resourceTemplate:testing:uber1",
+					"label": "Uber template1, property21",
+					"uri": "http://id.loc.gov/ontologies/bibframe/uber/template1/property21",
+					"required": false,
+					"repeatable": true,
+					"ordered": false,
+					"remark": "Nested, repeatable, suppressible resource template.",
+					"remarkUrl": null,
+					"defaults": [],
+					"valueSubjectTemplateKeys": [
+						"resourceTemplate:testing:uber5"
+					],
+					"authorities": [],
+					"type": "resource",
+					"component": "NestedResource"
+				},
+				{
+					"key": "resourceTemplate:testing:uber1 > http://www.w3.org/2000/01/rdf-schema#label",
+					"subjectTemplateKey": "resourceTemplate:testing:uber1",
+					"label": "rdfs label",
+					"uri": "http://www.w3.org/2000/01/rdf-schema#label",
+					"required": false,
+					"repeatable": false,
+					"ordered": false,
+					"remark": "rdfs label",
+					"remarkUrl": null,
+					"defaults": [],
+					"valueSubjectTemplateKeys": [],
+					"authorities": [],
+					"type": "literal",
+					"component": "InputLiteral"
 				}
 			],
-				"type": "uri",
-				"component": "InputLookup"
-			}, {
-				"key": "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property14",
-				"subjectTemplateKey": "resourceTemplate:testing:uber1",
-				"label": "Uber template1, property14",
-				"uri": "http://id.loc.gov/ontologies/bibframe/uber/template1/property14",
-				"required": true,
-				"repeatable": true,
-				"ordered": false,
-				"remark": "A repeatable QA lookup.",
-				"remarkUrl": null,
-				"defaults": [],
-				"valueSubjectTemplateKeys": [],
-				"authorities": [{
-					"uri": "urn:ld4p:qa:agrovoc",
-					"label": "AGROVOC (QA)",
-					"authority": "agrovoc_ld4l_cache",
-					"subauthority": "",
-					"nonldLookup": false
-				}],
-				"type": "uri",
-				"component": "InputLookup"
-			}, {
-				"key": "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property15",
-				"subjectTemplateKey": "resourceTemplate:testing:uber1",
-				"label": "Uber template1, property15",
-				"uri": "http://id.loc.gov/ontologies/bibframe/uber/template1/property15",
-				"required": true,
-				"repeatable": false,
-				"ordered": false,
-				"remark": "A QA lookup with multiple authorities.",
-				"remarkUrl": null,
-				"defaults": [],
-				"valueSubjectTemplateKeys": [],
-				"authorities": [{
-					"uri": "urn:ld4p:qa:agrovoc",
-					"label": "AGROVOC (QA)",
-					"authority": "agrovoc_ld4l_cache",
-					"subauthority": "",
-					"nonldLookup": false
-				}, {
-					"uri": "urn:ld4p:qa:geonames:spot",
-					"label": "GEONAMES spot (QA)",
-					"authority": "geonames_ld4l_cache",
-					"subauthority": "spot",
-					"nonldLookup": false
-				}],
-				"type": "uri",
-				"component": "InputLookup"
-			}, {
-				"key": "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property16",
-				"subjectTemplateKey": "resourceTemplate:testing:uber1",
-				"label": "Uber template1, property16",
-				"uri": "http://id.loc.gov/ontologies/bibframe/uber/template1/property16",
-				"required": true,
-				"repeatable": false,
-				"ordered": false,
-				"remark": "A non-repeatable Sinopia lookup.",
-				"remarkUrl": null,
-				"defaults": [],
-				"valueSubjectTemplateKeys": [],
-				"authorities": [{
-					"uri": "urn:ld4p:sinopia:bibframe:instance",
-					"label": "Sinopia BIBFRAME instance resources",
-					"nonldLookup": false,
-					"type": "http://id.loc.gov/ontologies/bibframe/Instance"
-				}],
-				"type": "uri",
-				"component": "InputLookup"
-			}, {
-				"key": "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property17",
-				"subjectTemplateKey": "resourceTemplate:testing:uber1",
-				"label": "Uber template1, property17",
-				"uri": "http://id.loc.gov/ontologies/bibframe/uber/template1/property17",
-				"required": true,
-				"repeatable": true,
-				"ordered": false,
-				"remark": "A repeatable Sinopia lookup.",
-				"remarkUrl": null,
-				"defaults": [],
-				"valueSubjectTemplateKeys": [],
-				"authorities": [{
-					"uri": "urn:ld4p:sinopia:bibframe:instance",
-					"label": "Sinopia BIBFRAME instance resources",
-					"nonldLookup": false,
-					"type": "http://id.loc.gov/ontologies/bibframe/Instance"
-				}],
-				"type": "uri",
-				"component": "InputLookup"
-			}, {
-				"key": "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property18",
-				"subjectTemplateKey": "resourceTemplate:testing:uber1",
-				"label": "Uber template1, property18",
-				"uri": "http://id.loc.gov/ontologies/bibframe/uber/template1/property18",
-				"required": true,
-				"repeatable": true,
-				"ordered": false,
-				"remark": "Mandatory nested resource templates.",
-				"remarkUrl": null,
-				"defaults": [],
-				"valueSubjectTemplateKeys": ["resourceTemplate:testing:uber4"],
-				"authorities": [],
-				"type": "resource",
-				"component": "NestedResource"
-			}, {
-				"key": "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property19",
-				"subjectTemplateKey": "resourceTemplate:testing:uber1",
-				"label": "Uber template1, property19",
-				"uri": "http://id.loc.gov/ontologies/bibframe/uber/template1/property19",
-				"required": false,
-				"repeatable": true,
-				"ordered": true,
-				"remark": "Ordered nested resource templates.",
-				"remarkUrl": null,
-				"defaults": [],
-				"valueSubjectTemplateKeys": ["resourceTemplate:testing:uber4"],
-				"authorities": [],
-				"type": "resource",
-				"component": "NestedResource"
-			}, {
-				"key": "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/adminMetadata",
-				"subjectTemplateKey": "resourceTemplate:testing:uber1",
-				"label": "Admin metadata",
-				"uri": "http://id.loc.gov/ontologies/bibframe/adminMetadata",
-				"required": false,
-				"repeatable": false,
-				"ordered": false,
-				"remark": null,
-				"remarkUrl": null,
-				"defaults": [],
-				"valueSubjectTemplateKeys": [],
-				"authorities": [{
-					"uri": "urn:ld4p:sinopia:bibframe:adminMetadata",
-					"label": "Sinopia BIBFRAME admin metadata resources",
-					"nonldLookup": false,
-					"type": "http://id.loc.gov/ontologies/bibframe/AdminMetadata"
-				}],
-				"type": "uri",
-				"component": "InputLookup"
-			}, {
-				"key": "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/hasInstance",
-				"subjectTemplateKey": "resourceTemplate:testing:uber1",
-				"label": "Has instance",
-				"uri": "http://id.loc.gov/ontologies/bibframe/hasInstance",
-				"required": false,
-				"repeatable": true,
-				"ordered": false,
-				"remark": null,
-				"remarkUrl": null,
-				"defaults": [],
-				"valueSubjectTemplateKeys": [],
-				"authorities": [{
-					"uri": "urn:ld4p:sinopia:bibframe:instance",
-					"label": "Sinopia BIBFRAME instance resources",
-					"nonldLookup": false,
-					"type": "http://id.loc.gov/ontologies/bibframe/Instance"
-				}],
-				"type": "uri",
-				"component": "InputLookup"
-			}, {
-				"key": "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/instanceOf",
-				"subjectTemplateKey": "resourceTemplate:testing:uber1",
-				"label": "Instance of",
-				"uri": "http://id.loc.gov/ontologies/bibframe/instanceOf",
-				"required": false,
-				"repeatable": true,
-				"ordered": false,
-				"remark": null,
-				"remarkUrl": null,
-				"defaults": [],
-				"valueSubjectTemplateKeys": [],
-				"authorities": [{
-					"uri": "urn:ld4p:sinopia:bibframe:work",
-					"label": "Sinopia BIBFRAME work resources",
-					"nonldLookup": false,
-					"type": "http://id.loc.gov/ontologies/bibframe/Work"
-				}],
-				"type": "uri",
-				"component": "InputLookup"
-			}, {
-				"key": "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/hasItem",
-				"subjectTemplateKey": "resourceTemplate:testing:uber1",
-				"label": "Has item",
-				"uri": "http://id.loc.gov/ontologies/bibframe/hasItem",
-				"required": false,
-				"repeatable": true,
-				"ordered": false,
-				"remark": null,
-				"remarkUrl": null,
-				"defaults": [],
-				"valueSubjectTemplateKeys": [],
-				"authorities": [{
-					"uri": "urn:ld4p:sinopia:bibframe:item",
-					"label": "Sinopia BIBFRAME item resources",
-					"nonldLookup": false,
-					"type": "http://id.loc.gov/ontologies/bibframe/Item"
-				}],
-				"type": "uri",
-				"component": "InputLookup"
-			}, {
-				"key": "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/itemOf",
-				"subjectTemplateKey": "resourceTemplate:testing:uber1",
-				"label": "Item of",
-				"uri": "http://id.loc.gov/ontologies/bibframe/itemOf",
-				"required": false,
-				"repeatable": true,
-				"ordered": false,
-				"remark": null,
-				"remarkUrl": null,
-				"defaults": [],
-				"valueSubjectTemplateKeys": [],
-				"authorities": [{
-					"uri": "urn:ld4p:sinopia:bibframe:instance",
-					"label": "Sinopia BIBFRAME instance resources",
-					"nonldLookup": false,
-					"type": "http://id.loc.gov/ontologies/bibframe/Instance"
-				}],
-				"type": "uri",
-				"component": "InputLookup"
-			}, {
-				"key": "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property20",
-				"subjectTemplateKey": "resourceTemplate:testing:uber1",
-				"label": "Uber template1, property20",
-				"uri": "http://id.loc.gov/ontologies/bibframe/uber/template1/property20",
-				"required": true,
-				"repeatable": false,
-				"ordered": false,
-				"remark": "A required, repeatable literal with defaults.",
-				"remarkUrl": null,
-				"defaults": [{
-					"literal": "Default required literal1",
-					"lang": null
-				}, {
-					"literal": "Default required literal2",
-					"lang": null
-				}],
-				"valueSubjectTemplateKeys": [],
-				"authorities": [],
-				"type": "literal",
-				"component": "InputLiteral"
-			}, {
-				"key": "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property21",
-				"subjectTemplateKey": "resourceTemplate:testing:uber1",
-				"label": "Uber template1, property21",
-				"uri": "http://id.loc.gov/ontologies/bibframe/uber/template1/property21",
-				"required": false,
-				"repeatable": true,
-				"ordered": false,
-				"remark": "Nested, repeatable, suppressible resource template.",
-				"remarkUrl": null,
-				"defaults": [],
-				"valueSubjectTemplateKeys": ["resourceTemplate:testing:uber5"],
-				"authorities": [],
-				"type": "resource",
-				"component": "NestedResource"
-			}, {
-				"key": "resourceTemplate:testing:uber1 > http://www.w3.org/2000/01/rdf-schema#label",
-				"subjectTemplateKey": "resourceTemplate:testing:uber1",
-				"label": "rdfs label",
-				"uri": "http://www.w3.org/2000/01/rdf-schema#label",
-				"required": false,
-				"repeatable": false,
-				"ordered": false,
-				"remark": "rdfs label",
-				"remarkUrl": null,
-				"defaults": [],
-				"valueSubjectTemplateKeys": [],
-				"authorities": [],
-				"type": "literal",
-				"component": "InputLiteral"
-			}]
+			"group": "stanford",
+			"editGroups": [
+				"cornell"
+			]
 		},
-		"properties": [{
-			"key": "abc1",
-			"values": [{
-				"key": "abc67",
-				"literal": null,
-				"lang": null,
-				"uri": null,
-				"label": null,
-				"component": null,
-				"valueSubject": {
-					"key": "abc46",
-					"uri": null,
-					"subjectTemplate": {
-						"key": "resourceTemplate:testing:uber2",
-						"uri": "http://localhost:3000/resource/resourceTemplate:testing:uber2",
-						"id": "resourceTemplate:testing:uber2",
-						"class": "http://id.loc.gov/ontologies/bibframe/Uber2",
-						"label": "Uber template2",
-						"author": null,
-						"remark": "Template for testing purposes with single repeatable literal.",
-						"date": null,
-            "group": "stanford",
-            "editGroups": [
-              "cornell"
-            ],      
-						"suppressible": false,
-						"propertyTemplateKeys": ["resourceTemplate:testing:uber2 > http://id.loc.gov/ontologies/bibframe/uber/template2/property1"],
-						"propertyTemplates": [{
-							"key": "resourceTemplate:testing:uber2 > http://id.loc.gov/ontologies/bibframe/uber/template2/property1",
-							"subjectTemplateKey": "resourceTemplate:testing:uber2",
-							"label": "Uber template2, property1",
-							"uri": "http://id.loc.gov/ontologies/bibframe/uber/template2/property1",
-							"required": false,
-							"repeatable": true,
-							"ordered": false,
-							"remark": "A repeatable literal",
-							"remarkUrl": null,
-							"defaults": [],
-							"valueSubjectTemplateKeys": [],
-							"authorities": [],
-							"type": "literal",
-							"component": "InputLiteral"
-						}]
+		"properties": [
+			{
+				"key": "abc1",
+				"values": [
+					{
+						"key": "abc87",
+						"literal": null,
+						"lang": null,
+						"uri": null,
+						"label": null,
+						"valueSubject": {
+							"key": "abc66",
+							"uri": null,
+							"subjectTemplate": {
+								"key": "resourceTemplate:testing:uber2",
+								"uri": "http://localhost:3000/resource/resourceTemplate:testing:uber2",
+								"id": "resourceTemplate:testing:uber2",
+								"class": "http://id.loc.gov/ontologies/bibframe/Uber2",
+								"label": "Uber template2",
+								"author": null,
+								"remark": "Template for testing purposes with single repeatable literal.",
+								"date": null,
+								"suppressible": false,
+								"propertyTemplateKeys": [
+									"resourceTemplate:testing:uber2 > http://id.loc.gov/ontologies/bibframe/uber/template2/property1"
+								],
+								"propertyTemplates": [
+									{
+										"key": "resourceTemplate:testing:uber2 > http://id.loc.gov/ontologies/bibframe/uber/template2/property1",
+										"subjectTemplateKey": "resourceTemplate:testing:uber2",
+										"label": "Uber template2, property1",
+										"uri": "http://id.loc.gov/ontologies/bibframe/uber/template2/property1",
+										"required": false,
+										"repeatable": true,
+										"ordered": false,
+										"remark": "A repeatable literal",
+										"remarkUrl": null,
+										"defaults": [],
+										"valueSubjectTemplateKeys": [],
+										"authorities": [],
+										"type": "literal",
+										"component": "InputLiteral"
+									}
+								],
+								"group": "stanford",
+								"editGroups": [
+									"cornell"
+								]
+							},
+							"properties": [
+								{
+									"key": "abc73",
+									"values": [
+										{
+											"key": "abc81",
+											"literal": "Uber template2, property1",
+											"lang": "eng",
+											"uri": null,
+											"label": null,
+											"valueSubject": null,
+											"component": "InputLiteralValue"
+										}
+									],
+									"show": true
+								}
+							]
+						},
+						"component": null
 					},
-					"properties": [{
-						"key": "abc53",
-						"values": [{
-							"key": "abc61",
-							"literal": "Uber template2, property1",
-							"lang": "eng",
+					{
+						"key": "abc88",
+						"literal": null,
+						"lang": null,
+						"uri": null,
+						"label": null,
+						"valueSubject": {
+							"key": "abc67",
 							"uri": null,
-							"label": null,
-							"valueSubject": null,
-							"component": "InputLiteralValue"
-						}],
-						"show": false
-					}]
-				}
-			}, {
-				"key": "abc68",
-				"literal": null,
-				"lang": null,
-				"uri": null,
-				"label": null,
-				"component": null,
-				"valueSubject": {
-					"key": "abc47",
-					"uri": null,
-					"properties": [{
-						"key": "abc54",
-						"values": [{
-							"key": "abc62",
-							"literal": "Uber template2, property1b",
-							"lang": "eng",
-							"uri": null,
-							"label": null,
-							"valueSubject": null,
-							"component": "InputLiteralValue"
-						}],
-						"show": false
-					}]
-				}
-			}, {
-				"key": "abc66",
-				"literal": null,
-				"lang": null,
-				"uri": null,
-				"label": null,
-				"component": null,
-				"valueSubject": {
-					"key": "abc45",
-					"uri": null,
-					"subjectTemplate": {
-						"key": "resourceTemplate:testing:uber3",
-						"uri": "http://localhost:3000/resource/resourceTemplate:testing:uber3",
-						"id": "resourceTemplate:testing:uber3",
-						"class": "http://id.loc.gov/ontologies/bibframe/Uber3",
-						"label": "Uber template3",
-						"author": null,
-						"remark": "Template for testing purposes with multiple literal.",
-						"date": null,
-            "group": "stanford",
-            "editGroups": [
-              "cornell"
-            ],      
-						"suppressible": false,
-						"propertyTemplateKeys": ["resourceTemplate:testing:uber3 > http://id.loc.gov/ontologies/bibframe/uber/template3/property1", "resourceTemplate:testing:uber3 > http://id.loc.gov/ontologies/bibframe/uber/template3/property2"],
-						"propertyTemplates": [{
-							"key": "resourceTemplate:testing:uber3 > http://id.loc.gov/ontologies/bibframe/uber/template3/property1",
-							"subjectTemplateKey": "resourceTemplate:testing:uber3",
-							"label": "Uber template3, property1",
-							"uri": "http://id.loc.gov/ontologies/bibframe/uber/template3/property1",
-							"required": false,
-							"repeatable": true,
-							"ordered": false,
-							"remark": "A literal",
-							"remarkUrl": null,
-							"defaults": [],
-							"valueSubjectTemplateKeys": [],
-							"authorities": [],
-							"type": "literal",
-							"component": "InputLiteral"
-						}, {
-							"key": "resourceTemplate:testing:uber3 > http://id.loc.gov/ontologies/bibframe/uber/template3/property2",
-							"subjectTemplateKey": "resourceTemplate:testing:uber3",
-							"label": "Uber template3, property2",
-							"uri": "http://id.loc.gov/ontologies/bibframe/uber/template3/property2",
-							"required": false,
-							"repeatable": true,
-							"ordered": false,
-							"remark": null,
-							"remarkUrl": "http://access.rdatoolkit.org/1.0.html",
-							"defaults": [],
-							"valueSubjectTemplateKeys": [],
-							"authorities": [],
-							"type": "literal",
-							"component": "InputLiteral"
-						}]
+							"properties": [
+								{
+									"key": "abc74",
+									"values": [
+										{
+											"key": "abc82",
+											"literal": "Uber template2, property1b",
+											"lang": "eng",
+											"uri": null,
+											"label": null,
+											"valueSubject": null,
+											"component": "InputLiteralValue"
+										}
+									],
+									"show": true
+								}
+							]
+						},
+						"component": null
 					},
-					"properties": [{
-						"key": "abc51",
-						"values": [{
-							"key": "abc58",
-							"literal": "Uber template3, property1",
-							"lang": "eng",
-							"uri": null,
-							"label": null,
-							"valueSubject": null,
-							"component": "InputLiteralValue"
-						}],
-						"show": false
-					}, {
-						"key": "abc52",
-						"values": [{
-							"key": "abc59",
-							"literal": "Uber template3, property2, value1",
-							"lang": "eng",
-							"uri": null,
-							"label": null,
-							"valueSubject": null,
-							"component": "InputLiteralValue"
-						}, {
-							"key": "abc60",
-							"literal": "Uber template3, property2, value2",
-							"lang": "eng",
-							"uri": null,
-							"label": null,
-							"valueSubject": null,
-							"component": "InputLiteralValue"
-						}],
-						"show": false
-					}]
-				}
-			}],
-			"show": false
-		}, {
-			"key": "abc2",
-			"values": [{
-				"key": "abc31",
-				"literal": "Uber template1, property2",
-				"lang": "eng",
-				"uri": null,
-				"label": null,
-				"valueSubject": null,
-				"component": "InputLiteralValue"
-			}],
-			"show": false
-		}, {
-			"key": "abc3",
-			"values": null,
-			"show": false
-		}, {
-			"key": "abc4",
-			"values": [{
-				"key": "abc32",
-				"literal": "Uber template1, property4",
-				"lang": "eng",
-				"uri": null,
-				"label": null,
-				"valueSubject": null,
-				"component": "InputLiteralValue"
-			}],
-			"show": true
-		}, {
-			"key": "abc5",
-			"values": [{
-				"key": "abc33",
-				"literal": null,
-				"lang": "eng",
-				"uri": "http://example.edu/ubertemplate1:property5",
-				"label": "ubertemplate1:property5",
-				"valueSubject": null,
-				"component": "InputURIValue"
-			}],
-			"show": true
-		}, {
-			"key": "abc6",
-			"values": [{
-				"key": "abc34",
-				"literal": null,
-				"lang": null,
-				"uri": "ubertemplate1:property6",
-				"label": "ubertemplate1:property6",
-				"valueSubject": null,
-				"component": "InputURIValue"
-			}],
-			"show": true
-		}, {
-			"key": "abc7",
-			"values": null,
-			"show": false
-		}, {
-			"key": "abc8",
-			"values": null,
-			"show": false
-		}, {
-			"key": "abc9",
-			"values": [{
-				"key": "abc35",
-				"literal": "Uber template1, property9",
-				"lang": "eng",
-				"uri": null,
-				"label": null,
-				"valueSubject": null,
-				"component": "InputLiteralValue"
-			}],
-			"show": true
-		}, {
-			"key": "abc10",
-			"values": [{
-				"key": "abc36",
-				"literal": null,
-				"lang": null,
-				"uri": "http://id.loc.gov/vocabulary/mrectype/analog",
-				"label": "analog",
-				"valueSubject": null,
-				"component": "InputURIValue"
-			}],
-			"show": true
-		}, {
-			"key": "abc11",
-			"values": [{
-				"key": "abc37",
-				"literal": null,
-				"lang": null,
-				"uri": "http://id.loc.gov/vocabulary/mrectype/digital",
-				"label": "digital",
-				"valueSubject": null,
-				"component": "InputURIValue"
-			}],
-			"show": true
-		}, {
-			"key": "abc12",
-			"values": [{
-				"key": "abc38",
-				"literal": null,
-				"lang": null,
-				"uri": "http://id.loc.gov/vocabulary/mrecmedium/mag",
-				"label": "magnetic",
-				"valueSubject": null,
-				"component": "InputURIValue"
-			}],
-			"show": true
-		}, {
-			"key": "abc13",
-			"values": [{
-				"key": "abc39",
-				"literal": null,
-				"lang": null,
-				"uri": "http://aims.fao.org/aos/agrovoc/c_35856",
-				"label": "summer squash",
-				"valueSubject": null,
-				"component": "InputURIValue"
-			}],
-			"show": true
-		}, {
-			"key": "abc14",
-			"values": [{
-				"key": "abc40",
-				"literal": null,
-				"lang": null,
-				"uri": "http://aims.fao.org/aos/agrovoc/c_331388",
-				"label": "corn sheller",
-				"valueSubject": null,
-				"component": "InputURIValue"
-			}],
-			"show": true
-		}, {
-			"key": "abc15",
-			"values": [{
-				"key": "abc41",
-				"literal": null,
-				"lang": null,
-				"uri": "http://sws.geonames.org/5098279/",
-				"label": "Freehold Borough High School (US)",
-				"valueSubject": null,
-				"component": "InputURIValue"
-			}],
-			"show": true
-		}, {
-			"key": "abc16",
-			"values": [{
-				"key": "abc42",
-				"literal": null,
-				"lang": null,
-				"uri": "http://localhost:3000/resource/c7db5404-7d7d-40ac-b38e-c821d2c3ae3f",
-				"label": "Example Label",
-				"valueSubject": null,
-				"component": "InputURIValue"
-			}],
-			"show": true
-		}, {
-			"key": "abc17",
-			"values": [{
-				"key": "abc43",
-				"literal": null,
-				"lang": null,
-				"uri": "http://localhost:3000/resource/c7db5404-7d7d-40ac-b38e-c821d2c3ae3f",
-				"label": "Example Label",
-				"valueSubject": null,
-				"component": "InputURIValue"
-			}],
-			"show": true
-		}, {
-			"key": "abc18",
-			"values": [{
-				"key": "abc69",
-				"literal": null,
-				"lang": null,
-				"uri": null,
-				"label": null,
-				"component": null,
-				"valueSubject": {
-					"key": "abc48",
-					"uri": null,
-					"subjectTemplate": {
-						"key": "resourceTemplate:testing:uber4",
-						"uri": "http://localhost:3000/resource/resourceTemplate:testing:uber4",
-						"id": "resourceTemplate:testing:uber4",
-						"class": "http://id.loc.gov/ontologies/bibframe/Uber4",
-						"label": "Uber template4",
-						"author": null,
-						"remark": "Template for testing purposes with single repeatable, required literal.",
-						"date": null,
-            "group": "stanford",
-            "editGroups": [
-              "cornell"
-            ],      
-						"suppressible": false,
-						"propertyTemplateKeys": ["resourceTemplate:testing:uber4 > http://id.loc.gov/ontologies/bibframe/uber/template4/property1"],
-						"propertyTemplates": [{
-							"key": "resourceTemplate:testing:uber4 > http://id.loc.gov/ontologies/bibframe/uber/template4/property1",
-							"subjectTemplateKey": "resourceTemplate:testing:uber4",
-							"label": "Uber template4, property1",
-							"uri": "http://id.loc.gov/ontologies/bibframe/uber/template4/property1",
-							"required": true,
-							"repeatable": true,
-							"ordered": false,
-							"remark": "A repeatable, required literal",
-							"remarkUrl": null,
-							"defaults": [],
-							"valueSubjectTemplateKeys": [],
-							"authorities": [],
-							"type": "literal",
-							"component": "InputLiteral"
-						}]
-					},
-					"properties": [{
-						"key": "abc55",
-						"values": [{
-							"key": "abc63",
-							"literal": "Uber template4, property1",
-							"lang": "eng",
-							"uri": null,
-							"label": null,
-							"valueSubject": null,
-							"component": "InputLiteralValue"
-						}],
-						"show": true
-					}]
-				}
-			}],
-			"show": true
-		}, {
-			"key": "abc20",
-			"values": [{
-				"key": "abc70",
-				"literal": null,
-				"lang": null,
-				"uri": null,
-				"label": null,
-				"component": null,
-				"valueSubject": {
-					"key": "abc49",
-					"uri": null,
-					"properties": [{
-						"key": "abc56",
-						"values": [{
-							"key": "abc64",
-							"literal": "Uber template4, property1, first",
-							"lang": "eng",
-							"uri": null,
-							"label": null,
-							"valueSubject": null,
-							"component": "InputLiteralValue"
-						}],
-						"show": true
-					}]
-				}
-			}, {
-				"key": "abc71",
-				"literal": null,
-				"lang": null,
-				"uri": null,
-				"label": null,
-				"component": null,
-				"valueSubject": {
-					"key": "abc50",
-					"uri": null,
-					"properties": [{
-						"key": "abc57",
-						"values": [{
+					{
+						"key": "abc86",
+						"literal": null,
+						"lang": null,
+						"uri": null,
+						"label": null,
+						"valueSubject": {
 							"key": "abc65",
-							"literal": "Uber template4, property1, second",
-							"lang": "eng",
 							"uri": null,
-							"label": null,
-							"valueSubject": null,
-							"component": "InputLiteralValue"
-						}],
-						"show": true
-					}]
-				}
-			}],
-			"show": false
-		}, {
-			"key": "abc21",
-			"values": null,
-			"show": false
-		}, {
-			"key": "abc22",
-			"values": null,
-			"show": false
-		}, {
-			"key": "abc23",
-			"values": null,
-			"show": false
-		}, {
-			"key": "abc24",
-			"values": null,
-			"show": false
-		}, {
-			"key": "abc25",
-			"values": null,
-			"show": false
-		}, {
-			"key": "abc26",
-			"values": [],
-			"show": true
-		}, {
-			"key": "abc27",
-			"values": null,
-			"show": false
-		}, {
-			"key": "abc28",
-			"show": false,
-			"values": [{
-				"key": "abc44",
-				"literal": "Example Label",
-				"label": null,
-				"lang": "",
-				"uri": null,
-				"valueSubject": null,
-				"component": "InputLiteralValue"
-			}]
-		}],
+							"subjectTemplate": {
+								"key": "resourceTemplate:testing:uber3",
+								"uri": "http://localhost:3000/resource/resourceTemplate:testing:uber3",
+								"id": "resourceTemplate:testing:uber3",
+								"class": "http://id.loc.gov/ontologies/bibframe/Uber3",
+								"label": "Uber template3",
+								"author": null,
+								"remark": "Template for testing purposes with multiple literal.",
+								"date": null,
+								"suppressible": false,
+								"propertyTemplateKeys": [
+									"resourceTemplate:testing:uber3 > http://id.loc.gov/ontologies/bibframe/uber/template3/property1",
+									"resourceTemplate:testing:uber3 > http://id.loc.gov/ontologies/bibframe/uber/template3/property2"
+								],
+								"propertyTemplates": [
+									{
+										"key": "resourceTemplate:testing:uber3 > http://id.loc.gov/ontologies/bibframe/uber/template3/property1",
+										"subjectTemplateKey": "resourceTemplate:testing:uber3",
+										"label": "Uber template3, property1",
+										"uri": "http://id.loc.gov/ontologies/bibframe/uber/template3/property1",
+										"required": false,
+										"repeatable": true,
+										"ordered": false,
+										"remark": "A literal",
+										"remarkUrl": null,
+										"defaults": [],
+										"valueSubjectTemplateKeys": [],
+										"authorities": [],
+										"type": "literal",
+										"component": "InputLiteral"
+									},
+									{
+										"key": "resourceTemplate:testing:uber3 > http://id.loc.gov/ontologies/bibframe/uber/template3/property2",
+										"subjectTemplateKey": "resourceTemplate:testing:uber3",
+										"label": "Uber template3, property2",
+										"uri": "http://id.loc.gov/ontologies/bibframe/uber/template3/property2",
+										"required": false,
+										"repeatable": true,
+										"ordered": false,
+										"remark": null,
+										"remarkUrl": "http://access.rdatoolkit.org/1.0.html",
+										"defaults": [],
+										"valueSubjectTemplateKeys": [],
+										"authorities": [],
+										"type": "literal",
+										"component": "InputLiteral"
+									}
+								],
+								"group": "stanford",
+								"editGroups": [
+									"cornell"
+								]
+							},
+							"properties": [
+								{
+									"key": "abc71",
+									"values": [
+										{
+											"key": "abc78",
+											"literal": "Uber template3, property1",
+											"lang": "eng",
+											"uri": null,
+											"label": null,
+											"valueSubject": null,
+											"component": "InputLiteralValue"
+										}
+									],
+									"show": true
+								},
+								{
+									"key": "abc72",
+									"values": [
+										{
+											"key": "abc79",
+											"literal": "Uber template3, property2, value1",
+											"lang": "eng",
+											"uri": null,
+											"label": null,
+											"valueSubject": null,
+											"component": "InputLiteralValue"
+										},
+										{
+											"key": "abc80",
+											"literal": "Uber template3, property2, value2",
+											"lang": "eng",
+											"uri": null,
+											"label": null,
+											"valueSubject": null,
+											"component": "InputLiteralValue"
+										}
+									],
+									"show": true
+								}
+							]
+						},
+						"component": null
+					}
+				],
+				"show": true
+			},
+			{
+				"key": "abc4",
+				"values": [
+					{
+						"key": "abc51",
+						"literal": "Uber template1, property2",
+						"lang": "eng",
+						"uri": null,
+						"label": null,
+						"valueSubject": null,
+						"component": "InputLiteralValue"
+					}
+				],
+				"show": true
+			},
+			{
+				"key": "abc5",
+				"values": [
+					{
+						"key": "abc45",
+						"literal": null,
+						"lang": null,
+						"uri": null,
+						"label": null,
+						"valueSubject": {
+							"key": "abc6",
+							"uri": null,
+							"subjectTemplate": {
+								"key": "resourceTemplate:testing:uber2",
+								"uri": "http://localhost:3000/resource/resourceTemplate:testing:uber2",
+								"id": "resourceTemplate:testing:uber2",
+								"class": "http://id.loc.gov/ontologies/bibframe/Uber2",
+								"label": "Uber template2",
+								"author": null,
+								"remark": "Template for testing purposes with single repeatable literal.",
+								"date": null,
+								"suppressible": false,
+								"propertyTemplateKeys": [
+									"resourceTemplate:testing:uber2 > http://id.loc.gov/ontologies/bibframe/uber/template2/property1"
+								],
+								"propertyTemplates": [
+									{
+										"key": "resourceTemplate:testing:uber2 > http://id.loc.gov/ontologies/bibframe/uber/template2/property1",
+										"subjectTemplateKey": "resourceTemplate:testing:uber2",
+										"label": "Uber template2, property1",
+										"uri": "http://id.loc.gov/ontologies/bibframe/uber/template2/property1",
+										"required": false,
+										"repeatable": true,
+										"ordered": false,
+										"remark": "A repeatable literal",
+										"remarkUrl": null,
+										"defaults": [],
+										"valueSubjectTemplateKeys": [],
+										"authorities": [],
+										"type": "literal",
+										"component": "InputLiteral"
+									}
+								],
+								"group": "stanford",
+								"editGroups": [
+									"cornell"
+								]
+							},
+							"properties": [
+								{
+									"key": "abc36",
+									"values": [],
+									"show": true
+								}
+							]
+						},
+						"component": null
+					},
+					{
+						"key": "abc50",
+						"literal": null,
+						"lang": null,
+						"uri": null,
+						"label": null,
+						"valueSubject": {
+							"key": "abc7",
+							"uri": null,
+							"subjectTemplate": {
+								"key": "resourceTemplate:testing:uber3",
+								"uri": "http://localhost:3000/resource/resourceTemplate:testing:uber3",
+								"id": "resourceTemplate:testing:uber3",
+								"class": "http://id.loc.gov/ontologies/bibframe/Uber3",
+								"label": "Uber template3",
+								"author": null,
+								"remark": "Template for testing purposes with multiple literal.",
+								"date": null,
+								"suppressible": false,
+								"propertyTemplateKeys": [
+									"resourceTemplate:testing:uber3 > http://id.loc.gov/ontologies/bibframe/uber/template3/property1",
+									"resourceTemplate:testing:uber3 > http://id.loc.gov/ontologies/bibframe/uber/template3/property2"
+								],
+								"propertyTemplates": [
+									{
+										"key": "resourceTemplate:testing:uber3 > http://id.loc.gov/ontologies/bibframe/uber/template3/property1",
+										"subjectTemplateKey": "resourceTemplate:testing:uber3",
+										"label": "Uber template3, property1",
+										"uri": "http://id.loc.gov/ontologies/bibframe/uber/template3/property1",
+										"required": false,
+										"repeatable": true,
+										"ordered": false,
+										"remark": "A literal",
+										"remarkUrl": null,
+										"defaults": [],
+										"valueSubjectTemplateKeys": [],
+										"authorities": [],
+										"type": "literal",
+										"component": "InputLiteral"
+									},
+									{
+										"key": "resourceTemplate:testing:uber3 > http://id.loc.gov/ontologies/bibframe/uber/template3/property2",
+										"subjectTemplateKey": "resourceTemplate:testing:uber3",
+										"label": "Uber template3, property2",
+										"uri": "http://id.loc.gov/ontologies/bibframe/uber/template3/property2",
+										"required": false,
+										"repeatable": true,
+										"ordered": false,
+										"remark": null,
+										"remarkUrl": "http://access.rdatoolkit.org/1.0.html",
+										"defaults": [],
+										"valueSubjectTemplateKeys": [],
+										"authorities": [],
+										"type": "literal",
+										"component": "InputLiteral"
+									}
+								],
+								"group": "stanford",
+								"editGroups": [
+									"cornell"
+								]
+							},
+							"properties": [
+								{
+									"key": "abc42",
+									"values": [],
+									"show": true
+								},
+								{
+									"key": "abc43",
+									"values": [],
+									"show": true
+								}
+							]
+						},
+						"component": null
+					}
+				],
+				"show": true
+			},
+			{
+				"key": "abc8",
+				"values": [
+					{
+						"key": "abc52",
+						"literal": "Uber template1, property4",
+						"lang": "eng",
+						"uri": null,
+						"label": null,
+						"valueSubject": null,
+						"component": "InputLiteralValue"
+					}
+				],
+				"show": true
+			},
+			{
+				"key": "abc9",
+				"values": [
+					{
+						"key": "abc53",
+						"literal": null,
+						"lang": "eng",
+						"uri": "http://example.edu/ubertemplate1:property5",
+						"label": "ubertemplate1:property5",
+						"valueSubject": null,
+						"component": "InputURIValue"
+					}
+				],
+				"show": true
+			},
+			{
+				"key": "abc10",
+				"values": [
+					{
+						"key": "abc54",
+						"literal": null,
+						"lang": null,
+						"uri": "ubertemplate1:property6",
+						"label": "ubertemplate1:property6",
+						"valueSubject": null,
+						"component": "InputURIValue"
+					}
+				],
+				"show": true
+			},
+			{
+				"key": "abc11",
+				"values": [],
+				"show": true
+			},
+			{
+				"key": "abc12",
+				"values": [],
+				"show": true
+			},
+			{
+				"key": "abc13",
+				"values": [
+					{
+						"key": "abc55",
+						"literal": "Uber template1, property9",
+						"lang": "eng",
+						"uri": null,
+						"label": null,
+						"valueSubject": null,
+						"component": "InputLiteralValue"
+					}
+				],
+				"show": true
+			},
+			{
+				"key": "abc14",
+				"values": [
+					{
+						"key": "abc56",
+						"literal": null,
+						"lang": null,
+						"uri": "http://id.loc.gov/vocabulary/mrectype/analog",
+						"label": "analog",
+						"valueSubject": null,
+						"component": "InputURIValue"
+					}
+				],
+				"show": true
+			},
+			{
+				"key": "abc15",
+				"values": [
+					{
+						"key": "abc57",
+						"literal": null,
+						"lang": null,
+						"uri": "http://id.loc.gov/vocabulary/mrectype/digital",
+						"label": "digital",
+						"valueSubject": null,
+						"component": "InputURIValue"
+					}
+				],
+				"show": true
+			},
+			{
+				"key": "abc16",
+				"values": [
+					{
+						"key": "abc58",
+						"literal": null,
+						"lang": null,
+						"uri": "http://id.loc.gov/vocabulary/mrecmedium/mag",
+						"label": "magnetic",
+						"valueSubject": null,
+						"component": "InputURIValue"
+					}
+				],
+				"show": true
+			},
+			{
+				"key": "abc17",
+				"values": [
+					{
+						"key": "abc59",
+						"literal": null,
+						"lang": null,
+						"uri": "http://aims.fao.org/aos/agrovoc/c_35856",
+						"label": "summer squash",
+						"valueSubject": null,
+						"component": "InputURIValue"
+					}
+				],
+				"show": true
+			},
+			{
+				"key": "abc18",
+				"values": [
+					{
+						"key": "abc60",
+						"literal": null,
+						"lang": null,
+						"uri": "http://aims.fao.org/aos/agrovoc/c_331388",
+						"label": "corn sheller",
+						"valueSubject": null,
+						"component": "InputURIValue"
+					}
+				],
+				"show": true
+			},
+			{
+				"key": "abc19",
+				"values": [
+					{
+						"key": "abc61",
+						"literal": null,
+						"lang": null,
+						"uri": "http://sws.geonames.org/5098279/",
+						"label": "Freehold Borough High School (US)",
+						"valueSubject": null,
+						"component": "InputURIValue"
+					}
+				],
+				"show": true
+			},
+			{
+				"key": "abc20",
+				"values": [
+					{
+						"key": "abc62",
+						"literal": null,
+						"lang": null,
+						"uri": "http://localhost:3000/resource/c7db5404-7d7d-40ac-b38e-c821d2c3ae3f",
+						"label": "Example Label",
+						"valueSubject": null,
+						"component": "InputURIValue"
+					}
+				],
+				"show": true
+			},
+			{
+				"key": "abc21",
+				"values": [
+					{
+						"key": "abc63",
+						"literal": null,
+						"lang": null,
+						"uri": "http://localhost:3000/resource/c7db5404-7d7d-40ac-b38e-c821d2c3ae3f",
+						"label": "Example Label",
+						"valueSubject": null,
+						"component": "InputURIValue"
+					}
+				],
+				"show": true
+			},
+			{
+				"key": "abc22",
+				"values": [
+					{
+						"key": "abc89",
+						"literal": null,
+						"lang": null,
+						"uri": null,
+						"label": null,
+						"valueSubject": {
+							"key": "abc68",
+							"uri": null,
+							"subjectTemplate": {
+								"key": "resourceTemplate:testing:uber4",
+								"uri": "http://localhost:3000/resource/resourceTemplate:testing:uber4",
+								"id": "resourceTemplate:testing:uber4",
+								"class": "http://id.loc.gov/ontologies/bibframe/Uber4",
+								"label": "Uber template4",
+								"author": null,
+								"remark": "Template for testing purposes with single repeatable, required literal.",
+								"date": null,
+								"suppressible": false,
+								"propertyTemplateKeys": [
+									"resourceTemplate:testing:uber4 > http://id.loc.gov/ontologies/bibframe/uber/template4/property1"
+								],
+								"propertyTemplates": [
+									{
+										"key": "resourceTemplate:testing:uber4 > http://id.loc.gov/ontologies/bibframe/uber/template4/property1",
+										"subjectTemplateKey": "resourceTemplate:testing:uber4",
+										"label": "Uber template4, property1",
+										"uri": "http://id.loc.gov/ontologies/bibframe/uber/template4/property1",
+										"required": true,
+										"repeatable": true,
+										"ordered": false,
+										"remark": "A repeatable, required literal",
+										"remarkUrl": null,
+										"defaults": [],
+										"valueSubjectTemplateKeys": [],
+										"authorities": [],
+										"type": "literal",
+										"component": "InputLiteral"
+									}
+								],
+								"group": "stanford",
+								"editGroups": [
+									"cornell"
+								]
+							},
+							"properties": [
+								{
+									"key": "abc75",
+									"values": [
+										{
+											"key": "abc83",
+											"literal": "Uber template4, property1",
+											"lang": "eng",
+											"uri": null,
+											"label": null,
+											"valueSubject": null,
+											"component": "InputLiteralValue"
+										}
+									],
+									"show": true
+								}
+							]
+						},
+						"component": null
+					}
+				],
+				"show": true
+			},
+			{
+				"key": "abc24",
+				"values": [
+					{
+						"key": "abc90",
+						"literal": null,
+						"lang": null,
+						"uri": null,
+						"label": null,
+						"valueSubject": {
+							"key": "abc69",
+							"uri": null,
+							"properties": [
+								{
+									"key": "abc76",
+									"values": [
+										{
+											"key": "abc84",
+											"literal": "Uber template4, property1, first",
+											"lang": "eng",
+											"uri": null,
+											"label": null,
+											"valueSubject": null,
+											"component": "InputLiteralValue"
+										}
+									],
+									"show": true
+								}
+							]
+						},
+						"component": null
+					},
+					{
+						"key": "abc91",
+						"literal": null,
+						"lang": null,
+						"uri": null,
+						"label": null,
+						"valueSubject": {
+							"key": "abc70",
+							"uri": null,
+							"properties": [
+								{
+									"key": "abc77",
+									"values": [
+										{
+											"key": "abc85",
+											"literal": "Uber template4, property1, second",
+											"lang": "eng",
+											"uri": null,
+											"label": null,
+											"valueSubject": null,
+											"component": "InputLiteralValue"
+										}
+									],
+									"show": true
+								}
+							]
+						},
+						"component": null
+					}
+				],
+				"show": true
+			},
+			{
+				"key": "abc26",
+				"values": [],
+				"show": true
+			},
+			{
+				"key": "abc27",
+				"values": [],
+				"show": true
+			},
+			{
+				"key": "abc28",
+				"values": [],
+				"show": true
+			},
+			{
+				"key": "abc29",
+				"values": [],
+				"show": true
+			},
+			{
+				"key": "abc30",
+				"values": [],
+				"show": true
+			},
+			{
+				"key": "abc31",
+				"values": [],
+				"show": true
+			},
+			{
+				"key": "abc32",
+				"values": [
+					{
+						"key": "abc48",
+						"literal": null,
+						"lang": null,
+						"uri": null,
+						"label": null,
+						"valueSubject": {
+							"key": "abc33",
+							"uri": null,
+							"subjectTemplate": {
+								"key": "resourceTemplate:testing:uber5",
+								"uri": "http://localhost:3000/resource/resourceTemplate:testing:uber5",
+								"id": "resourceTemplate:testing:uber5",
+								"class": "http://id.loc.gov/ontologies/bibframe/Uber5",
+								"label": "Uber template5",
+								"author": null,
+								"remark": "Template for testing purposes with suppressed, repeatable URI.",
+								"date": null,
+								"suppressible": true,
+								"propertyTemplateKeys": [
+									"resourceTemplate:testing:uber5 > http://id.loc.gov/ontologies/bibframe/uber/template5/property1"
+								],
+								"propertyTemplates": [
+									{
+										"key": "resourceTemplate:testing:uber5 > http://id.loc.gov/ontologies/bibframe/uber/template5/property1",
+										"subjectTemplateKey": "resourceTemplate:testing:uber5",
+										"label": "Uber template5, property1",
+										"uri": "http://id.loc.gov/ontologies/bibframe/uber/template5/property1",
+										"required": false,
+										"repeatable": true,
+										"ordered": false,
+										"remark": "A repeatable URI",
+										"remarkUrl": null,
+										"defaults": [],
+										"valueSubjectTemplateKeys": [],
+										"authorities": [],
+										"type": "uri",
+										"component": "InputURI"
+									}
+								],
+								"group": "stanford",
+								"editGroups": [
+									"cornell"
+								]
+							},
+							"properties": [
+								{
+									"key": "abc39",
+									"values": [],
+									"show": true
+								}
+							]
+						},
+						"component": null
+					}
+				],
+				"show": true
+			},
+			{
+				"key": "abc34",
+				"values": [
+					{
+						"key": "abc64",
+						"literal": "Example Label",
+						"lang": "",
+						"uri": null,
+						"label": null,
+						"valueSubject": null,
+						"component": "InputLiteralValue"
+					}
+				],
+				"show": true
+			}
+		],
 		"group": "stanford",
-		"editGroups": ["cornell"]
+		"editGroups": [
+			"cornell"
+		]
 	}
 }

--- a/__tests__/__action_fixtures__/loadResourceNestedResource-ADD_SUBJECT.json
+++ b/__tests__/__action_fixtures__/loadResourceNestedResource-ADD_SUBJECT.json
@@ -12,8 +12,6 @@
       "author": "Justin Littman",
       "remark": "Template for testing purposes.",
       "date": "2020-07-27",
-      "group": "stanford",
-      "editGroups": ["cornell"],
       "suppressible": false,
       "propertyTemplateKeys": [
         "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property1",
@@ -305,11 +303,11 @@
               "nonldLookup": false
             },
             {
-              "authority": "getty_aat_ld4l_cache",
+              "uri": "urn:ld4p:qa:gettyaat",
               "label": "GETTY_AAT  (QA)",
-              "nonldLookup": false,
+              "authority": "getty_aat_ld4l_cache",
               "subauthority": "",
-              "uri": "urn:ld4p:qa:gettyaat"
+              "nonldLookup": false
             }
           ],
           "type": "uri",
@@ -626,6 +624,10 @@
           "type": "literal",
           "component": "InputLiteral"
         }
+      ],
+      "group": "stanford",
+      "editGroups": [
+        "cornell"
       ]
     },
     "properties": [
@@ -633,14 +635,13 @@
         "key": "abc1",
         "values": [
           {
-            "key": "abc42",
+            "key": "abc62",
             "literal": null,
             "lang": null,
             "uri": null,
             "label": null,
-            "component": null,
             "valueSubject": {
-              "key": "abc37",
+              "key": "abc57",
               "uri": null,
               "subjectTemplate": {
                 "key": "resourceTemplate:testing:uber2",
@@ -651,8 +652,6 @@
                 "author": null,
                 "remark": "Template for testing purposes with single repeatable literal.",
                 "date": null,
-                "group": "stanford",
-                "editGroups": ["cornell"],
                 "suppressible": false,
                 "propertyTemplateKeys": [
                   "resourceTemplate:testing:uber2 > http://id.loc.gov/ontologies/bibframe/uber/template2/property1"
@@ -674,26 +673,30 @@
                     "type": "literal",
                     "component": "InputLiteral"
                   }
+                ],
+                "group": "stanford",
+                "editGroups": [
+                  "cornell"
                 ]
               },
               "properties": [
                 {
-                  "key": "abc39",
-                  "values": null,
-                  "show": false
+                  "key": "abc59",
+                  "values": [],
+                  "show": true
                 }
               ]
-            }
+            },
+            "component": null
           },
           {
-            "key": "abc36",
+            "key": "abc56",
             "literal": null,
             "lang": null,
             "uri": null,
             "label": null,
-            "component": null,
             "valueSubject": {
-              "key": "abc31",
+              "key": "abc51",
               "uri": null,
               "subjectTemplate": {
                 "key": "resourceTemplate:testing:uber3",
@@ -704,8 +707,6 @@
                 "author": null,
                 "remark": "Template for testing purposes with multiple literal.",
                 "date": null,
-                "group": "stanford",
-                "editGroups": ["cornell"],
                 "suppressible": false,
                 "propertyTemplateKeys": [
                   "resourceTemplate:testing:uber3 > http://id.loc.gov/ontologies/bibframe/uber/template3/property1",
@@ -744,14 +745,18 @@
                     "type": "literal",
                     "component": "InputLiteral"
                   }
+                ],
+                "group": "stanford",
+                "editGroups": [
+                  "cornell"
                 ]
               },
               "properties": [
                 {
-                  "key": "abc32",
+                  "key": "abc52",
                   "values": [
                     {
-                      "key": "abc34",
+                      "key": "abc54",
                       "literal": "Uber template3, property1",
                       "lang": "eng",
                       "uri": null,
@@ -760,13 +765,13 @@
                       "component": "InputLiteralValue"
                     }
                   ],
-                  "show": false
+                  "show": true
                 },
                 {
-                  "key": "abc33",
+                  "key": "abc53",
                   "values": [
                     {
-                      "key": "abc35",
+                      "key": "abc55",
                       "literal": "Uber template3, property2",
                       "lang": "eng",
                       "uri": null,
@@ -775,23 +780,14 @@
                       "component": "InputLiteralValue"
                     }
                   ],
-                  "show": false
+                  "show": true
                 }
               ]
-            }
+            },
+            "component": null
           }
         ],
-        "show": false
-      },
-      {
-        "key": "abc2",
-        "values": null,
-        "show": false
-      },
-      {
-        "key": "abc3",
-        "values": null,
-        "show": false
+        "show": true
       },
       {
         "key": "abc4",
@@ -800,23 +796,146 @@
       },
       {
         "key": "abc5",
-        "values": [],
+        "values": [
+          {
+            "key": "abc45",
+            "literal": null,
+            "lang": null,
+            "uri": null,
+            "label": null,
+            "valueSubject": {
+              "key": "abc6",
+              "uri": null,
+              "subjectTemplate": {
+                "key": "resourceTemplate:testing:uber2",
+                "uri": "http://localhost:3000/resource/resourceTemplate:testing:uber2",
+                "id": "resourceTemplate:testing:uber2",
+                "class": "http://id.loc.gov/ontologies/bibframe/Uber2",
+                "label": "Uber template2",
+                "author": null,
+                "remark": "Template for testing purposes with single repeatable literal.",
+                "date": null,
+                "suppressible": false,
+                "propertyTemplateKeys": [
+                  "resourceTemplate:testing:uber2 > http://id.loc.gov/ontologies/bibframe/uber/template2/property1"
+                ],
+                "propertyTemplates": [
+                  {
+                    "key": "resourceTemplate:testing:uber2 > http://id.loc.gov/ontologies/bibframe/uber/template2/property1",
+                    "subjectTemplateKey": "resourceTemplate:testing:uber2",
+                    "label": "Uber template2, property1",
+                    "uri": "http://id.loc.gov/ontologies/bibframe/uber/template2/property1",
+                    "required": false,
+                    "repeatable": true,
+                    "ordered": false,
+                    "remark": "A repeatable literal",
+                    "remarkUrl": null,
+                    "defaults": [],
+                    "valueSubjectTemplateKeys": [],
+                    "authorities": [],
+                    "type": "literal",
+                    "component": "InputLiteral"
+                  }
+                ],
+                "group": "stanford",
+                "editGroups": [
+                  "cornell"
+                ]
+              },
+              "properties": [
+                {
+                  "key": "abc36",
+                  "values": [],
+                  "show": true
+                }
+              ]
+            },
+            "component": null
+          },
+          {
+            "key": "abc50",
+            "literal": null,
+            "lang": null,
+            "uri": null,
+            "label": null,
+            "valueSubject": {
+              "key": "abc7",
+              "uri": null,
+              "subjectTemplate": {
+                "key": "resourceTemplate:testing:uber3",
+                "uri": "http://localhost:3000/resource/resourceTemplate:testing:uber3",
+                "id": "resourceTemplate:testing:uber3",
+                "class": "http://id.loc.gov/ontologies/bibframe/Uber3",
+                "label": "Uber template3",
+                "author": null,
+                "remark": "Template for testing purposes with multiple literal.",
+                "date": null,
+                "suppressible": false,
+                "propertyTemplateKeys": [
+                  "resourceTemplate:testing:uber3 > http://id.loc.gov/ontologies/bibframe/uber/template3/property1",
+                  "resourceTemplate:testing:uber3 > http://id.loc.gov/ontologies/bibframe/uber/template3/property2"
+                ],
+                "propertyTemplates": [
+                  {
+                    "key": "resourceTemplate:testing:uber3 > http://id.loc.gov/ontologies/bibframe/uber/template3/property1",
+                    "subjectTemplateKey": "resourceTemplate:testing:uber3",
+                    "label": "Uber template3, property1",
+                    "uri": "http://id.loc.gov/ontologies/bibframe/uber/template3/property1",
+                    "required": false,
+                    "repeatable": true,
+                    "ordered": false,
+                    "remark": "A literal",
+                    "remarkUrl": null,
+                    "defaults": [],
+                    "valueSubjectTemplateKeys": [],
+                    "authorities": [],
+                    "type": "literal",
+                    "component": "InputLiteral"
+                  },
+                  {
+                    "key": "resourceTemplate:testing:uber3 > http://id.loc.gov/ontologies/bibframe/uber/template3/property2",
+                    "subjectTemplateKey": "resourceTemplate:testing:uber3",
+                    "label": "Uber template3, property2",
+                    "uri": "http://id.loc.gov/ontologies/bibframe/uber/template3/property2",
+                    "required": false,
+                    "repeatable": true,
+                    "ordered": false,
+                    "remark": null,
+                    "remarkUrl": "http://access.rdatoolkit.org/1.0.html",
+                    "defaults": [],
+                    "valueSubjectTemplateKeys": [],
+                    "authorities": [],
+                    "type": "literal",
+                    "component": "InputLiteral"
+                  }
+                ],
+                "group": "stanford",
+                "editGroups": [
+                  "cornell"
+                ]
+              },
+              "properties": [
+                {
+                  "key": "abc42",
+                  "values": [],
+                  "show": true
+                },
+                {
+                  "key": "abc43",
+                  "values": [],
+                  "show": true
+                }
+              ]
+            },
+            "component": null
+          }
+        ],
         "show": true
-      },
-      {
-        "key": "abc6",
-        "values": [],
-        "show": true
-      },
-      {
-        "key": "abc7",
-        "values": null,
-        "show": false
       },
       {
         "key": "abc8",
-        "values": null,
-        "show": false
+        "values": [],
+        "show": true
       },
       {
         "key": "abc9",
@@ -865,16 +984,35 @@
       },
       {
         "key": "abc18",
+        "values": [],
+        "show": true
+      },
+      {
+        "key": "abc19",
+        "values": [],
+        "show": true
+      },
+      {
+        "key": "abc20",
+        "values": [],
+        "show": true
+      },
+      {
+        "key": "abc21",
+        "values": [],
+        "show": true
+      },
+      {
+        "key": "abc22",
         "values": [
           {
-            "key": "abc30",
+            "key": "abc46",
             "literal": null,
             "lang": null,
             "uri": null,
             "label": null,
-            "component": null,
             "valueSubject": {
-              "key": "abc19",
+              "key": "abc23",
               "uri": null,
               "subjectTemplate": {
                 "key": "resourceTemplate:testing:uber4",
@@ -885,8 +1023,6 @@
                 "author": null,
                 "remark": "Template for testing purposes with single repeatable, required literal.",
                 "date": null,
-                "group": "stanford",
-                "editGroups": ["cornell"],
                 "suppressible": false,
                 "propertyTemplateKeys": [
                   "resourceTemplate:testing:uber4 > http://id.loc.gov/ontologies/bibframe/uber/template4/property1"
@@ -908,49 +1044,85 @@
                     "type": "literal",
                     "component": "InputLiteral"
                   }
+                ],
+                "group": "stanford",
+                "editGroups": [
+                  "cornell"
                 ]
               },
               "properties": [
                 {
-                  "key": "abc29",
+                  "key": "abc37",
                   "values": [],
                   "show": true
                 }
               ]
-            }
+            },
+            "component": null
           }
         ],
         "show": true
       },
       {
-        "key": "abc20",
-        "values": null,
-        "show": false
-      },
-      {
-        "key": "abc21",
-        "values": null,
-        "show": false
-      },
-      {
-        "key": "abc22",
-        "values": null,
-        "show": false
-      },
-      {
-        "key": "abc23",
-        "values": null,
-        "show": false
-      },
-      {
         "key": "abc24",
-        "values": null,
-        "show": false
-      },
-      {
-        "key": "abc25",
-        "values": null,
-        "show": false
+        "values": [
+          {
+            "key": "abc47",
+            "literal": null,
+            "lang": null,
+            "uri": null,
+            "label": null,
+            "valueSubject": {
+              "key": "abc25",
+              "uri": null,
+              "subjectTemplate": {
+                "key": "resourceTemplate:testing:uber4",
+                "uri": "http://localhost:3000/resource/resourceTemplate:testing:uber4",
+                "id": "resourceTemplate:testing:uber4",
+                "class": "http://id.loc.gov/ontologies/bibframe/Uber4",
+                "label": "Uber template4",
+                "author": null,
+                "remark": "Template for testing purposes with single repeatable, required literal.",
+                "date": null,
+                "suppressible": false,
+                "propertyTemplateKeys": [
+                  "resourceTemplate:testing:uber4 > http://id.loc.gov/ontologies/bibframe/uber/template4/property1"
+                ],
+                "propertyTemplates": [
+                  {
+                    "key": "resourceTemplate:testing:uber4 > http://id.loc.gov/ontologies/bibframe/uber/template4/property1",
+                    "subjectTemplateKey": "resourceTemplate:testing:uber4",
+                    "label": "Uber template4, property1",
+                    "uri": "http://id.loc.gov/ontologies/bibframe/uber/template4/property1",
+                    "required": true,
+                    "repeatable": true,
+                    "ordered": false,
+                    "remark": "A repeatable, required literal",
+                    "remarkUrl": null,
+                    "defaults": [],
+                    "valueSubjectTemplateKeys": [],
+                    "authorities": [],
+                    "type": "literal",
+                    "component": "InputLiteral"
+                  }
+                ],
+                "group": "stanford",
+                "editGroups": [
+                  "cornell"
+                ]
+              },
+              "properties": [
+                {
+                  "key": "abc38",
+                  "values": [],
+                  "show": true
+                }
+              ]
+            },
+            "component": null
+          }
+        ],
+        "show": true
       },
       {
         "key": "abc26",
@@ -959,16 +1131,99 @@
       },
       {
         "key": "abc27",
-        "values": null,
-        "show": false
+        "values": [],
+        "show": true
       },
       {
         "key": "abc28",
-        "values": null,
-        "show": false
+        "values": [],
+        "show": true
+      },
+      {
+        "key": "abc29",
+        "values": [],
+        "show": true
+      },
+      {
+        "key": "abc30",
+        "values": [],
+        "show": true
+      },
+      {
+        "key": "abc31",
+        "values": [],
+        "show": true
+      },
+      {
+        "key": "abc32",
+        "values": [
+          {
+            "key": "abc48",
+            "literal": null,
+            "lang": null,
+            "uri": null,
+            "label": null,
+            "valueSubject": {
+              "key": "abc33",
+              "uri": null,
+              "subjectTemplate": {
+                "key": "resourceTemplate:testing:uber5",
+                "uri": "http://localhost:3000/resource/resourceTemplate:testing:uber5",
+                "id": "resourceTemplate:testing:uber5",
+                "class": "http://id.loc.gov/ontologies/bibframe/Uber5",
+                "label": "Uber template5",
+                "author": null,
+                "remark": "Template for testing purposes with suppressed, repeatable URI.",
+                "date": null,
+                "suppressible": true,
+                "propertyTemplateKeys": [
+                  "resourceTemplate:testing:uber5 > http://id.loc.gov/ontologies/bibframe/uber/template5/property1"
+                ],
+                "propertyTemplates": [
+                  {
+                    "key": "resourceTemplate:testing:uber5 > http://id.loc.gov/ontologies/bibframe/uber/template5/property1",
+                    "subjectTemplateKey": "resourceTemplate:testing:uber5",
+                    "label": "Uber template5, property1",
+                    "uri": "http://id.loc.gov/ontologies/bibframe/uber/template5/property1",
+                    "required": false,
+                    "repeatable": true,
+                    "ordered": false,
+                    "remark": "A repeatable URI",
+                    "remarkUrl": null,
+                    "defaults": [],
+                    "valueSubjectTemplateKeys": [],
+                    "authorities": [],
+                    "type": "uri",
+                    "component": "InputURI"
+                  }
+                ],
+                "group": "stanford",
+                "editGroups": [
+                  "cornell"
+                ]
+              },
+              "properties": [
+                {
+                  "key": "abc39",
+                  "values": [],
+                  "show": true
+                }
+              ]
+            },
+            "component": null
+          }
+        ],
+        "show": true
+      },
+      {
+        "key": "abc34",
+        "values": [],
+        "show": true
       }
     ],
     "group": "stanford",
-    "editGroups": ["cornell"]
+    "editGroups": [
+      "cornell"
+    ]
   }
 }

--- a/__tests__/__action_fixtures__/newResource-ADD_SUBJECT.json
+++ b/__tests__/__action_fixtures__/newResource-ADD_SUBJECT.json
@@ -12,8 +12,6 @@
       "author": "Justin Littman",
       "remark": "Template for testing purposes.",
       "date": "2020-07-27",
-      "group": "stanford",
-      "editGroups": ["cornell"],
       "suppressible": false,
       "propertyTemplateKeys": [
         "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property1",
@@ -305,12 +303,12 @@
               "nonldLookup": false
             },
             {
-              "authority": "getty_aat_ld4l_cache",
+              "uri": "urn:ld4p:qa:gettyaat",
               "label": "GETTY_AAT  (QA)",
-              "nonldLookup": false,
+              "authority": "getty_aat_ld4l_cache",
               "subauthority": "",
-              "uri": "urn:ld4p:qa:gettyaat"
-            }            
+              "nonldLookup": false
+            }
           ],
           "type": "uri",
           "component": "InputLookup"
@@ -626,6 +624,10 @@
           "type": "literal",
           "component": "InputLiteral"
         }
+      ],
+      "group": "stanford",
+      "editGroups": [
+        "cornell"
       ]
     },
     "properties": [
@@ -633,14 +635,13 @@
         "key": "abc1",
         "values": [
           {
-            "key": "abc59",
+            "key": "abc79",
             "literal": null,
             "lang": null,
             "uri": null,
             "label": null,
-            "component": null,
             "valueSubject": {
-              "key": "abc37",
+              "key": "abc57",
               "uri": null,
               "subjectTemplate": {
                 "key": "resourceTemplate:testing:uber2",
@@ -651,8 +652,6 @@
                 "author": null,
                 "remark": "Template for testing purposes with single repeatable literal.",
                 "date": null,
-                "group": "stanford",
-                "editGroups": ["cornell"],
                 "suppressible": false,
                 "propertyTemplateKeys": [
                   "resourceTemplate:testing:uber2 > http://id.loc.gov/ontologies/bibframe/uber/template2/property1"
@@ -674,26 +673,30 @@
                     "type": "literal",
                     "component": "InputLiteral"
                   }
+                ],
+                "group": "stanford",
+                "editGroups": [
+                  "cornell"
                 ]
               },
               "properties": [
                 {
-                  "key": "abc50",
-                  "values": null,
-                  "show": false
+                  "key": "abc70",
+                  "values": [],
+                  "show": true
                 }
               ]
-            }
+            },
+            "component": null
           },
           {
-            "key": "abc62",
+            "key": "abc84",
             "literal": null,
             "lang": null,
             "uri": null,
             "label": null,
-            "component": null,
             "valueSubject": {
-              "key": "abc38",
+              "key": "abc58",
               "uri": null,
               "subjectTemplate": {
                 "key": "resourceTemplate:testing:uber3",
@@ -704,8 +707,6 @@
                 "author": null,
                 "remark": "Template for testing purposes with multiple literal.",
                 "date": null,
-                "group": "stanford",
-                "editGroups": ["cornell"],
                 "suppressible": false,
                 "propertyTemplateKeys": [
                   "resourceTemplate:testing:uber3 > http://id.loc.gov/ontologies/bibframe/uber/template3/property1",
@@ -744,160 +745,26 @@
                     "type": "literal",
                     "component": "InputLiteral"
                   }
+                ],
+                "group": "stanford",
+                "editGroups": [
+                  "cornell"
                 ]
               },
               "properties": [
                 {
-                  "key": "abc55",
-                  "values": null,
-                  "show": false
+                  "key": "abc75",
+                  "values": [],
+                  "show": true
                 },
                 {
-                  "key": "abc56",
-                  "values": null,
-                  "show": false
+                  "key": "abc76",
+                  "values": [],
+                  "show": true
                 }
               ]
-            }
-          }
-        ],
-        "show": true
-      },
-      {
-        "key": "abc2",
-        "values": [],
-        "show": true
-      },
-      {
-        "key": "abc3",
-        "values": [
-          {
-            "key": "abc60",
-            "literal": null,
-            "lang": null,
-            "uri": null,
-            "label": null,
-            "component": null,
-            "valueSubject": {
-              "key": "abc39",
-              "uri": null,
-              "subjectTemplate": {
-                "key": "resourceTemplate:testing:uber2",
-                "uri": "http://localhost:3000/resource/resourceTemplate:testing:uber2",
-                "id": "resourceTemplate:testing:uber2",
-                "class": "http://id.loc.gov/ontologies/bibframe/Uber2",
-                "label": "Uber template2",
-                "author": null,
-                "remark": "Template for testing purposes with single repeatable literal.",
-                "date": null,
-                "group": "stanford",
-                "editGroups": ["cornell"],
-                "suppressible": false,
-                "propertyTemplateKeys": [
-                  "resourceTemplate:testing:uber2 > http://id.loc.gov/ontologies/bibframe/uber/template2/property1"
-                ],
-                "propertyTemplates": [
-                  {
-                    "key": "resourceTemplate:testing:uber2 > http://id.loc.gov/ontologies/bibframe/uber/template2/property1",
-                    "subjectTemplateKey": "resourceTemplate:testing:uber2",
-                    "label": "Uber template2, property1",
-                    "uri": "http://id.loc.gov/ontologies/bibframe/uber/template2/property1",
-                    "required": false,
-                    "repeatable": true,
-                    "ordered": false,
-                    "remark": "A repeatable literal",
-                    "remarkUrl": null,
-                    "defaults": [],
-                    "valueSubjectTemplateKeys": [],
-                    "authorities": [],
-                    "type": "literal",
-                    "component": "InputLiteral"
-                  }
-                ]
-              },
-              "properties": [
-                {
-                  "key": "abc51",
-                  "values": null,
-                  "show": false
-                }
-              ]
-            }
-          },
-          {
-            "key": "abc63",
-            "literal": null,
-            "lang": null,
-            "uri": null,
-            "label": null,
-            "component": null,
-            "valueSubject": {
-              "key": "abc40",
-              "uri": null,
-              "subjectTemplate": {
-                "key": "resourceTemplate:testing:uber3",
-                "uri": "http://localhost:3000/resource/resourceTemplate:testing:uber3",
-                "id": "resourceTemplate:testing:uber3",
-                "class": "http://id.loc.gov/ontologies/bibframe/Uber3",
-                "label": "Uber template3",
-                "author": null,
-                "remark": "Template for testing purposes with multiple literal.",
-                "date": null,
-                "group": "stanford",
-                "editGroups": ["cornell"],
-                "suppressible": false,
-                "propertyTemplateKeys": [
-                  "resourceTemplate:testing:uber3 > http://id.loc.gov/ontologies/bibframe/uber/template3/property1",
-                  "resourceTemplate:testing:uber3 > http://id.loc.gov/ontologies/bibframe/uber/template3/property2"
-                ],
-                "propertyTemplates": [
-                  {
-                    "key": "resourceTemplate:testing:uber3 > http://id.loc.gov/ontologies/bibframe/uber/template3/property1",
-                    "subjectTemplateKey": "resourceTemplate:testing:uber3",
-                    "label": "Uber template3, property1",
-                    "uri": "http://id.loc.gov/ontologies/bibframe/uber/template3/property1",
-                    "required": false,
-                    "repeatable": true,
-                    "ordered": false,
-                    "remark": "A literal",
-                    "remarkUrl": null,
-                    "defaults": [],
-                    "valueSubjectTemplateKeys": [],
-                    "authorities": [],
-                    "type": "literal",
-                    "component": "InputLiteral"
-                  },
-                  {
-                    "key": "resourceTemplate:testing:uber3 > http://id.loc.gov/ontologies/bibframe/uber/template3/property2",
-                    "subjectTemplateKey": "resourceTemplate:testing:uber3",
-                    "label": "Uber template3, property2",
-                    "uri": "http://id.loc.gov/ontologies/bibframe/uber/template3/property2",
-                    "required": false,
-                    "repeatable": true,
-                    "ordered": false,
-                    "remark": null,
-                    "remarkUrl": "http://access.rdatoolkit.org/1.0.html",
-                    "defaults": [],
-                    "valueSubjectTemplateKeys": [],
-                    "authorities": [],
-                    "type": "literal",
-                    "component": "InputLiteral"
-                  }
-                ]
-              },
-              "properties": [
-                {
-                  "key": "abc57",
-                  "values": null,
-                  "show": false
-                },
-                {
-                  "key": "abc58",
-                  "values": null,
-                  "show": false
-                }
-              ]
-            }
+            },
+            "component": null
           }
         ],
         "show": true
@@ -909,19 +776,162 @@
       },
       {
         "key": "abc5",
-        "values": [],
-        "show": true
-      },
-      {
-        "key": "abc6",
-        "values": [],
-        "show": true
-      },
-      {
-        "key": "abc7",
         "values": [
           {
-            "key": "abc41",
+            "key": "abc80",
+            "literal": null,
+            "lang": null,
+            "uri": null,
+            "label": null,
+            "valueSubject": {
+              "key": "abc59",
+              "uri": null,
+              "subjectTemplate": {
+                "key": "resourceTemplate:testing:uber2",
+                "uri": "http://localhost:3000/resource/resourceTemplate:testing:uber2",
+                "id": "resourceTemplate:testing:uber2",
+                "class": "http://id.loc.gov/ontologies/bibframe/Uber2",
+                "label": "Uber template2",
+                "author": null,
+                "remark": "Template for testing purposes with single repeatable literal.",
+                "date": null,
+                "suppressible": false,
+                "propertyTemplateKeys": [
+                  "resourceTemplate:testing:uber2 > http://id.loc.gov/ontologies/bibframe/uber/template2/property1"
+                ],
+                "propertyTemplates": [
+                  {
+                    "key": "resourceTemplate:testing:uber2 > http://id.loc.gov/ontologies/bibframe/uber/template2/property1",
+                    "subjectTemplateKey": "resourceTemplate:testing:uber2",
+                    "label": "Uber template2, property1",
+                    "uri": "http://id.loc.gov/ontologies/bibframe/uber/template2/property1",
+                    "required": false,
+                    "repeatable": true,
+                    "ordered": false,
+                    "remark": "A repeatable literal",
+                    "remarkUrl": null,
+                    "defaults": [],
+                    "valueSubjectTemplateKeys": [],
+                    "authorities": [],
+                    "type": "literal",
+                    "component": "InputLiteral"
+                  }
+                ],
+                "group": "stanford",
+                "editGroups": [
+                  "cornell"
+                ]
+              },
+              "properties": [
+                {
+                  "key": "abc71",
+                  "values": [],
+                  "show": true
+                }
+              ]
+            },
+            "component": null
+          },
+          {
+            "key": "abc85",
+            "literal": null,
+            "lang": null,
+            "uri": null,
+            "label": null,
+            "valueSubject": {
+              "key": "abc60",
+              "uri": null,
+              "subjectTemplate": {
+                "key": "resourceTemplate:testing:uber3",
+                "uri": "http://localhost:3000/resource/resourceTemplate:testing:uber3",
+                "id": "resourceTemplate:testing:uber3",
+                "class": "http://id.loc.gov/ontologies/bibframe/Uber3",
+                "label": "Uber template3",
+                "author": null,
+                "remark": "Template for testing purposes with multiple literal.",
+                "date": null,
+                "suppressible": false,
+                "propertyTemplateKeys": [
+                  "resourceTemplate:testing:uber3 > http://id.loc.gov/ontologies/bibframe/uber/template3/property1",
+                  "resourceTemplate:testing:uber3 > http://id.loc.gov/ontologies/bibframe/uber/template3/property2"
+                ],
+                "propertyTemplates": [
+                  {
+                    "key": "resourceTemplate:testing:uber3 > http://id.loc.gov/ontologies/bibframe/uber/template3/property1",
+                    "subjectTemplateKey": "resourceTemplate:testing:uber3",
+                    "label": "Uber template3, property1",
+                    "uri": "http://id.loc.gov/ontologies/bibframe/uber/template3/property1",
+                    "required": false,
+                    "repeatable": true,
+                    "ordered": false,
+                    "remark": "A literal",
+                    "remarkUrl": null,
+                    "defaults": [],
+                    "valueSubjectTemplateKeys": [],
+                    "authorities": [],
+                    "type": "literal",
+                    "component": "InputLiteral"
+                  },
+                  {
+                    "key": "resourceTemplate:testing:uber3 > http://id.loc.gov/ontologies/bibframe/uber/template3/property2",
+                    "subjectTemplateKey": "resourceTemplate:testing:uber3",
+                    "label": "Uber template3, property2",
+                    "uri": "http://id.loc.gov/ontologies/bibframe/uber/template3/property2",
+                    "required": false,
+                    "repeatable": true,
+                    "ordered": false,
+                    "remark": null,
+                    "remarkUrl": "http://access.rdatoolkit.org/1.0.html",
+                    "defaults": [],
+                    "valueSubjectTemplateKeys": [],
+                    "authorities": [],
+                    "type": "literal",
+                    "component": "InputLiteral"
+                  }
+                ],
+                "group": "stanford",
+                "editGroups": [
+                  "cornell"
+                ]
+              },
+              "properties": [
+                {
+                  "key": "abc77",
+                  "values": [],
+                  "show": true
+                },
+                {
+                  "key": "abc78",
+                  "values": [],
+                  "show": true
+                }
+              ]
+            },
+            "component": null
+          }
+        ],
+        "show": true
+      },
+      {
+        "key": "abc8",
+        "values": [],
+        "show": true
+      },
+      {
+        "key": "abc9",
+        "values": [],
+        "show": true
+      },
+      {
+        "key": "abc10",
+        "values": [],
+        "show": true
+      },
+      {
+        "key": "abc11",
+        "values": [
+          {
+            "key": "abc61",
             "literal": "Default literal1",
             "lang": null,
             "uri": null,
@@ -930,7 +940,7 @@
             "component": "InputLiteralValue"
           },
           {
-            "key": "abc42",
+            "key": "abc62",
             "literal": "Default literal2",
             "lang": null,
             "uri": null,
@@ -942,10 +952,10 @@
         "show": true
       },
       {
-        "key": "abc10",
+        "key": "abc14",
         "values": [
           {
-            "key": "abc43",
+            "key": "abc63",
             "literal": null,
             "lang": "eng",
             "uri": "http://sinopia.io/defaultURI1",
@@ -954,7 +964,7 @@
             "component": "InputURIValue"
           },
           {
-            "key": "abc44",
+            "key": "abc64",
             "literal": null,
             "lang": "eng",
             "uri": "http://sinopia.io/defaultURI2",
@@ -963,26 +973,6 @@
             "component": "InputURIValue"
           }
         ],
-        "show": true
-      },
-      {
-        "key": "abc13",
-        "values": [],
-        "show": true
-      },
-      {
-        "key": "abc14",
-        "values": [],
-        "show": true
-      },
-      {
-        "key": "abc15",
-        "values": [],
-        "show": true
-      },
-      {
-        "key": "abc16",
-        "values": [],
         "show": true
       },
       {
@@ -1012,120 +1002,17 @@
       },
       {
         "key": "abc22",
-        "values": [
-          {
-            "key": "abc64",
-            "literal": null,
-            "lang": null,
-            "uri": null,
-            "label": null,
-            "component": null,
-            "valueSubject": {
-              "key": "abc45",
-              "uri": null,
-              "subjectTemplate": {
-                "key": "resourceTemplate:testing:uber4",
-                "uri": "http://localhost:3000/resource/resourceTemplate:testing:uber4",
-                "id": "resourceTemplate:testing:uber4",
-                "class": "http://id.loc.gov/ontologies/bibframe/Uber4",
-                "label": "Uber template4",
-                "author": null,
-                "remark": "Template for testing purposes with single repeatable, required literal.",
-                "date": null,
-                "group": "stanford",
-                "editGroups": ["cornell"],
-                "suppressible": false,
-                "propertyTemplateKeys": [
-                  "resourceTemplate:testing:uber4 > http://id.loc.gov/ontologies/bibframe/uber/template4/property1"
-                ],
-                "propertyTemplates": [
-                  {
-                    "key": "resourceTemplate:testing:uber4 > http://id.loc.gov/ontologies/bibframe/uber/template4/property1",
-                    "subjectTemplateKey": "resourceTemplate:testing:uber4",
-                    "label": "Uber template4, property1",
-                    "uri": "http://id.loc.gov/ontologies/bibframe/uber/template4/property1",
-                    "required": true,
-                    "repeatable": true,
-                    "ordered": false,
-                    "remark": "A repeatable, required literal",
-                    "remarkUrl": null,
-                    "defaults": [],
-                    "valueSubjectTemplateKeys": [],
-                    "authorities": [],
-                    "type": "literal",
-                    "component": "InputLiteral"
-                  }
-                ]
-              },
-              "properties": [
-                {
-                  "key": "abc52",
-                  "values": [],
-                  "show": true
-                }
-              ]
-            }
-          }
-        ],
+        "values": [],
+        "show": true
+      },
+      {
+        "key": "abc23",
+        "values": [],
         "show": true
       },
       {
         "key": "abc24",
-        "values": [
-          {
-            "key": "abc65",
-            "literal": null,
-            "lang": null,
-            "uri": null,
-            "label": null,
-            "component": null,
-            "valueSubject": {
-              "key": "abc46",
-              "uri": null,
-              "subjectTemplate": {
-                "key": "resourceTemplate:testing:uber4",
-                "uri": "http://localhost:3000/resource/resourceTemplate:testing:uber4",
-                "id": "resourceTemplate:testing:uber4",
-                "class": "http://id.loc.gov/ontologies/bibframe/Uber4",
-                "label": "Uber template4",
-                "author": null,
-                "remark": "Template for testing purposes with single repeatable, required literal.",
-                "date": null,
-                "group": "stanford",
-                "editGroups": ["cornell"],
-                "suppressible": false,
-                "propertyTemplateKeys": [
-                  "resourceTemplate:testing:uber4 > http://id.loc.gov/ontologies/bibframe/uber/template4/property1"
-                ],
-                "propertyTemplates": [
-                  {
-                    "key": "resourceTemplate:testing:uber4 > http://id.loc.gov/ontologies/bibframe/uber/template4/property1",
-                    "subjectTemplateKey": "resourceTemplate:testing:uber4",
-                    "label": "Uber template4, property1",
-                    "uri": "http://id.loc.gov/ontologies/bibframe/uber/template4/property1",
-                    "required": true,
-                    "repeatable": true,
-                    "ordered": false,
-                    "remark": "A repeatable, required literal",
-                    "remarkUrl": null,
-                    "defaults": [],
-                    "valueSubjectTemplateKeys": [],
-                    "authorities": [],
-                    "type": "literal",
-                    "component": "InputLiteral"
-                  }
-                ]
-              },
-              "properties": [
-                {
-                  "key": "abc53",
-                  "values": [],
-                  "show": true
-                }
-              ]
-            }
-          }
-        ],
+        "values": [],
         "show": true
       },
       {
@@ -1135,29 +1022,156 @@
       },
       {
         "key": "abc26",
-        "values": [],
-        "show": true
-      },
-      {
-        "key": "abc27",
-        "values": [],
+        "values": [
+          {
+            "key": "abc81",
+            "literal": null,
+            "lang": null,
+            "uri": null,
+            "label": null,
+            "valueSubject": {
+              "key": "abc65",
+              "uri": null,
+              "subjectTemplate": {
+                "key": "resourceTemplate:testing:uber4",
+                "uri": "http://localhost:3000/resource/resourceTemplate:testing:uber4",
+                "id": "resourceTemplate:testing:uber4",
+                "class": "http://id.loc.gov/ontologies/bibframe/Uber4",
+                "label": "Uber template4",
+                "author": null,
+                "remark": "Template for testing purposes with single repeatable, required literal.",
+                "date": null,
+                "suppressible": false,
+                "propertyTemplateKeys": [
+                  "resourceTemplate:testing:uber4 > http://id.loc.gov/ontologies/bibframe/uber/template4/property1"
+                ],
+                "propertyTemplates": [
+                  {
+                    "key": "resourceTemplate:testing:uber4 > http://id.loc.gov/ontologies/bibframe/uber/template4/property1",
+                    "subjectTemplateKey": "resourceTemplate:testing:uber4",
+                    "label": "Uber template4, property1",
+                    "uri": "http://id.loc.gov/ontologies/bibframe/uber/template4/property1",
+                    "required": true,
+                    "repeatable": true,
+                    "ordered": false,
+                    "remark": "A repeatable, required literal",
+                    "remarkUrl": null,
+                    "defaults": [],
+                    "valueSubjectTemplateKeys": [],
+                    "authorities": [],
+                    "type": "literal",
+                    "component": "InputLiteral"
+                  }
+                ],
+                "group": "stanford",
+                "editGroups": [
+                  "cornell"
+                ]
+              },
+              "properties": [
+                {
+                  "key": "abc72",
+                  "values": [],
+                  "show": true
+                }
+              ]
+            },
+            "component": null
+          }
+        ],
         "show": true
       },
       {
         "key": "abc28",
-        "values": [],
-        "show": true
-      },
-      {
-        "key": "abc29",
-        "values": [],
+        "values": [
+          {
+            "key": "abc82",
+            "literal": null,
+            "lang": null,
+            "uri": null,
+            "label": null,
+            "valueSubject": {
+              "key": "abc66",
+              "uri": null,
+              "subjectTemplate": {
+                "key": "resourceTemplate:testing:uber4",
+                "uri": "http://localhost:3000/resource/resourceTemplate:testing:uber4",
+                "id": "resourceTemplate:testing:uber4",
+                "class": "http://id.loc.gov/ontologies/bibframe/Uber4",
+                "label": "Uber template4",
+                "author": null,
+                "remark": "Template for testing purposes with single repeatable, required literal.",
+                "date": null,
+                "suppressible": false,
+                "propertyTemplateKeys": [
+                  "resourceTemplate:testing:uber4 > http://id.loc.gov/ontologies/bibframe/uber/template4/property1"
+                ],
+                "propertyTemplates": [
+                  {
+                    "key": "resourceTemplate:testing:uber4 > http://id.loc.gov/ontologies/bibframe/uber/template4/property1",
+                    "subjectTemplateKey": "resourceTemplate:testing:uber4",
+                    "label": "Uber template4, property1",
+                    "uri": "http://id.loc.gov/ontologies/bibframe/uber/template4/property1",
+                    "required": true,
+                    "repeatable": true,
+                    "ordered": false,
+                    "remark": "A repeatable, required literal",
+                    "remarkUrl": null,
+                    "defaults": [],
+                    "valueSubjectTemplateKeys": [],
+                    "authorities": [],
+                    "type": "literal",
+                    "component": "InputLiteral"
+                  }
+                ],
+                "group": "stanford",
+                "editGroups": [
+                  "cornell"
+                ]
+              },
+              "properties": [
+                {
+                  "key": "abc73",
+                  "values": [],
+                  "show": true
+                }
+              ]
+            },
+            "component": null
+          }
+        ],
         "show": true
       },
       {
         "key": "abc30",
+        "values": [],
+        "show": true
+      },
+      {
+        "key": "abc31",
+        "values": [],
+        "show": true
+      },
+      {
+        "key": "abc32",
+        "values": [],
+        "show": true
+      },
+      {
+        "key": "abc33",
+        "values": [],
+        "show": true
+      },
+      {
+        "key": "abc34",
+        "values": [],
+        "show": true
+      },
+      {
+        "key": "abc35",
         "values": [
           {
-            "key": "abc47",
+            "key": "abc67",
             "literal": "Default required literal1",
             "lang": null,
             "uri": null,
@@ -1166,7 +1180,7 @@
             "component": "InputLiteralValue"
           },
           {
-            "key": "abc48",
+            "key": "abc68",
             "literal": "Default required literal2",
             "lang": null,
             "uri": null,
@@ -1178,17 +1192,16 @@
         "show": true
       },
       {
-        "key": "abc33",
+        "key": "abc38",
         "values": [
           {
-            "key": "abc61",
+            "key": "abc83",
             "literal": null,
             "lang": null,
             "uri": null,
             "label": null,
-            "component": null,
             "valueSubject": {
-              "key": "abc49",
+              "key": "abc69",
               "uri": null,
               "subjectTemplate": {
                 "key": "resourceTemplate:testing:uber5",
@@ -1199,8 +1212,6 @@
                 "author": null,
                 "remark": "Template for testing purposes with suppressed, repeatable URI.",
                 "date": null,
-                "group": "stanford",
-                "editGroups": ["cornell"],
                 "suppressible": true,
                 "propertyTemplateKeys": [
                   "resourceTemplate:testing:uber5 > http://id.loc.gov/ontologies/bibframe/uber/template5/property1"
@@ -1222,22 +1233,27 @@
                     "type": "uri",
                     "component": "InputURI"
                   }
+                ],
+                "group": "stanford",
+                "editGroups": [
+                  "cornell"
                 ]
               },
               "properties": [
                 {
-                  "key": "abc54",
-                  "values": null,
-                  "show": false
+                  "key": "abc74",
+                  "values": [],
+                  "show": true
                 }
               ]
-            }
+            },
+            "component": null
           }
         ],
         "show": true
       },
       {
-        "key": "abc34",
+        "key": "abc40",
         "values": [],
         "show": true
       }

--- a/__tests__/__action_fixtures__/newResourceFromDataset-ADD_SUBJECT.json
+++ b/__tests__/__action_fixtures__/newResourceFromDataset-ADD_SUBJECT.json
@@ -12,8 +12,6 @@
       "author": "Justin Littman",
       "remark": "Template for testing purposes.",
       "date": "2020-07-27",
-      "group": "stanford",
-      "editGroups": ["cornell"],
       "suppressible": false,
       "propertyTemplateKeys": [
         "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property1",
@@ -305,11 +303,11 @@
               "nonldLookup": false
             },
             {
-              "authority": "getty_aat_ld4l_cache",
+              "uri": "urn:ld4p:qa:gettyaat",
               "label": "GETTY_AAT  (QA)",
-              "nonldLookup": false,
+              "authority": "getty_aat_ld4l_cache",
               "subauthority": "",
-              "uri": "urn:ld4p:qa:gettyaat"
+              "nonldLookup": false
             }
           ],
           "type": "uri",
@@ -626,6 +624,10 @@
           "type": "literal",
           "component": "InputLiteral"
         }
+      ],
+      "group": "stanford",
+      "editGroups": [
+        "cornell"
       ]
     },
     "properties": [
@@ -633,14 +635,13 @@
         "key": "abc1",
         "values": [
           {
-            "key": "abc50",
+            "key": "abc70",
             "literal": null,
             "lang": null,
             "uri": null,
             "label": null,
-            "component": null,
             "valueSubject": {
-              "key": "abc36",
+              "key": "abc56",
               "uri": null,
               "subjectTemplate": {
                 "key": "resourceTemplate:testing:uber2",
@@ -651,8 +652,6 @@
                 "author": null,
                 "remark": "Template for testing purposes with single repeatable literal.",
                 "date": null,
-                "group": "stanford",
-                "editGroups": ["cornell"],
                 "suppressible": false,
                 "propertyTemplateKeys": [
                   "resourceTemplate:testing:uber2 > http://id.loc.gov/ontologies/bibframe/uber/template2/property1"
@@ -674,14 +673,18 @@
                     "type": "literal",
                     "component": "InputLiteral"
                   }
+                ],
+                "group": "stanford",
+                "editGroups": [
+                  "cornell"
                 ]
               },
               "properties": [
                 {
-                  "key": "abc41",
+                  "key": "abc61",
                   "values": [
                     {
-                      "key": "abc46",
+                      "key": "abc66",
                       "literal": "Uber template2, property1",
                       "lang": "eng",
                       "uri": null,
@@ -690,27 +693,27 @@
                       "component": "InputLiteralValue"
                     }
                   ],
-                  "show": false
+                  "show": true
                 }
               ]
-            }
+            },
+            "component": null
           },
           {
-            "key": "abc51",
+            "key": "abc71",
             "literal": null,
             "lang": null,
             "uri": null,
             "label": null,
-            "component": null,
             "valueSubject": {
-              "key": "abc37",
+              "key": "abc57",
               "uri": null,
               "properties": [
                 {
-                  "key": "abc42",
+                  "key": "abc62",
                   "values": [
                     {
-                      "key": "abc47",
+                      "key": "abc67",
                       "literal": "Uber template2, property1b",
                       "lang": "eng",
                       "uri": null,
@@ -719,20 +722,20 @@
                       "component": "InputLiteralValue"
                     }
                   ],
-                  "show": false
+                  "show": true
                 }
               ]
-            }
+            },
+            "component": null
           },
           {
-            "key": "abc49",
+            "key": "abc69",
             "literal": null,
             "lang": null,
             "uri": null,
             "label": null,
-            "component": null,
             "valueSubject": {
-              "key": "abc35",
+              "key": "abc55",
               "uri": null,
               "subjectTemplate": {
                 "key": "resourceTemplate:testing:uber3",
@@ -743,8 +746,6 @@
                 "author": null,
                 "remark": "Template for testing purposes with multiple literal.",
                 "date": null,
-                "group": "stanford",
-                "editGroups": ["cornell"],
                 "suppressible": false,
                 "propertyTemplateKeys": [
                   "resourceTemplate:testing:uber3 > http://id.loc.gov/ontologies/bibframe/uber/template3/property1",
@@ -783,14 +784,18 @@
                     "type": "literal",
                     "component": "InputLiteral"
                   }
+                ],
+                "group": "stanford",
+                "editGroups": [
+                  "cornell"
                 ]
               },
               "properties": [
                 {
-                  "key": "abc39",
+                  "key": "abc59",
                   "values": [
                     {
-                      "key": "abc44",
+                      "key": "abc64",
                       "literal": "Uber template3, property1",
                       "lang": "eng",
                       "uri": null,
@@ -799,13 +804,13 @@
                       "component": "InputLiteralValue"
                     }
                   ],
-                  "show": false
+                  "show": true
                 },
                 {
-                  "key": "abc40",
+                  "key": "abc60",
                   "values": [
                     {
-                      "key": "abc45",
+                      "key": "abc65",
                       "literal": "Uber template3, property2",
                       "lang": "eng",
                       "uri": null,
@@ -814,40 +819,21 @@
                       "component": "InputLiteralValue"
                     }
                   ],
-                  "show": false
+                  "show": true
                 }
               ]
-            }
+            },
+            "component": null
           }
         ],
-        "show": false
-      },
-      {
-        "key": "abc2",
-        "values": [
-          {
-            "key": "abc31",
-            "literal": "Uber template1, property2",
-            "lang": "eng",
-            "uri": null,
-            "label": null,
-            "valueSubject": null,
-            "component": "InputLiteralValue"
-          }
-        ],
-        "show": false
-      },
-      {
-        "key": "abc3",
-        "values": null,
-        "show": false
+        "show": true
       },
       {
         "key": "abc4",
         "values": [
           {
-            "key": "abc32",
-            "literal": "Uber template1, property4",
+            "key": "abc51",
+            "literal": "Uber template1, property2",
             "lang": "eng",
             "uri": null,
             "label": null,
@@ -861,7 +847,160 @@
         "key": "abc5",
         "values": [
           {
-            "key": "abc33",
+            "key": "abc45",
+            "literal": null,
+            "lang": null,
+            "uri": null,
+            "label": null,
+            "valueSubject": {
+              "key": "abc6",
+              "uri": null,
+              "subjectTemplate": {
+                "key": "resourceTemplate:testing:uber2",
+                "uri": "http://localhost:3000/resource/resourceTemplate:testing:uber2",
+                "id": "resourceTemplate:testing:uber2",
+                "class": "http://id.loc.gov/ontologies/bibframe/Uber2",
+                "label": "Uber template2",
+                "author": null,
+                "remark": "Template for testing purposes with single repeatable literal.",
+                "date": null,
+                "suppressible": false,
+                "propertyTemplateKeys": [
+                  "resourceTemplate:testing:uber2 > http://id.loc.gov/ontologies/bibframe/uber/template2/property1"
+                ],
+                "propertyTemplates": [
+                  {
+                    "key": "resourceTemplate:testing:uber2 > http://id.loc.gov/ontologies/bibframe/uber/template2/property1",
+                    "subjectTemplateKey": "resourceTemplate:testing:uber2",
+                    "label": "Uber template2, property1",
+                    "uri": "http://id.loc.gov/ontologies/bibframe/uber/template2/property1",
+                    "required": false,
+                    "repeatable": true,
+                    "ordered": false,
+                    "remark": "A repeatable literal",
+                    "remarkUrl": null,
+                    "defaults": [],
+                    "valueSubjectTemplateKeys": [],
+                    "authorities": [],
+                    "type": "literal",
+                    "component": "InputLiteral"
+                  }
+                ],
+                "group": "stanford",
+                "editGroups": [
+                  "cornell"
+                ]
+              },
+              "properties": [
+                {
+                  "key": "abc36",
+                  "values": [],
+                  "show": true
+                }
+              ]
+            },
+            "component": null
+          },
+          {
+            "key": "abc50",
+            "literal": null,
+            "lang": null,
+            "uri": null,
+            "label": null,
+            "valueSubject": {
+              "key": "abc7",
+              "uri": null,
+              "subjectTemplate": {
+                "key": "resourceTemplate:testing:uber3",
+                "uri": "http://localhost:3000/resource/resourceTemplate:testing:uber3",
+                "id": "resourceTemplate:testing:uber3",
+                "class": "http://id.loc.gov/ontologies/bibframe/Uber3",
+                "label": "Uber template3",
+                "author": null,
+                "remark": "Template for testing purposes with multiple literal.",
+                "date": null,
+                "suppressible": false,
+                "propertyTemplateKeys": [
+                  "resourceTemplate:testing:uber3 > http://id.loc.gov/ontologies/bibframe/uber/template3/property1",
+                  "resourceTemplate:testing:uber3 > http://id.loc.gov/ontologies/bibframe/uber/template3/property2"
+                ],
+                "propertyTemplates": [
+                  {
+                    "key": "resourceTemplate:testing:uber3 > http://id.loc.gov/ontologies/bibframe/uber/template3/property1",
+                    "subjectTemplateKey": "resourceTemplate:testing:uber3",
+                    "label": "Uber template3, property1",
+                    "uri": "http://id.loc.gov/ontologies/bibframe/uber/template3/property1",
+                    "required": false,
+                    "repeatable": true,
+                    "ordered": false,
+                    "remark": "A literal",
+                    "remarkUrl": null,
+                    "defaults": [],
+                    "valueSubjectTemplateKeys": [],
+                    "authorities": [],
+                    "type": "literal",
+                    "component": "InputLiteral"
+                  },
+                  {
+                    "key": "resourceTemplate:testing:uber3 > http://id.loc.gov/ontologies/bibframe/uber/template3/property2",
+                    "subjectTemplateKey": "resourceTemplate:testing:uber3",
+                    "label": "Uber template3, property2",
+                    "uri": "http://id.loc.gov/ontologies/bibframe/uber/template3/property2",
+                    "required": false,
+                    "repeatable": true,
+                    "ordered": false,
+                    "remark": null,
+                    "remarkUrl": "http://access.rdatoolkit.org/1.0.html",
+                    "defaults": [],
+                    "valueSubjectTemplateKeys": [],
+                    "authorities": [],
+                    "type": "literal",
+                    "component": "InputLiteral"
+                  }
+                ],
+                "group": "stanford",
+                "editGroups": [
+                  "cornell"
+                ]
+              },
+              "properties": [
+                {
+                  "key": "abc42",
+                  "values": [],
+                  "show": true
+                },
+                {
+                  "key": "abc43",
+                  "values": [],
+                  "show": true
+                }
+              ]
+            },
+            "component": null
+          }
+        ],
+        "show": true
+      },
+      {
+        "key": "abc8",
+        "values": [
+          {
+            "key": "abc52",
+            "literal": "Uber template1, property4",
+            "lang": "eng",
+            "uri": null,
+            "label": null,
+            "valueSubject": null,
+            "component": "InputLiteralValue"
+          }
+        ],
+        "show": true
+      },
+      {
+        "key": "abc9",
+        "values": [
+          {
+            "key": "abc53",
             "literal": null,
             "lang": null,
             "uri": "ubertemplate1:property5",
@@ -873,10 +1012,10 @@
         "show": true
       },
       {
-        "key": "abc6",
+        "key": "abc10",
         "values": [
           {
-            "key": "abc34",
+            "key": "abc54",
             "literal": null,
             "lang": null,
             "uri": "ubertemplate1:property6",
@@ -885,26 +1024,6 @@
             "component": "InputURIValue"
           }
         ],
-        "show": true
-      },
-      {
-        "key": "abc7",
-        "values": null,
-        "show": false
-      },
-      {
-        "key": "abc8",
-        "values": null,
-        "show": false
-      },
-      {
-        "key": "abc9",
-        "values": [],
-        "show": true
-      },
-      {
-        "key": "abc10",
-        "values": [],
         "show": true
       },
       {
@@ -944,16 +1063,35 @@
       },
       {
         "key": "abc18",
+        "values": [],
+        "show": true
+      },
+      {
+        "key": "abc19",
+        "values": [],
+        "show": true
+      },
+      {
+        "key": "abc20",
+        "values": [],
+        "show": true
+      },
+      {
+        "key": "abc21",
+        "values": [],
+        "show": true
+      },
+      {
+        "key": "abc22",
         "values": [
           {
-            "key": "abc30",
+            "key": "abc46",
             "literal": null,
             "lang": null,
             "uri": null,
             "label": null,
-            "component": null,
             "valueSubject": {
-              "key": "abc19",
+              "key": "abc23",
               "uri": null,
               "subjectTemplate": {
                 "key": "resourceTemplate:testing:uber4",
@@ -964,8 +1102,6 @@
                 "author": null,
                 "remark": "Template for testing purposes with single repeatable, required literal.",
                 "date": null,
-                "group": "stanford",
-                "editGroups": ["cornell"],
                 "suppressible": false,
                 "propertyTemplateKeys": [
                   "resourceTemplate:testing:uber4 > http://id.loc.gov/ontologies/bibframe/uber/template4/property1"
@@ -987,49 +1123,85 @@
                     "type": "literal",
                     "component": "InputLiteral"
                   }
+                ],
+                "group": "stanford",
+                "editGroups": [
+                  "cornell"
                 ]
               },
               "properties": [
                 {
-                  "key": "abc29",
+                  "key": "abc37",
                   "values": [],
                   "show": true
                 }
               ]
-            }
+            },
+            "component": null
           }
         ],
         "show": true
       },
       {
-        "key": "abc20",
-        "values": null,
-        "show": false
-      },
-      {
-        "key": "abc21",
-        "values": null,
-        "show": false
-      },
-      {
-        "key": "abc22",
-        "values": null,
-        "show": false
-      },
-      {
-        "key": "abc23",
-        "values": null,
-        "show": false
-      },
-      {
         "key": "abc24",
-        "values": null,
-        "show": false
-      },
-      {
-        "key": "abc25",
-        "values": null,
-        "show": false
+        "values": [
+          {
+            "key": "abc47",
+            "literal": null,
+            "lang": null,
+            "uri": null,
+            "label": null,
+            "valueSubject": {
+              "key": "abc25",
+              "uri": null,
+              "subjectTemplate": {
+                "key": "resourceTemplate:testing:uber4",
+                "uri": "http://localhost:3000/resource/resourceTemplate:testing:uber4",
+                "id": "resourceTemplate:testing:uber4",
+                "class": "http://id.loc.gov/ontologies/bibframe/Uber4",
+                "label": "Uber template4",
+                "author": null,
+                "remark": "Template for testing purposes with single repeatable, required literal.",
+                "date": null,
+                "suppressible": false,
+                "propertyTemplateKeys": [
+                  "resourceTemplate:testing:uber4 > http://id.loc.gov/ontologies/bibframe/uber/template4/property1"
+                ],
+                "propertyTemplates": [
+                  {
+                    "key": "resourceTemplate:testing:uber4 > http://id.loc.gov/ontologies/bibframe/uber/template4/property1",
+                    "subjectTemplateKey": "resourceTemplate:testing:uber4",
+                    "label": "Uber template4, property1",
+                    "uri": "http://id.loc.gov/ontologies/bibframe/uber/template4/property1",
+                    "required": true,
+                    "repeatable": true,
+                    "ordered": false,
+                    "remark": "A repeatable, required literal",
+                    "remarkUrl": null,
+                    "defaults": [],
+                    "valueSubjectTemplateKeys": [],
+                    "authorities": [],
+                    "type": "literal",
+                    "component": "InputLiteral"
+                  }
+                ],
+                "group": "stanford",
+                "editGroups": [
+                  "cornell"
+                ]
+              },
+              "properties": [
+                {
+                  "key": "abc38",
+                  "values": [],
+                  "show": true
+                }
+              ]
+            },
+            "component": null
+          }
+        ],
+        "show": true
       },
       {
         "key": "abc26",
@@ -1038,16 +1210,40 @@
       },
       {
         "key": "abc27",
+        "values": [],
+        "show": true
+      },
+      {
+        "key": "abc28",
+        "values": [],
+        "show": true
+      },
+      {
+        "key": "abc29",
+        "values": [],
+        "show": true
+      },
+      {
+        "key": "abc30",
+        "values": [],
+        "show": true
+      },
+      {
+        "key": "abc31",
+        "values": [],
+        "show": true
+      },
+      {
+        "key": "abc32",
         "values": [
           {
-            "key": "abc52",
+            "key": "abc72",
             "literal": null,
             "lang": null,
             "uri": null,
             "label": null,
-            "component": null,
             "valueSubject": {
-              "key": "abc38",
+              "key": "abc58",
               "uri": null,
               "subjectTemplate": {
                 "key": "resourceTemplate:testing:uber5",
@@ -1058,8 +1254,6 @@
                 "author": null,
                 "remark": "Template for testing purposes with suppressed, repeatable URI.",
                 "date": null,
-                "group": "stanford",
-                "editGroups": ["cornell"],
                 "suppressible": true,
                 "propertyTemplateKeys": [
                   "resourceTemplate:testing:uber5 > http://id.loc.gov/ontologies/bibframe/uber/template5/property1"
@@ -1081,14 +1275,18 @@
                     "type": "uri",
                     "component": "InputURI"
                   }
+                ],
+                "group": "stanford",
+                "editGroups": [
+                  "cornell"
                 ]
               },
               "properties": [
                 {
-                  "key": "abc43",
+                  "key": "abc63",
                   "values": [
                     {
-                      "key": "abc48",
+                      "key": "abc68",
                       "literal": null,
                       "lang": null,
                       "uri": "http://sinopia.io/ubertemplate5/property1",
@@ -1097,18 +1295,19 @@
                       "component": "InputURIValue"
                     }
                   ],
-                  "show": false
+                  "show": true
                 }
               ]
-            }
+            },
+            "component": null
           }
         ],
-        "show": false
+        "show": true
       },
       {
-        "key": "abc28",
-        "values": null,
-        "show": false
+        "key": "abc34",
+        "values": [],
+        "show": true
       }
     ]
   }

--- a/__tests__/feature/editing/addRemove.test.js
+++ b/__tests__/feature/editing/addRemove.test.js
@@ -99,13 +99,15 @@ describe("adding and removing properties", () => {
 
     await screen.findByText("Uber template1", { selector: "h3" })
 
-    // Add a nested property (literal)
-    fireEvent.click(screen.getAllByTestId("Add Uber template2, property1")[0])
+    // Show a nested property (literal)
+    fireEvent.click(screen.getAllByTestId("Show Uber template2, property1")[0])
     // Input box displayed
     await screen.findByPlaceholderText("Uber template2, property1")
 
     // Now remove it.
-    fireEvent.click(screen.getByTestId("Remove Uber template2, property1"))
+    fireEvent.click(
+      screen.getAllByTestId("Remove Uber template2, property1")[0]
+    )
 
     // Input box removed.
     expect(
@@ -114,7 +116,7 @@ describe("adding and removing properties", () => {
     // Delete button removed
     expect(
       screen.queryAllByTestId("Remove Uber template2, property1")
-    ).toHaveLength(0)
+    ).toHaveLength(1)
   }, 15000)
 
   it("removes and adds a required property with defaults, leaving the defaults but deleting the user entered literal", async () => {

--- a/__tests__/feature/editing/expandContract.test.js
+++ b/__tests__/feature/editing/expandContract.test.js
@@ -17,8 +17,8 @@ describe("expanding and contracting properties", () => {
     await screen.findByText("Uber template2", { selector: "h5" })
     await screen.findByText("Uber template3", { selector: "h5" })
 
-    // Add a nested property
-    fireEvent.click(screen.getByTestId("Add Uber template2, property1"))
+    // Show a nested property
+    fireEvent.click(screen.getByTestId("Show Uber template2, property1"))
     // Input box displayed
     await screen.findByPlaceholderText("Uber template2, property1")
 

--- a/__tests__/feature/loadResource.test.js
+++ b/__tests__/feature/loadResource.test.js
@@ -53,11 +53,11 @@ describe("loading saved resource", () => {
       screen.getAllByText("Uber template2", { selector: "h5" })
       screen.getAllByText("Uber template3", { selector: "h5" })
       // Length is the heading and the value.
-      expect(screen.getAllByText("Uber template3, property1")).toHaveLength(3)
-      expect(screen.getAllByText("Uber template3, property2")).toHaveLength(2)
+      expect(screen.getAllByText("Uber template3, property1")).toHaveLength(4)
+      expect(screen.getAllByText("Uber template3, property2")).toHaveLength(3)
       expect(screen.getAllByText("Uber template1, property2")).toHaveLength(3)
       // Heading appears twice, value once.
-      expect(screen.getAllByText("Uber template2, property1")).toHaveLength(5)
+      expect(screen.getAllByText("Uber template2, property1")).toHaveLength(6)
 
       // Show input components
       screen.getByTestId("Hide Uber template3, property1")

--- a/src/actionCreators/resourceHelpers.js
+++ b/src/actionCreators/resourceHelpers.js
@@ -456,8 +456,8 @@ const newProperty =
       if (!_.isEmpty(property.values)) property.show = true
     }
 
-    // If required and we do not already have some default values, then expand the property.
-    if (propertyTemplate.required && !property.values) {
+    // If we do not already have some default values, then expand the property.
+    if (!property.values) {
       property.show = true
       return dispatch(
         valuesForExpandedProperty(property, noDefaults, errorKey)

--- a/src/components/editor/property/PanelProperty.jsx
+++ b/src/components/editor/property/PanelProperty.jsx
@@ -94,10 +94,7 @@ const PanelProperty = (props) => {
                 onClick={() => props.contractProperty(props.property.key)}
                 data-id={props.id}
               >
-                <FontAwesomeIcon
-                  className="fa-inverse trash-icon"
-                  icon={trashIcon}
-                />
+                <FontAwesomeIcon className="trash-icon" icon={trashIcon} />
               </button>
             )}
           </h5>

--- a/src/reducers/resources.js
+++ b/src/reducers/resources.js
@@ -487,8 +487,7 @@ export const removeValue = (state, action) => {
 }
 
 const addFirstValue = (state, property) => {
-  // For URI and Literal component, if no values, add a value.
-  // Eventually, this will apply to other components as well.
+  // If not a nested resource and if no values, add a value.
 
   if (property.valueKeys === null || !_.isEmpty(property.valueKeys))
     return state


### PR DESCRIPTION
closes #3120

## Why was this change made?
When loading resources, some properties were not in editable state.


## How was this change tested?
Unit, local


## Which documentation and/or configurations were updated?



