### PR TITLE
fix style warning

### DIFF
--- a/src/components/home/LoginPanel.jsx
+++ b/src/components/home/LoginPanel.jsx
@@ -54,7 +54,7 @@ const LoginPanel = () => {
         <div className="row">
           <label
             htmlFor="password"
-            style={{ "word-wrap": "normal" }}
+            style={{ wordWrap: "normal" }}
             className="col-sm-3 col-form-label"
           >
             Password


### PR DESCRIPTION
## Why was this change made?

Why yes, I did mean "wordWrap".

Gets rid of this:

![image](https://user-images.githubusercontent.com/47137/138952598-594832c2-cb56-48df-8001-5c3b86b9e8a8.png)


## How was this change tested?



## Which documentation and/or configurations were updated?



