### PR TITLE
disable scrolling and clicks behind modals

### DIFF
--- a/src/components/editor/leftNav/ActivePanelPropertyNav.jsx
+++ b/src/components/editor/leftNav/ActivePanelPropertyNav.jsx
@@ -1,17 +1,15 @@
 import React from "react"
 import PropTypes from "prop-types"
-import { setCurrentComponent } from "actions/index"
-import { useDispatch, useSelector } from "react-redux"
+import { useSelector } from "react-redux"
 import { displayResourceValidations } from "selectors/errors"
 import { selectNormProperty, selectNormValues } from "selectors/resources"
 import { selectPropertyTemplate } from "selectors/templates"
 import SubjectSubNav from "./SubjectSubNav"
 import PresenceIndicator from "./PresenceIndicator"
-import { selectModalType } from "selectors/modals"
+import useLeftNav from "hooks/useLeftNav"
 import _ from "lodash"
 
 const ActivePanelPropertyNav = (props) => {
-  const dispatch = useDispatch()
   const property = useSelector((state) =>
     selectNormProperty(state, props.propertyKey)
   )
@@ -21,6 +19,8 @@ const ActivePanelPropertyNav = (props) => {
   const propertyTemplate = useSelector((state) =>
     selectPropertyTemplate(state, property?.propertyTemplateKey)
   )
+
+  const handleClick = useLeftNav(property)
 
   const liClassNames = []
 
@@ -45,20 +45,6 @@ const ActivePanelPropertyNav = (props) => {
     return <ul>{subNavItems}</ul>
   }
 
-  const isModalOpen = useSelector((state) => selectModalType(state))
-
-  const handleClick = (property) => {
-    if (isModalOpen) return // do not respond to clicks in the nav if any modal is open
-
-    dispatch(
-      setCurrentComponent(
-        property.rootSubjectKey,
-        property.rootPropertyKey,
-        property.key
-      )
-    )
-  }
-
   if (!property) return null
 
   // Render this property and any children value subjects (if a property type = resource).
@@ -69,7 +55,7 @@ const ActivePanelPropertyNav = (props) => {
         className="btn btn-primary"
         aria-label={`Go to ${propertyTemplate.label}`}
         data-testid={`Go to ${propertyTemplate.label}`}
-        onClick={() => handleClick(property)}
+        onClick={handleClick}
       >
         <h5 className={headingClassNames.join(" ")}>
           {propertyTemplate.label}

--- a/src/components/editor/leftNav/ActivePanelPropertyNav.jsx
+++ b/src/components/editor/leftNav/ActivePanelPropertyNav.jsx
@@ -7,6 +7,7 @@ import { selectNormProperty, selectNormValues } from "selectors/resources"
 import { selectPropertyTemplate } from "selectors/templates"
 import SubjectSubNav from "./SubjectSubNav"
 import PresenceIndicator from "./PresenceIndicator"
+import { selectModalType } from "selectors/modals"
 import _ from "lodash"
 
 const ActivePanelPropertyNav = (props) => {
@@ -44,6 +45,20 @@ const ActivePanelPropertyNav = (props) => {
     return <ul>{subNavItems}</ul>
   }
 
+  const isModalOpen = useSelector((state) => selectModalType(state))
+
+  const handleClick = (property) => {
+    if (isModalOpen) return // do not respond to clicks in the nav if any modal is open
+
+    dispatch(
+      setCurrentComponent(
+        property.rootSubjectKey,
+        property.rootPropertyKey,
+        property.key
+      )
+    )
+  }
+
   if (!property) return null
 
   // Render this property and any children value subjects (if a property type = resource).
@@ -54,15 +69,7 @@ const ActivePanelPropertyNav = (props) => {
         className="btn btn-primary"
         aria-label={`Go to ${propertyTemplate.label}`}
         data-testid={`Go to ${propertyTemplate.label}`}
-        onClick={() =>
-          dispatch(
-            setCurrentComponent(
-              property.rootSubjectKey,
-              property.rootPropertyKey,
-              property.key
-            )
-          )
-        }
+        onClick={() => handleClick(property)}
       >
         <h5 className={headingClassNames.join(" ")}>
           {propertyTemplate.label}

--- a/src/components/editor/leftNav/PanelPropertyNav.jsx
+++ b/src/components/editor/leftNav/PanelPropertyNav.jsx
@@ -1,16 +1,14 @@
 import React from "react"
 import PropTypes from "prop-types"
-import { setCurrentComponent } from "actions/index"
-import { useDispatch, useSelector } from "react-redux"
+import { useSelector } from "react-redux"
 import { displayResourceValidations } from "selectors/errors"
 import { selectNormProperty } from "selectors/resources"
 import { selectPropertyTemplate } from "selectors/templates"
 import PresenceIndicator from "./PresenceIndicator"
-import { selectModalType } from "selectors/modals"
+import useLeftNav from "hooks/useLeftNav"
 import _ from "lodash"
 
 const PanelPropertyNav = (props) => {
-  const dispatch = useDispatch()
   const property = useSelector((state) =>
     selectNormProperty(state, props.propertyKey)
   )
@@ -25,21 +23,9 @@ const PanelPropertyNav = (props) => {
   const headingClassNames = ["left-nav-header"]
   if (displayValidations && hasError) headingClassNames.push("text-danger")
 
-  const isModalOpen = useSelector((state) => selectModalType(state))
+  const handleClick = useLeftNav(property)
 
   if (!property) return null
-
-  const handleClick = (property) => {
-    if (isModalOpen) return // do not respond to clicks in the nav if any modal is open
-
-    dispatch(
-      setCurrentComponent(
-        property.rootSubjectKey,
-        property.rootPropertyKey,
-        property.key
-      )
-    )
-  }
 
   return (
     <li>
@@ -48,7 +34,7 @@ const PanelPropertyNav = (props) => {
         className="btn btn-link"
         aria-label={`Go to ${propertyTemplate.label}`}
         data-testid={`Go to ${propertyTemplate.label}`}
-        onClick={() => handleClick(property)}
+        onClick={handleClick}
       >
         <h5 className={headingClassNames.join(" ")}>
           {propertyTemplate.label}

--- a/src/components/editor/leftNav/PanelPropertyNav.jsx
+++ b/src/components/editor/leftNav/PanelPropertyNav.jsx
@@ -6,6 +6,7 @@ import { displayResourceValidations } from "selectors/errors"
 import { selectNormProperty } from "selectors/resources"
 import { selectPropertyTemplate } from "selectors/templates"
 import PresenceIndicator from "./PresenceIndicator"
+import { selectModalType } from "selectors/modals"
 import _ from "lodash"
 
 const PanelPropertyNav = (props) => {
@@ -24,7 +25,21 @@ const PanelPropertyNav = (props) => {
   const headingClassNames = ["left-nav-header"]
   if (displayValidations && hasError) headingClassNames.push("text-danger")
 
+  const isModalOpen = useSelector((state) => selectModalType(state))
+
   if (!property) return null
+
+  const handleClick = (property) => {
+    if (isModalOpen) return // do not respond to clicks in the nav if any modal is open
+
+    dispatch(
+      setCurrentComponent(
+        property.rootSubjectKey,
+        property.rootPropertyKey,
+        property.key
+      )
+    )
+  }
 
   return (
     <li>
@@ -33,15 +48,7 @@ const PanelPropertyNav = (props) => {
         className="btn btn-link"
         aria-label={`Go to ${propertyTemplate.label}`}
         data-testid={`Go to ${propertyTemplate.label}`}
-        onClick={() =>
-          dispatch(
-            setCurrentComponent(
-              property.rootSubjectKey,
-              property.rootPropertyKey,
-              property.key
-            )
-          )
-        }
+        onClick={() => handleClick(property)}
       >
         <h5 className={headingClassNames.join(" ")}>
           {propertyTemplate.label}

--- a/src/components/editor/leftNav/PropertySubNav.jsx
+++ b/src/components/editor/leftNav/PropertySubNav.jsx
@@ -7,6 +7,7 @@ import { selectNormProperty, selectNormValues } from "selectors/resources"
 import { selectPropertyTemplate } from "selectors/templates"
 import SubjectSubNav from "./SubjectSubNav"
 import PresenceIndicator from "./PresenceIndicator"
+import { selectModalType } from "selectors/modals"
 import _ from "lodash"
 
 const PropertySubNav = (props) => {
@@ -21,6 +22,20 @@ const PropertySubNav = (props) => {
   const values = useSelector((state) =>
     selectNormValues(state, property?.valueKeys)
   )
+
+  const isModalOpen = useSelector((state) => selectModalType(state))
+
+  const handleClick = (property) => {
+    if (isModalOpen) return // do not respond to clicks in the nav if any modal is open
+
+    dispatch(
+      setCurrentComponent(
+        property.rootSubjectKey,
+        property.rootPropertyKey,
+        property.key
+      )
+    )
+  }
 
   const hasError = !_.isEmpty(property.descWithErrorPropertyKeys)
   const displayValidations = useSelector((state) =>
@@ -50,15 +65,7 @@ const PropertySubNav = (props) => {
         className="btn btn-link"
         aria-label={`Go to ${propertyTemplate.label}`}
         data-testid={`Go to ${propertyTemplate.label}`}
-        onClick={() =>
-          dispatch(
-            setCurrentComponent(
-              property.rootSubjectKey,
-              property.rootPropertyKey,
-              property.key
-            )
-          )
-        }
+        onClick={() => handleClick(property)}
       >
         <span className={headingClassNames.join(" ")}>
           {propertyTemplate.label}

--- a/src/components/editor/leftNav/PropertySubNav.jsx
+++ b/src/components/editor/leftNav/PropertySubNav.jsx
@@ -1,18 +1,15 @@
 import React from "react"
 import PropTypes from "prop-types"
-import { setCurrentComponent } from "actions/index"
-import { useDispatch, useSelector } from "react-redux"
+import { useSelector } from "react-redux"
 import { displayResourceValidations } from "selectors/errors"
 import { selectNormProperty, selectNormValues } from "selectors/resources"
 import { selectPropertyTemplate } from "selectors/templates"
 import SubjectSubNav from "./SubjectSubNav"
 import PresenceIndicator from "./PresenceIndicator"
-import { selectModalType } from "selectors/modals"
+import useLeftNav from "hooks/useLeftNav"
 import _ from "lodash"
 
 const PropertySubNav = (props) => {
-  const dispatch = useDispatch()
-
   const property = useSelector((state) =>
     selectNormProperty(state, props.propertyKey)
   )
@@ -23,19 +20,7 @@ const PropertySubNav = (props) => {
     selectNormValues(state, property?.valueKeys)
   )
 
-  const isModalOpen = useSelector((state) => selectModalType(state))
-
-  const handleClick = (property) => {
-    if (isModalOpen) return // do not respond to clicks in the nav if any modal is open
-
-    dispatch(
-      setCurrentComponent(
-        property.rootSubjectKey,
-        property.rootPropertyKey,
-        property.key
-      )
-    )
-  }
+  const handleClick = useLeftNav(property)
 
   const hasError = !_.isEmpty(property.descWithErrorPropertyKeys)
   const displayValidations = useSelector((state) =>
@@ -65,7 +50,7 @@ const PropertySubNav = (props) => {
         className="btn btn-link"
         aria-label={`Go to ${propertyTemplate.label}`}
         data-testid={`Go to ${propertyTemplate.label}`}
-        onClick={() => handleClick(property)}
+        onClick={handleClick}
       >
         <span className={headingClassNames.join(" ")}>
           {propertyTemplate.label}

--- a/src/hooks/useLeftNav.js
+++ b/src/hooks/useLeftNav.js
@@ -1,0 +1,26 @@
+import { useDispatch, useSelector } from "react-redux"
+import { setCurrentComponent } from "actions/index"
+import { selectModalType } from "selectors/modals"
+
+const useLeftNav = (property) => {
+  const isModalOpen = useSelector((state) => selectModalType(state))
+  const dispatch = useDispatch()
+
+  const handleClick = (event) => {
+    event.preventDefault()
+
+    if (isModalOpen) return // do not respond to clicks in the nav if any modal is open
+
+    dispatch(
+      setCurrentComponent(
+        property.rootSubjectKey,
+        property.rootPropertyKey,
+        property.key
+      )
+    )
+  }
+
+  return handleClick
+}
+
+export default useLeftNav

--- a/src/hooks/useNavigableComponent.js
+++ b/src/hooks/useNavigableComponent.js
@@ -2,6 +2,7 @@ import { useLayoutEffect, useRef, useState } from "react"
 import { setCurrentComponent } from "actions/index"
 import { useDispatch, useSelector } from "react-redux"
 import { selectCurrentComponentKey } from "selectors/index"
+import { selectModalType } from "selectors/modals"
 
 const useNavigableComponent = (
   rootSubjectKey,
@@ -13,8 +14,11 @@ const useNavigableComponent = (
     selectCurrentComponentKey(state, rootSubjectKey)
   )
   const [lastComponentKey, setLastComponentKey] = useState(null)
+  const isModalOpen = useSelector((state) => selectModalType(state))
 
   useLayoutEffect(() => {
+    if (isModalOpen) return // if any modal is open, do not scroll the page in response to clicks
+
     if (
       componentKey === currentComponentKey &&
       lastComponentKey !== currentComponentKey &&
@@ -24,7 +28,7 @@ const useNavigableComponent = (
       navEl.current.scrollIntoView({ behavior: "smooth" })
       setLastComponentKey(currentComponentKey)
     }
-  }, [componentKey, currentComponentKey, lastComponentKey])
+  }, [componentKey, currentComponentKey, lastComponentKey, isModalOpen])
 
   // From  https://blogreact.com/check-element-is-in-viewport/
   const isVisible = (el) => {


### PR DESCRIPTION
## Why was this change made?

More attempts to fix #3109 as a follow on to work done in #3136 

1. Prevent scrolling when a field is clicked behind a modal
2. Prevent fields from being selected behind a modal

~~Still unclear: clicking a header in a resource template behind the modal still changes the left nav (even though that doesn't really impact you or cause problems, it can be confusing).  The template property headers are rendered here:~~

~~https://github.com/LD4P/sinopia_editor/blob/main/src/components/editor/property/PanelProperty.jsx#L63-L68~~
~~https://github.com/LD4P/sinopia_editor/blob/main/src/components/editor/property/PropertyLabel.jsx~~

~~but I  don't see where we are responding to clicks to change the left nav in response (to disable there too).~~

UPDATE: Now unable to reproduce this behavior :/

## How was this change tested?

Localhost browser

## Which documentation and/or configurations were updated?



