### PR TITLE
Align the search utility with the navigation links

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -65,56 +65,54 @@ const Header = (props) => {
         </div>
       </div>
       <nav className="navbar navbar-expand-lg editor-navtabs">
-        <div className="container-fluid pe-0">
-          <ul className="navbar-nav">
-            {/* Navlinks enable highlighting the appropriate tab based on route, active style is defined in css */}
+        <ul className="navbar-nav">
+          {/* Navlinks enable highlighting the appropriate tab based on route, active style is defined in css */}
+          <li className="nav-item">
+            <NavLink className="nav-link" to="/dashboard">
+              Dashboard
+            </NavLink>
+          </li>
+          {props.hasResource && canCreate && (
             <li className="nav-item">
-              <NavLink className="nav-link" to="/dashboard">
-                Dashboard
+              <NavLink className="nav-link" to="/editor">
+                Editor
               </NavLink>
             </li>
-            {props.hasResource && canCreate && (
-              <li className="nav-item">
-                <NavLink className="nav-link" to="/editor">
-                  Editor
-                </NavLink>
-              </li>
-            )}
-            <li className="nav-item">
-              <NavLink className="nav-link" to="/templates">
-                Resource Templates
-              </NavLink>
-            </li>
-            <li className="nav-item dropdown">
-              <a
-                className={`nav-link dropdown-toggle ${
-                  isActionsActive && "active"
-                }`}
-                data-bs-toggle="dropdown"
-                href="#"
-                role="button"
-                aria-expanded="false"
-              >
-                Actions
-              </a>
-              <ul className="dropdown-menu">
-                {canCreate && (
-                  <li>
-                    <NavLink className="dropdown-item" to="/load">
-                      Load RDF
-                    </NavLink>
-                  </li>
-                )}
+          )}
+          <li className="nav-item">
+            <NavLink className="nav-link" to="/templates">
+              Resource Templates
+            </NavLink>
+          </li>
+          <li className="nav-item dropdown">
+            <a
+              className={`nav-link dropdown-toggle ${
+                isActionsActive && "active"
+              }`}
+              data-bs-toggle="dropdown"
+              href="#"
+              role="button"
+              aria-expanded="false"
+            >
+              Actions
+            </a>
+            <ul className="dropdown-menu">
+              {canCreate && (
                 <li>
-                  <NavLink className="dropdown-item" to="/exports">
-                    Exports
+                  <NavLink className="dropdown-item" to="/load">
+                    Load RDF
                   </NavLink>
                 </li>
-              </ul>
-            </li>
-          </ul>
-          <HeaderSearch />
-        </div>
+              )}
+              <li>
+                <NavLink className="dropdown-item" to="/exports">
+                  Exports
+                </NavLink>
+              </li>
+            </ul>
+          </li>
+        </ul>
+        <HeaderSearch />
       </nav>
     </React.Fragment>
   )

--- a/src/components/search/HeaderSearch.jsx
+++ b/src/components/search/HeaderSearch.jsx
@@ -65,9 +65,9 @@ const HeaderSearch = () => {
   }
 
   return (
-    <div className="d-flex">
-      <div className="input-group mb-3">
-        <label htmlFor="search" className="col-form-label pe-1">
+    <div className="flex-grow-1">
+      <div className="input-group mb-2">
+        <label htmlFor="search" className="col-form-label pe-1 ms-5">
           Search
         </label>
         <a
@@ -81,7 +81,7 @@ const HeaderSearch = () => {
           <FontAwesomeIcon className="info-icon" icon={faInfoCircle} />
         </a>
         <select
-          className="form-select"
+          className="flex-grow-0 form-select"
           id="searchType"
           value={uri}
           onChange={handleUriChange}
@@ -91,7 +91,7 @@ const HeaderSearch = () => {
           {options}
         </select>
         <input
-          className="form-control"
+          className="flex-grow-1 form-control"
           type="search"
           id="search"
           onChange={handleQueryChange}

--- a/src/styles/header.scss
+++ b/src/styles/header.scss
@@ -30,7 +30,7 @@
     font-weight: 500;
   }
 
-  #search {
-    width: 500px;
+  #searchType {
+    width: 8rem;
   }
 }


### PR DESCRIPTION
and avoid awkward splits

## Why was this change made?



## How was this change tested?


<img width="1007" alt="Screen Shot 2021-10-25 at 3 17 29 PM" src="https://user-images.githubusercontent.com/92044/138764590-33d92ab6-a79f-48dc-aad8-c99e4ad0cb67.png">

## Which documentation and/or configurations were updated?



