### PR TITLE
Update visual design of various controls

### DIFF
--- a/src/components/editor/EditorActions.jsx
+++ b/src/components/editor/EditorActions.jsx
@@ -12,7 +12,7 @@ const EditorActions = () => (
     <div className="d-flex justify-content-end">
       <MarcButton />
       <TransferButtons />
-      <CloseButton label={"Close"} />
+      <CloseButton css={"editor-action-close"} label={"Close"} />
       <SaveAndPublishButton class="editor-save" />
     </div>
   </div>

--- a/src/components/editor/EditorActions.jsx
+++ b/src/components/editor/EditorActions.jsx
@@ -1,20 +1,17 @@
 // Copyright 2019 Stanford University see LICENSE for license
 
 import React from "react"
-import CopyToNewButton from "./actions/CopyToNewButton"
-import PreviewButton from "./actions/PreviewButton"
 import CloseButton from "./actions/CloseButton"
 import SaveAndPublishButton from "./actions/SaveAndPublishButton"
 import MarcButton from "./actions/MarcButton"
 import TransferButtons from "./actions/TransferButtons"
 
+// CopyToNewButton and PreviewButton are now called from ResourceComponent
 const EditorActions = () => (
   <div className="row">
     <div className="d-flex justify-content-end">
       <MarcButton />
       <TransferButtons />
-      <CopyToNewButton />
-      <PreviewButton />
       <CloseButton label={"Close"} />
       <SaveAndPublishButton class="editor-save" />
     </div>

--- a/src/components/editor/ResourceComponent.jsx
+++ b/src/components/editor/ResourceComponent.jsx
@@ -5,6 +5,8 @@ import { useSelector } from "react-redux"
 import PanelResource from "./property/PanelResource"
 import CopyToNewMessage from "./CopyToNewMessage"
 import ResourceURIMessage from "./ResourceURIMessage"
+import CopyToNewButton from "./actions/CopyToNewButton"
+import PreviewButton from "./actions/PreviewButton"
 import PermissionsAction from "./actions/PermissionsAction"
 import SaveAlert from "./SaveAlert"
 import Alerts from "../Alerts"
@@ -41,7 +43,11 @@ const ResourceComponent = () => {
         <Alerts errorKey={resourceEditWarningKey(resourceKey)} />
         <Alerts errorKey={newResourceErrorKey} />
         <section>
-          <h3>{resource.label}</h3>
+          <h3>
+            {resource.label}
+            <CopyToNewButton />
+            <PreviewButton />
+          </h3>
           <CopyToNewMessage />
           <div className="row">
             <div className="col-md-11">

--- a/src/components/editor/ResourceURIMessage.jsx
+++ b/src/components/editor/ResourceURIMessage.jsx
@@ -32,7 +32,7 @@ const ResourceURIMessage = () => {
       URI for this resource: &lt;{uri}&gt;&nbsp;
       <button
         type="button"
-        className="btn btn-secondary btn-xs"
+        className="btn btn-secondary btn-sm"
         onClick={handleClick}
       >
         {copyText}

--- a/src/components/editor/actions/CloseButton.jsx
+++ b/src/components/editor/actions/CloseButton.jsx
@@ -32,7 +32,11 @@ const CloseButton = (props) => {
     }
     event.preventDefault()
   }
-  const btnClass = props.css || "btn-secondary"
+  let btnClass = props.css || "btn-secondary"
+  // kludge to space circles between editor actions
+  if (btnClass === "editor-action-close") {
+    btnClass = "btn-secondary editor-action-close"
+  }
   const buttonLabel = props.label
   const buttonClasses = `btn ${btnClass}`
 

--- a/src/components/editor/actions/CloseButton.jsx
+++ b/src/components/editor/actions/CloseButton.jsx
@@ -32,7 +32,7 @@ const CloseButton = (props) => {
     }
     event.preventDefault()
   }
-  const btnClass = props.css || "btn-primary"
+  const btnClass = props.css || "btn-secondary"
   const buttonLabel = props.label
   const buttonClasses = `btn ${btnClass}`
 

--- a/src/components/editor/actions/MarcButton.jsx
+++ b/src/components/editor/actions/MarcButton.jsx
@@ -74,7 +74,7 @@ const MarcButton = () => {
     event.preventDefault()
   }
 
-  const btnClasses = ["btn", "dropdown-toggle"]
+  const btnClasses = ["btn", "dropdown-toggle", "btn-no-outline"]
   if (marcs.current[resourceKey]?.marc) {
     btnClasses.push("btn-success")
   } else if (marcs.current[resourceKey]?.error) {

--- a/src/components/editor/actions/MarcButton.jsx
+++ b/src/components/editor/actions/MarcButton.jsx
@@ -96,7 +96,7 @@ const MarcButton = () => {
         aria-haspopup="true"
         aria-expanded="false"
       >
-        MARC
+        Request MARC
       </button>
       <div className="dropdown-menu" aria-labelledby="marcBtn">
         <button

--- a/src/components/editor/actions/MarcButton.jsx
+++ b/src/components/editor/actions/MarcButton.jsx
@@ -98,6 +98,7 @@ const MarcButton = () => {
       >
         Request MARC
       </button>
+      <div className="separator-circle">•</div>
       <div className="dropdown-menu" aria-labelledby="marcBtn">
         <button
           className={dropDownItemBtnClasses.join(" ")}

--- a/src/components/editor/actions/TransferButton.jsx
+++ b/src/components/editor/actions/TransferButton.jsx
@@ -22,7 +22,7 @@ const TransferButton = ({ label, handleClick }) => {
   return (
     <button
       type="button"
-      className="btn btn-secondary"
+      className="btn btn-secondary btn-no-outline"
       onClick={handleBtnClick}
     >
       {btnText}

--- a/src/components/editor/actions/TransferButtons.jsx
+++ b/src/components/editor/actions/TransferButtons.jsx
@@ -58,7 +58,11 @@ const TransferButtons = () => {
     />
   ))
 
-  return <React.Fragment>{buttons}</React.Fragment>
+  return (
+    <React.Fragment>
+      {buttons} <div className="separator-circle">•</div>
+    </React.Fragment>
+  )
 }
 
 export default TransferButtons

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -236,6 +236,11 @@ button.collapse-heading.collapsed::before {
   box-shadow: none !important;
 }
 
+.btn-no-outline.btn-danger {
+  background-color: transparent;
+  color: $bright-red;
+}
+
 @import "resourceTabs";
 @import "resourceNav";
 

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -234,11 +234,21 @@ button.collapse-heading.collapsed::before {
 .btn-no-outline {
   border: 0px;
   box-shadow: none !important;
+  margin-right: 0px;
 }
 
 .btn-no-outline.btn-danger {
   background-color: transparent;
   color: $bright-red;
+}
+
+.separator-circle {
+  margin-top: 0.4em;
+  color: #004372;
+}
+
+.editor-action-close {
+  margin-left: 1em;
 }
 
 @import "resourceTabs";

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -231,6 +231,11 @@ button.collapse-heading.collapsed::before {
   @extend .btn-link;
 }
 
+.btn-no-outline {
+  border: 0px;
+  box-shadow: none !important;
+}
+
 @import "resourceTabs";
 @import "resourceNav";
 


### PR DESCRIPTION
## Why was this change made?

Closes #3125 

There is a comment at the end of #3125 in that this PR converts the "Request Marc" and "Export to Symphony" buttons to have no borders, but it does NOT turn them into links.  The main difference to the user is the hover behavior.  If that is unacceptable, I would request that a new issue be created for that.

I can split things up if it's easier for review.

- [x] Move copy and preview icons next to title on right.
- [x] Change existing "MARC" button at upper right to a "Request MARC" ~~link~~ button without border next to "Export to catalog" (now also without border)
- [x] When borderless button is clicked and there's a problem, text of "link" becomes red.
- [x] Change style of Close button to Secondary button
- [x] Add  "dot" separating the Permissions / Export... and / Request MARC
- [x] Change style of 'Copy URI' button to be small secondary button 
- Primary button: Save - no change

### After

![after](https://user-images.githubusercontent.com/96775/137410667-4e9d41ea-7e87-4c53-a0b6-a7f466b7e554.png)

**When hovering over "link"**

![image](https://user-images.githubusercontent.com/96775/137405068-a0c7ffc4-11ce-4fe0-9ab2-fefa49b347f0.png)

**When error producing MARC (or Export):**

![image](https://user-images.githubusercontent.com/96775/137404965-03c15a48-d6e9-430b-ab7d-cd3feacd2261.png)

### Before

![image](https://user-images.githubusercontent.com/96775/137403592-0123b198-24b0-4da7-acdf-73e882ca4ff3.png)


## How was this change tested?

locally

## Which documentation and/or configurations were updated?



