### PR TITLE
Get uri in PropertyComponent instead of entire property to reduce rerenders

### DIFF
--- a/src/components/editor/property/PropertyComponent.jsx
+++ b/src/components/editor/property/PropertyComponent.jsx
@@ -8,20 +8,18 @@ import NestedResource from "./NestedResource"
 import ReadOnlyInputLiteralOrURI from "../inputs/ReadOnlyInputLiteralOrURI"
 import Alert from "../../Alert"
 import { displayResourceValidations } from "selectors/errors"
-import { selectNormSubject } from "selectors/resources"
+import { selectUri } from "selectors/resources"
 
 // Decides how to render this property.
 const PropertyComponent = ({ property, propertyTemplate, readOnly }) => {
-  const resource = useSelector((state) =>
-    selectNormSubject(state, property.rootSubjectKey)
-  )
+  const uri = useSelector((state) => selectUri(state, property.rootSubjectKey))
 
   const displayValidations = useSelector((state) =>
     displayResourceValidations(state, property.rootSubjectKey)
   )
 
   // Immutable properties cannot be changed once saved.
-  const immutable = propertyTemplate.immutable && resource.uri
+  const immutable = propertyTemplate.immutable && uri
 
   // Might be tempted to use lazy / suspense here, but it forces a remounting of components.
   switch (propertyTemplate.component) {


### PR DESCRIPTION

refs #3045

## Why was this change made?
Speedier app


## How was this change tested?



## Which documentation and/or configurations were updated?



