### PR TITLE
create links from any URLs in remarks

### DIFF
--- a/__tests__/__action_fixtures__/addSiblingValueSubject-ADD_VALUE.json
+++ b/__tests__/__action_fixtures__/addSiblingValueSubject-ADD_VALUE.json
@@ -53,7 +53,7 @@
               "id": "resourceTemplate:testing:uber2",
               "class": "http://id.loc.gov/ontologies/bibframe/Uber2",
               "label": "Uber template2",
-              "remark": "Template for testing purposes with single repeatable literal.",
+              "remark": "Template for testing purposes with single repeatable literal with a link to Stanford at https://www.stanford.edu",
               "group": "stanford",
               "editGroups": ["cornell"],
               "propertyTemplateKeys": [

--- a/__tests__/components/editor/property/PropertyLabelInfoTooltip.test.js
+++ b/__tests__/components/editor/property/PropertyLabelInfoTooltip.test.js
@@ -1,0 +1,47 @@
+// Copyright 2021 Stanford University see LICENSE for license
+
+import React from "react"
+import { render } from "@testing-library/react"
+import { createState } from "stateUtils"
+import { selectSubjectAndPropertyTemplates } from "selectors/templates"
+import configureMockStore from "redux-mock-store"
+import PropertyLabelInfoTooltip from "components/editor/property/PropertyLabelInfoTooltip"
+import { Provider } from "react-redux"
+
+const mockStore = configureMockStore()
+
+describe("<PropertyLabelInfoTooltip />", () => {
+  it("displays remark without link", () => {
+    const state = createState({ hasResourceWithNestedResource: true })
+    const store = mockStore(state)
+    const propertyTemplate = selectSubjectAndPropertyTemplates(
+      state,
+      "resourceTemplate:testing:uber1"
+    )
+    const tooltip = render(
+      <Provider store={store}>
+        <PropertyLabelInfoTooltip propertyTemplate={propertyTemplate} />
+      </Provider>
+    )
+    expect(tooltip.getByRole("link").getAttribute("data-bs-content")).toBe(
+      "Template for testing purposes."
+    )
+  })
+
+  it("displays remark with a URL that is auto linked", () => {
+    const state = createState({ hasResourceWithNestedResource: true })
+    const store = mockStore(state)
+    const propertyTemplate = selectSubjectAndPropertyTemplates(
+      state,
+      "resourceTemplate:testing:uber2"
+    )
+    const tooltip = render(
+      <Provider store={store}>
+        <PropertyLabelInfoTooltip propertyTemplate={propertyTemplate} />
+      </Provider>
+    )
+    expect(tooltip.getByRole("link").getAttribute("data-bs-content")).toBe(
+      'Template for testing purposes with single repeatable literal with a link to Stanford at <a target="_blank" href="https://www.stanford.edu">https://www.stanford.edu</a>'
+    )
+  })
+})

--- a/__tests__/testUtilities/stateUtils.js
+++ b/__tests__/testUtilities/stateUtils.js
@@ -875,7 +875,8 @@ const buildResourceWithNestedResource = (state, options) => {
       id: "resourceTemplate:testing:uber2",
       class: "http://id.loc.gov/ontologies/bibframe/Uber2",
       label: "Uber template2",
-      remark: "Template for testing purposes with single repeatable literal.",
+      remark:
+        "Template for testing purposes with single repeatable literal with a link to Stanford at https://www.stanford.edu",
       group: "stanford",
       editGroups: ["cornell"],
       propertyTemplateKeys: [

--- a/cypress/fixtures/uber_template1.txt
+++ b/cypress/fixtures/uber_template1.txt
@@ -1097,7 +1097,7 @@
     ],
     "http://sinopia.io/vocabulary/hasRemark": [
       {
-        "@value": "Multiple nested, non-repeatable resource templates with a link: https://www.stanford.edu"
+        "@value": "Multiple nested, non-repeatable resource templates."
       }
     ],
     "http://sinopia.io/vocabulary/hasPropertyUri": [


### PR DESCRIPTION
## Why was this change made?

Fixes #3219 - convert URLs in remarks into href links

Note: my implementation of this feature makes the links open in a new window (target=_blank). This makes sense to me or else it will replace the editor window content. 

## How was this change tested?

localhost


## Which documentation and/or configurations were updated?



