### PR TITLE
remove fixed width username/password input; do not wrap password label

### DIFF
--- a/src/components/home/LoginPanel.jsx
+++ b/src/components/home/LoginPanel.jsx
@@ -42,7 +42,6 @@ const LoginPanel = () => {
           <div className="col-sm-9">
             <input
               id="username"
-              style={{ width: "300px" }}
               name="username"
               type="text"
               className="form-control"
@@ -53,14 +52,17 @@ const LoginPanel = () => {
           </div>
         </div>
         <div className="row">
-          <label htmlFor="password" className="col-sm-3 col-form-label">
+          <label
+            htmlFor="password"
+            style={{ "word-wrap": "normal" }}
+            className="col-sm-3 col-form-label"
+          >
             Password
           </label>
 
           <div className="col-sm-9">
             <input
               id="password"
-              style={{ width: "300px" }}
               name="password"
               type="password"
               className="form-control"
@@ -76,7 +78,7 @@ const LoginPanel = () => {
               Login
             </button>
           </div>
-          <div className="col-sm-4">
+          <div className="col-sm-9">
             <div className="row">
               <a href={Config.awsCognitoForgotPasswordUrl}>Forgot Password</a>
             </div>


### PR DESCRIPTION
## Why was this change made?

Fixes #3193

(1) remove the fixed 300 pixel setting on the username/password fields so the fields will just take up the normal width of the panel and shrink gracefully when the window gets narrower
(2) override the default word-wrap setting for the password label so that it doesn't split mid word
(3) (not mentioned in the original ticket, but noticed when editing): expand column size for "Forgot Password" / "Request Account" links so they don't wrap unnecessarily when the window gets narrowed

"Normal" size:

![Screen Shot 2021-10-25 at 2 12 33 PM](https://user-images.githubusercontent.com/47137/138771714-f79300ca-c24f-4834-b4a3-d173e29a7409.png)

Narrow size:

![Screen Shot 2021-10-25 at 2 15 15 PM](https://user-images.githubusercontent.com/47137/138772174-0504b770-1e0b-4f0d-aaf7-b964534c0586.png)

Even narrower size:

![Screen Shot 2021-10-25 at 2 12 09 PM](https://user-images.githubusercontent.com/47137/138771785-dc58f086-b3e1-48eb-a4b3-8961c3b86129.png)


## How was this change tested?

Localhost


## Which documentation and/or configurations were updated?



