### PR TITLE
Switches resource save to warn instead of error.

### DIFF
--- a/__tests__/actionCreators/resources.test.js
+++ b/__tests__/actionCreators/resources.test.js
@@ -704,6 +704,7 @@ describe("saveNewResource", () => {
 
     const actions = store.getActions()
 
+    expect(actions).toHaveAction("CLEAR_ERRORS")
     expect(actions).toHaveAction("SET_BASE_URL")
     expect(actions).toHaveAction("SAVE_RESOURCE_FINISHED")
     expect(actions).toHaveAction("ADD_RESOURCE_HISTORY", {
@@ -764,6 +765,8 @@ describe("saveResource", () => {
       saveResource("t9zVwg2zO", "stanford", ["cornell"], "testerror")
     )
     const actions = store.getActions()
+
+    expect(actions).toHaveAction("CLEAR_ERRORS")
     expect(actions).toHaveAction("SAVE_RESOURCE_FINISHED")
     expect(actions).toHaveAction("ADD_RESOURCE_HISTORY", {
       resourceUri: "https://api.sinopia.io/resource/0894a8b3",

--- a/src/actionCreators/resources.js
+++ b/src/actionCreators/resources.js
@@ -241,6 +241,9 @@ export const saveNewResource =
     const state = getState()
     const resource = selectFullSubject(state, resourceKey)
     const currentUser = selectUser(state)
+
+    dispatch(clearErrors(errorKey))
+
     return postResource(resource, currentUser, group, editGroups)
       .then((resourceUrl) => {
         dispatch(setBaseURL(resourceKey, resourceUrl))
@@ -265,6 +268,8 @@ export const saveResource =
     const state = getState()
     const resource = selectFullSubject(state, resourceKey)
     const currentUser = selectUser(state)
+
+    dispatch(clearErrors(errorKey))
 
     return putResource(resource, currentUser, group, editGroups)
       .then(() => {

--- a/src/components/editor/GroupChoiceModal.jsx
+++ b/src/components/editor/GroupChoiceModal.jsx
@@ -4,7 +4,7 @@ import React, { useState } from "react"
 import { useSelector, useDispatch } from "react-redux"
 import { MultiSelect } from "react-multi-select-component"
 import { hideModal } from "actions/modals"
-import { resourceEditErrorKey } from "./Editor"
+import { resourceEditWarningKey } from "./Editor"
 import { selectModalType } from "selectors/modals"
 import {
   saveNewResource,
@@ -89,7 +89,7 @@ const GroupChoiceModal = () => {
           resourceKey,
           ownerGroupId,
           editGroupIds,
-          resourceEditErrorKey(resourceKey)
+          resourceEditWarningKey(resourceKey)
         )
       )
     } else {
@@ -98,7 +98,7 @@ const GroupChoiceModal = () => {
           resourceKey,
           ownerGroupId,
           editGroupIds,
-          resourceEditErrorKey(resourceKey)
+          resourceEditWarningKey(resourceKey)
         )
       )
     }

--- a/src/components/editor/actions/SaveAndPublishButton.jsx
+++ b/src/components/editor/actions/SaveAndPublishButton.jsx
@@ -18,7 +18,7 @@ import {
   showValidationErrors as showValidationErrorsAction,
   hideValidationErrors as hideValidationErrorsAction,
 } from "actions/errors"
-import { resourceEditErrorKey } from "../Editor"
+import { resourceEditWarningKey } from "../Editor"
 
 const SaveAndPublishButton = (props) => {
   const dispatch = useDispatch()
@@ -32,7 +32,7 @@ const SaveAndPublishButton = (props) => {
         resourceKey,
         resource.group,
         resource.editGroups,
-        resourceEditErrorKey(resourceKey)
+        resourceEditWarningKey(resourceKey)
       )
     )
 


### PR DESCRIPTION
closes #3127

## Why was this change made?
Allow user to fix a recoverable error.


## How was this change tested?
<img width="1513" alt="image" src="https://user-images.githubusercontent.com/588335/137496751-c3e9f709-a0cd-44de-a970-03de09717d43.png">



## Which documentation and/or configurations were updated?



