### PR TITLE
Renames Symphony to Catalog.

### DIFF
--- a/__tests__/feature/editing/transfer.test.js
+++ b/__tests__/feature/editing/transfer.test.js
@@ -34,7 +34,7 @@ describe("transfer saved bf:Instance when user belongs to a transfer group", () 
       selector: "h3",
     })
 
-    const transferBtns = screen.getAllByText("Export to Symphony")
+    const transferBtns = screen.getAllByText("Export to Catalog")
     expect(transferBtns).toHaveLength(2)
 
     fireEvent.click(transferBtns[0])
@@ -49,7 +49,7 @@ describe("transfer unsaved bf:Instance when user belongs to a transfer group", (
 
     await screen.findByText("Uber template1", { selector: "h3" })
 
-    expect(screen.queryByText("Export to Symphony")).not.toBeInTheDocument()
+    expect(screen.queryByText("Export to Catalog")).not.toBeInTheDocument()
   })
 })
 
@@ -71,7 +71,7 @@ describe("transfer saved non-bf:Instance when user belongs to a transfer group",
 
     await screen.findByText("Example Label", { selector: "h3" })
 
-    expect(screen.queryByText("Export to Symphony")).not.toBeInTheDocument()
+    expect(screen.queryByText("Export to Catalog")).not.toBeInTheDocument()
   }, 10000)
 })
 
@@ -95,6 +95,6 @@ describe("transfer saved bf:Instance when user does not belong to a transfer gro
       selector: "h3",
     })
 
-    expect(screen.queryByText("Export to Symphony")).not.toBeInTheDocument()
+    expect(screen.queryByText("Export to Catalog")).not.toBeInTheDocument()
   }, 10000)
 })

--- a/src/Config.js
+++ b/src/Config.js
@@ -138,7 +138,7 @@ class Config {
     return {
       ils: {
         // group: label
-        stanford: "Symphony",
+        stanford: "Catalog",
       },
       // Can add additional transfer targets, e.g., discovery
     }


### PR DESCRIPTION
closes #3130

## Why was this change made?
Will be adding Folio shortly, no "Catalog" is more generic.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?



