### PR TITLE
do not truncate text unless there is at least one edit group

### DIFF
--- a/__tests__/components/editor/preview/ResourcePreviewHeader.test.js
+++ b/__tests__/components/editor/preview/ResourcePreviewHeader.test.js
@@ -22,8 +22,8 @@ describe("<ResourcePreviewHeader />", () => {
     )
     expect(header.getByText("Abbreviated Title")).toBeTruthy // label is shown
     expect(header.getByText("Stanford University")).toBeTruthy // owner is shown with full group name
-    expect(header.getByText("Cornell University,")).toBeTruthy // editable groups are shown with full group name
-    expect(header.getByTestId("expand-groups-button")).toBeTruthy // expand button is shown (since there are more groups than can be shown)
+    expect(header.getByText("Cornell University")).toBeTruthy // editable groups are shown with full group name
+    expect(header.queryByTestId("expand-groups-button")).not.toBeInTheDocument // expand button is not shown (since there is only edit group to be shown)
     expect(header.getByText(/(https:\/\/api.sinopia.io\/resource\/0894a8b3)/))
       .toBeTruthy // URI is shown
   })

--- a/src/components/editor/preview/ResourcePreviewHeader.jsx
+++ b/src/components/editor/preview/ResourcePreviewHeader.jsx
@@ -8,14 +8,14 @@ import { selectGroupMap } from "selectors/groups"
 
 const ResourcePreviewHeader = ({ resource }) => {
   const groupMap = useSelector((state) => selectGroupMap(state))
-  const editableBy = [...resource.editGroups, resource.group] // the creator can also edit!
+  const editableBy = resource.editGroups
     .map((group) => groupMap[group]) // look up the group name from the ID
     .filter((group) => group) // ditch any undefined group (an unmatched groupID for whatever reason)
     .join(", ")
   const maxGroupDisplay = 20
-  // truncate the display and show elippses if we have at least one edit group (in addition to the owner) and it's too long
+  // truncate the display and show ellipses if we have more than one edit group and all of them are too long
   const shouldTruncate =
-    editableBy.length > maxGroupDisplay && resource.editGroups.length >= 1
+    editableBy.length > maxGroupDisplay && resource.editGroups.length > 1
   const [isCollapsed, setIsCollapsed] = useState(shouldTruncate)
   const editableByText = isCollapsed
     ? editableBy.slice(0, maxGroupDisplay - 1)
@@ -36,21 +36,25 @@ const ResourcePreviewHeader = ({ resource }) => {
           <ResourceURIMessage resourceKey={resource.key} />
         </div>
         <div className="col-2">
-          <strong>Owned by</strong>
+          <strong>Owned/editable by</strong>
           <p>{groupMap[resource.group] || "Unknown"}</p>
-          <strong>Editable by</strong>
-          <p>
-            {editableByText}
-            {isCollapsed && (
-              <button
-                data-testid="expand-groups-button"
-                className="p-0 btn btn-link"
-                onClick={handleClick}
-              >
-                ...
-              </button>
-            )}
-          </p>
+          {resource.editGroups.length > 0 && (
+            <>
+              <strong>Also editable by</strong>
+              <p>
+                {editableByText}
+                {isCollapsed && (
+                  <button
+                    data-testid="expand-groups-button"
+                    className="p-0 btn btn-link"
+                    onClick={handleClick}
+                  >
+                    ...
+                  </button>
+                )}
+              </p>
+            </>
+          )}
         </div>
       </div>
     </React.Fragment>


### PR DESCRIPTION
## Why was this change made?

Fixes #3228 

- Change the label "Owned by" to "Owned/Editable by"
- Change the label "Editable by" to "Also editable by"
- Remove the owner group from the list of groups under the "Also editable by" label
- Only truncate the text if there is more than one group in the "Also editable by"
- Don't show the "Also editable by" section at all unless there is at least one group there. 

(note: this also makes it so the owner group name is not repeated 100% of the time like it is now).

**Screen shots:**

No additional editing groups:

![Screen Shot 2021-10-25 at 3 16 52 PM](https://user-images.githubusercontent.com/47137/138778629-a71c66c6-78f2-4fd2-adb3-79265943763c.png)

One additional editing group (no truncation because even though the editing group name is long, there is only one):

![Screen Shot 2021-10-25 at 3 17 21 PM](https://user-images.githubusercontent.com/47137/138778672-85f4234d-b4a3-4ec4-8c7e-474cbcb09e52.png)

Multiple additional editing groups (no truncation since names are short):

![Screen Shot 2021-10-25 at 3 19 43 PM](https://user-images.githubusercontent.com/47137/138778878-cc4e999c-17de-4d5a-81f6-ddffe70b3bcc.png)

Multiple additional editing groups (truncation since the names are long):

![Screen Shot 2021-10-25 at 3 16 45 PM](https://user-images.githubusercontent.com/47137/138778711-e869d1af-b781-41fb-a5ba-d8478188d9bc.png)

and expanded:

![Screen Shot 2021-10-25 at 3 16 48 PM](https://user-images.githubusercontent.com/47137/138778752-4aa45c8c-9412-4b37-8cb2-fdc3fe2fa219.png)


## How was this change tested?

Localhost 


## Which documentation and/or configurations were updated?



