### PR TITLE
Use the title property for a remarkUrl

### DIFF
--- a/src/components/editor/property/PropertyLabelInfoLink.jsx
+++ b/src/components/editor/property/PropertyLabelInfoLink.jsx
@@ -12,7 +12,7 @@ const PropertyLabelInfoLink = (props) => {
     <a
       href={url}
       className="prop-remark"
-      alt={props.propertyTemplate.remarkUrl}
+      title={props.propertyTemplate.remarkUrl}
       target="_blank"
       rel="noopener noreferrer"
     >


### PR DESCRIPTION
## Why was this change made?
The alt property is not a property of the anchor tag. See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#properties

Ref #3240

## How was this change tested?



## Which documentation and/or configurations were updated?



