### PR TITLE
npm install removes react-time-ago

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,6 @@
         "react-redux": "^7.2.5",
         "react-router-dom": "^5.3.0",
         "react-textarea-autosize": "^8.3.3",
-        "react-time-ago": "^7.1.3",
         "redux": "^4.1.1",
         "redux-thunk": "^2.3.0",
         "reselect": "^4.0.0",
@@ -18964,14 +18963,6 @@
         }
       ]
     },
-    "node_modules/raf": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
-      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
-      "dependencies": {
-        "performance-now": "^2.1.0"
-      }
-    },
     "node_modules/ramda": {
       "version": "0.27.1",
       "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.1.tgz",
@@ -19549,20 +19540,6 @@
         "@types/react": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-time-ago": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/react-time-ago/-/react-time-ago-7.1.3.tgz",
-      "integrity": "sha512-H+mhWft++gNt2x8Y9eAZ9vYwL6giPDnVIo68Ty7xFTJ2L+Tt7cyZ1sbMkTMKzHeeaQ+J8F2vt3PatdW6mFJmWQ==",
-      "dependencies": {
-        "prop-types": "^15.7.2",
-        "raf": "^3.4.1"
-      },
-      "peerDependencies": {
-        "javascript-time-ago": "^2.3.7",
-        "react": ">=0.16.8",
-        "react-dom": ">=0.16.8"
       }
     },
     "node_modules/readable-stream": {
@@ -38033,14 +38010,6 @@
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
     },
-    "raf": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
-      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
-      "requires": {
-        "performance-now": "^2.1.0"
-      }
-    },
     "ramda": {
       "version": "0.27.1",
       "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.1.tgz",
@@ -38492,15 +38461,6 @@
             }
           }
         }
-      }
-    },
-    "react-time-ago": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/react-time-ago/-/react-time-ago-7.1.3.tgz",
-      "integrity": "sha512-H+mhWft++gNt2x8Y9eAZ9vYwL6giPDnVIo68Ty7xFTJ2L+Tt7cyZ1sbMkTMKzHeeaQ+J8F2vt3PatdW6mFJmWQ==",
-      "requires": {
-        "prop-types": "^15.7.2",
-        "raf": "^3.4.1"
       }
     },
     "readable-stream": {


### PR DESCRIPTION
## Why was this change made?

I just pulled main and did `npm install` and `react-time-ago` was removed from `package.json` and `package-lock.json`.

Implication:  someone removed `react-time-ago` and forgot to npm install for the git commit: Possibly from PR #3232 when `javascript-time-ago` was introduced?

## How was this change tested?

test code, running it locally

## Which documentation and/or configurations were updated?



