### PR TITLE
Provide context for Sinopia lookup results.

### DIFF
--- a/__tests__/utilities/Lookup.test.js
+++ b/__tests__/utilities/Lookup.test.js
@@ -5,8 +5,17 @@ import { findAuthorityConfig } from "utilities/authorityConfig"
 
 describe("getLookupResult()", () => {
   sinopiaSearch.getLookupResult = jest.fn().mockResolvedValue({
-    totalHits: 0,
-    results: [],
+    totalHits: 1,
+    results: [
+      {
+        uri: "http://localhost:3000/resource/d336dee4-65e3-457f-9215-740531104681",
+        label: "Foo",
+        modified: "2021-10-15T21:10:12.615Z",
+        type: ["http://id.loc.gov/ontologies/bibframe/Instance"],
+        group: "other",
+        editGroups: [],
+      },
+    ],
     error: undefined,
   })
   describe("Sinopia lookup", () => {
@@ -14,15 +23,41 @@ describe("getLookupResult()", () => {
       const authorityConfig = findAuthorityConfig(
         "urn:ld4p:sinopia:bibframe:work"
       )
-      const result = await getLookupResult("lebowski", authorityConfig, 10)
+      const result = await getLookupResult("foo", authorityConfig, 10)
       expect(result).toEqual({
-        totalHits: 0,
-        results: [],
+        totalHits: 1,
+        results: [
+          {
+            context: [
+              {
+                property: "ID",
+                values: [
+                  "http://localhost:3000/resource/d336dee4-65e3-457f-9215-740531104681",
+                ],
+              },
+              {
+                property: "Class",
+                values: ["http://id.loc.gov/ontologies/bibframe/Instance"],
+              },
+              {
+                property: "Group",
+                values: ["other"],
+              },
+              {
+                property: "Modified",
+                values: ["2021-10-15T21:10:12.615Z"],
+              },
+            ],
+            id: "http://localhost:3000/resource/d336dee4-65e3-457f-9215-740531104681",
+            label: "Foo",
+            uri: "http://localhost:3000/resource/d336dee4-65e3-457f-9215-740531104681",
+          },
+        ],
         error: undefined,
-        authorityConfig,
+        ...authorityConfig,
       })
       expect(sinopiaSearch.getLookupResult).toHaveBeenCalledWith(
-        "lebowski",
+        "foo",
         authorityConfig,
         { startOfRange: 10 }
       )

--- a/src/utilities/Lookup.js
+++ b/src/utilities/Lookup.js
@@ -9,8 +9,27 @@ export const getLookupResult = (query, authorityConfig, startOfRange) => {
 
 const getSinopiaLookupResult = (query, authorityConfig, options) =>
   getSinopiaSearchLookupResult(query, authorityConfig, options).then(
-    (result) => ({ ...result, authorityConfig })
+    (result) => ({
+      ...authorityConfig,
+      error: result.error,
+      totalHits: result.totalHits,
+      results: adaptResults(result.results),
+    })
   )
+
+// Adapt Sinopia results to QA format
+const adaptResults = (results) =>
+  results.map((result) => ({
+    uri: result.uri,
+    id: result.uri,
+    label: result.label,
+    context: [
+      { property: "ID", values: [result.uri] },
+      { property: "Class", values: result.type },
+      { property: "Group", values: [result.group] },
+      { property: "Modified", values: [result.modified] },
+    ],
+  }))
 
 const getQALookupResult = (query, authorityConfig, options) =>
   createLookupPromise(query, authorityConfig, options).then((response) => {


### PR DESCRIPTION
closes #2769

## Why was this change made?
Slight more useful lookup results.


## How was this change tested?
Unit
![image](https://user-images.githubusercontent.com/588335/137557446-8150f1ae-d6ef-4fe0-a911-350f776b8b7a.png)



## Which documentation and/or configurations were updated?



