### PR TITLE
do not show separator bullets when not logged in

### DIFF
--- a/src/components/home/Header.jsx
+++ b/src/components/home/Header.jsx
@@ -33,7 +33,7 @@ const Header = (props) => (
           </li>
         </React.Fragment>
       )}
-      <div className="nav-link">•</div>
+      {props.currentUser && <div className="nav-link">•</div>}
       <li className="menu nav-item">
         <a
           href="#"
@@ -43,7 +43,7 @@ const Header = (props) => (
           Help
         </a>
       </li>
-      <div className="nav-link">•</div>
+      {props.currentUser && <div className="nav-link">•</div>}
       {props.currentUser && (
         <li className="nav-item">
           <a


### PR DESCRIPTION
## Why was this change made?

Fixes #3152 - separator bullets in top nav not needed when not logged in

**Logged in:**

![Screen Shot 2021-10-12 at 11 35 36 AM](https://user-images.githubusercontent.com/47137/137010663-f5b7d5d2-4098-4d76-b802-5073400ce4f0.png)

**Not logged in:**

![Screen Shot 2021-10-12 at 11 35 40 AM](https://user-images.githubusercontent.com/47137/137010687-284af489-c18c-4ea5-a0b7-f4e5a040465c.png)

## How was this change tested?

Localhost browser



## Which documentation and/or configurations were updated?



