### PR TITLE
Avoid wrapping buttons on small viewports

### DIFF
--- a/src/components/editor/leftNav/ActivePanelPropertyNav.jsx
+++ b/src/components/editor/leftNav/ActivePanelPropertyNav.jsx
@@ -11,6 +11,7 @@ import useLeftNav from "hooks/useLeftNav"
 import _ from "lodash"
 import useNavLink from "hooks/useNavLink"
 
+// This draws a link for the left side navbar
 const ActivePanelPropertyNav = (props) => {
   const property = useSelector((state) =>
     selectNormProperty(state, props.propertyKey)
@@ -51,7 +52,7 @@ const ActivePanelPropertyNav = (props) => {
     subNavForProperty = <ul>{subNavItems}</ul>
   }
 
-  const buttonClasses = ["btn", "d-inline-flex", "property-nav"]
+  const buttonClasses = ["d-inline-flex", "property-nav"]
   if (isCurrentProperty) buttonClasses.push("current")
 
   const toggleLabel = isExpanded

--- a/src/components/editor/leftNav/PanelResourceNav.jsx
+++ b/src/components/editor/leftNav/PanelResourceNav.jsx
@@ -20,7 +20,7 @@ const PanelResourceNav = (props) => {
     />
   ))
   return (
-    <div className="col-sm-4 left-nav">
+    <div className="col-md-5 col-lg-4 col-xl-3 left-nav">
       <div className={classNames.join(" ")} data-testid={classNames[1]}>
         <ul>{navItems}</ul>
       </div>

--- a/src/components/editor/property/PanelResource.jsx
+++ b/src/components/editor/property/PanelResource.jsx
@@ -7,7 +7,7 @@ import PanelResourceNav from "components/editor/leftNav/PanelResourceNav"
 
 // Top-level resource
 const PanelResource = ({ resource, readOnly = false }) => {
-  const resourceDivClass = readOnly ? "col-sm-12" : "col-sm-8"
+  const resourceDivClass = readOnly ? "col-md-12" : "col-md-7 col-lg-8 col-xl-9"
   const isTemplate = resource.subjectTemplateKey === "sinopia:template:resource"
 
   return (

--- a/src/styles/resourceNav.scss
+++ b/src/styles/resourceNav.scss
@@ -27,19 +27,18 @@
       margin-right: 0.4em;
     }
 
-    .btn {
-      color: $link-color;
-      h5 {
-        font-weight: bold;
-      }
-    }
-
     .current {
       color: $body-color;
     }
 
     .property-nav {
+      @extend .btn;
+      color: $link-color;
       padding: 0.25rem 0.25rem 0.25rem 0.25rem;
+      text-align: left;
+      h5 {
+        font-weight: bold;
+      }
     }
 
     .fa-circle {


### PR DESCRIPTION

## Why was this change made?
Then align them left.

Fixes #3195


## How was this change tested?

<img width="1005" alt="Screen Shot 2021-10-26 at 2 31 36 PM" src="https://user-images.githubusercontent.com/92044/138948273-f8b32cc1-1d07-48d5-a63e-e63502f28e79.png">

## Which documentation and/or configurations were updated?




