### PR TITLE
Fix handling of template lookup results.

### DIFF
--- a/__tests__/sinopiaSearch.test.js
+++ b/__tests__/sinopiaSearch.test.js
@@ -518,6 +518,12 @@ describe("getLookupResult", () => {
             label:
               "Cartographic Item (BIBFRAME) (ld4p:RT:bf2:Cartographic:Item)",
             uri: "ld4p:RT:bf2:Cartographic:Item",
+            author: "LD4P",
+            date: "2019-08-19",
+            id: "ld4p:RT:bf2:Cartographic:Item",
+            remark: "based on LC template ld4p:RT:bf2:Cartographic:Item",
+            resourceLabel: "Cartographic Item (BIBFRAME)",
+            resourceURI: "http://id.loc.gov/ontologies/bibframe/Item",
           },
         ],
       })

--- a/__tests__/utilities/Lookup.test.js
+++ b/__tests__/utilities/Lookup.test.js
@@ -4,21 +4,21 @@ import * as qaSearch from "utilities/QuestioningAuthority"
 import { findAuthorityConfig } from "utilities/authorityConfig"
 
 describe("getLookupResult()", () => {
-  sinopiaSearch.getLookupResult = jest.fn().mockResolvedValue({
-    totalHits: 1,
-    results: [
-      {
-        uri: "http://localhost:3000/resource/d336dee4-65e3-457f-9215-740531104681",
-        label: "Foo",
-        modified: "2021-10-15T21:10:12.615Z",
-        type: ["http://id.loc.gov/ontologies/bibframe/Instance"],
-        group: "other",
-        editGroups: [],
-      },
-    ],
-    error: undefined,
-  })
   describe("Sinopia lookup", () => {
+    sinopiaSearch.getLookupResult = jest.fn().mockResolvedValue({
+      totalHits: 1,
+      results: [
+        {
+          uri: "http://localhost:3000/resource/d336dee4-65e3-457f-9215-740531104681",
+          label: "Foo",
+          modified: "2021-10-15T21:10:12.615Z",
+          type: ["http://id.loc.gov/ontologies/bibframe/Instance"],
+          group: "other",
+          editGroups: [],
+        },
+      ],
+      error: undefined,
+    })
     it("returns result", async () => {
       const authorityConfig = findAuthorityConfig(
         "urn:ld4p:sinopia:bibframe:work"
@@ -51,6 +51,66 @@ describe("getLookupResult()", () => {
             id: "http://localhost:3000/resource/d336dee4-65e3-457f-9215-740531104681",
             label: "Foo",
             uri: "http://localhost:3000/resource/d336dee4-65e3-457f-9215-740531104681",
+          },
+        ],
+        error: undefined,
+        ...authorityConfig,
+      })
+      expect(sinopiaSearch.getLookupResult).toHaveBeenCalledWith(
+        "foo",
+        authorityConfig,
+        { startOfRange: 10 }
+      )
+    })
+  })
+
+  describe("Sinopia template lookup", () => {
+    sinopiaSearch.getLookupResult = jest.fn().mockResolvedValue({
+      totalHits: 1,
+      results: [
+        {
+          id: "foo:bar2",
+          uri: "http://localhost:3000/resource/foo:bar2",
+          author: "Justin7",
+          resourceLabel: "Foo Bar",
+          resourceURI: "http://foo/bar",
+          group: "stanford",
+          editGroups: [],
+          groupLabel: "Stanford",
+        },
+      ],
+      error: undefined,
+    })
+    it.only("returns result", async () => {
+      const authorityConfig = findAuthorityConfig(
+        "urn:ld4p:sinopia:resourceTemplate"
+      )
+      const result = await getLookupResult("foo", authorityConfig, 10)
+      expect(result).toEqual({
+        totalHits: 1,
+        results: [
+          {
+            context: [
+              {
+                property: "ID",
+                values: ["http://localhost:3000/resource/foo:bar2"],
+              },
+              {
+                property: "Group",
+                values: ["stanford"],
+              },
+              {
+                property: "Resource URI",
+                values: ["http://foo/bar"],
+              },
+              {
+                property: "Author",
+                values: ["Justin7"],
+              },
+            ],
+            id: "http://localhost:3000/resource/foo:bar2",
+            label: "Foo Bar",
+            uri: "http://localhost:3000/resource/foo:bar2",
           },
         ],
         error: undefined,

--- a/src/sinopiaSearch.js
+++ b/src/sinopiaSearch.js
@@ -290,8 +290,9 @@ const templateHitsToResult = (hits) => ({
 const templateLookupToResult = (hits) => ({
   totalHits: hits.total.value,
   results: hits.hits.map((row) => ({
-    uri: row._source.id,
+    ...row._source,
     label: `${row._source.resourceLabel} (${row._source.id})`,
+    uri: row._source.id,
   })),
 })
 

--- a/src/utilities/Lookup.js
+++ b/src/utilities/Lookup.js
@@ -13,23 +13,36 @@ const getSinopiaLookupResult = (query, authorityConfig, options) =>
       ...authorityConfig,
       error: result.error,
       totalHits: result.totalHits,
-      results: adaptResults(result.results),
+      results: adaptSinopiaResults(result.results),
     })
   )
 
 // Adapt Sinopia results to QA format
-const adaptResults = (results) =>
+const adaptSinopiaResults = (results) =>
   results.map((result) => ({
     uri: result.uri,
     id: result.uri,
-    label: result.label,
-    context: [
-      { property: "ID", values: [result.uri] },
-      { property: "Class", values: result.type },
-      { property: "Group", values: [result.group] },
-      { property: "Modified", values: [result.modified] },
-    ],
+    label: result.label || result.resourceLabel,
+    context: sinopiaContext(result),
   }))
+
+const sinopiaContext = (result) => {
+  const context = [
+    { property: "ID", values: [result.uri] },
+    { property: "Group", values: [result.group] },
+  ]
+  if (result.type) context.push({ property: "Class", values: result.type })
+  if (result.modified)
+    context.push({ property: "Modified", values: [result.modified] })
+  if (result.resourceURI)
+    context.push({ property: "Resource URI", values: [result.resourceURI] })
+  if (result.author)
+    context.push({ property: "Author", values: [result.author] })
+  if (result.date) context.push({ property: "Date", values: [result.date] })
+  if (result.remark)
+    context.push({ property: "Remark", values: [result.remark] })
+  return context
+}
 
 const getQALookupResult = (query, authorityConfig, options) =>
   createLookupPromise(query, authorityConfig, options).then((response) => {


### PR DESCRIPTION
closes #3222

## Why was this change made?
Allow users to create templates without error.


## How was this change tested?
Unit, local


## Which documentation and/or configurations were updated?



