### PR TITLE
show full group names in preview header

### DIFF
--- a/__tests__/components/editor/preview/ResourcePreviewHeader.test.js
+++ b/__tests__/components/editor/preview/ResourcePreviewHeader.test.js
@@ -21,7 +21,9 @@ describe("<ResourcePreviewHeader />", () => {
       </Provider>
     )
     expect(header.getByText("Abbreviated Title")).toBeTruthy // label is shown
-    expect(header.getByText("cornell, stanford")).toBeTruthy // editable groups are shown
+    expect(header.getByText("Stanford University")).toBeTruthy // owner is shown with full group name
+    expect(header.getByText("Cornell University,")).toBeTruthy // editable groups are shown with full group name
+    expect(header.getByTestId("expand-groups-button")).toBeTruthy // expand button is shown (since there are more groups than can be shown)
     expect(header.getByText(/(https:\/\/api.sinopia.io\/resource\/0894a8b3)/))
       .toBeTruthy // URI is shown
   })

--- a/src/components/editor/preview/ResourcePreviewHeader.jsx
+++ b/src/components/editor/preview/ResourcePreviewHeader.jsx
@@ -1,11 +1,17 @@
 // Copyright 2021 Stanford University see LICENSE for license
 
 import React, { useState } from "react"
+import { useSelector } from "react-redux"
 import PropTypes from "prop-types"
 import ResourceURIMessage from "../ResourceURIMessage"
+import { selectGroupMap } from "selectors/groups"
 
 const ResourcePreviewHeader = ({ resource }) => {
-  const editableBy = [...resource.editGroups, resource.group].join(", ") // the creator can also edit!
+  const groupMap = useSelector((state) => selectGroupMap(state))
+  const editableBy = [...resource.editGroups, resource.group] // the creator can also edit!
+    .map((group) => groupMap[group]) // look up the group name from the ID
+    .filter((group) => group) // ditch any undefined group (an unmatched groupID for whatever reason)
+    .join(", ")
   const maxGroupDisplay = 20
   const shouldTruncate = editableBy.length > maxGroupDisplay
   const [isCollapsed, setIsCollapsed] = useState(shouldTruncate)
@@ -29,12 +35,16 @@ const ResourcePreviewHeader = ({ resource }) => {
         </div>
         <div className="col-2">
           <strong>Owned by</strong>
-          <p>{resource.group}</p>
+          <p>{groupMap[resource.group] || "Unknown"}</p>
           <strong>Editable by</strong>
           <p>
             {editableByText}
             {isCollapsed && (
-              <button className="p-0 btn btn-link" onClick={handleClick}>
+              <button
+                data-testid="expand-groups-button"
+                className="p-0 btn btn-link"
+                onClick={handleClick}
+              >
                 ...
               </button>
             )}


### PR DESCRIPTION
## Why was this change made?

Fixes #3194 - show full group names, not IDs, in preview header

![Screen Shot 2021-10-15 at 2 54 34 PM](https://user-images.githubusercontent.com/47137/137557686-71b41f88-60e0-4374-a999-46000dfd209d.png)


## How was this change tested?

Localhost, and updated unit test


## Which documentation and/or configurations were updated?



