### PR TITLE
Show the remarkUrlLabel as the title for the property label info link

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ The following are only in the resource subject (that is, the base subject).
   defaults: [{literal: <literal>, lang: <lang>}, {uri: <uri>, label: <label>},...]
   remark: <remark>,
   remarkUrl: <remark url, e.g., "http://access.rdatoolkit.org/2.13.html">
+  remarkUrlLabel: <a descriptive label about the remark url, e.g., "Title Proper">
   type: <resource | uri | literal>,
   component: <InputLookup | InputLookupQA | InputList | InputLiteral | InputURI>,
   valueSubjectTemplateKeys: [<subject template keys>]

--- a/__tests__/TemplatesBuilder.test.js
+++ b/__tests__/TemplatesBuilder.test.js
@@ -56,7 +56,8 @@ _:b1_c14n0 <http://sinopia.io/vocabulary/hasRemark> "A repeatable literal."@eng 
 _:b1_c14n0 <http://sinopia.io/vocabulary/hasRemarkUrl> <http://access.rdatoolkit.org/2.4.2.html> .
 _:b1_c14n0 <http://sinopia.io/vocabulary/hasPropertyUri> <http://id.loc.gov/ontologies/bibframe/uber/template1/property1> .
 _:b1_c14n0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://sinopia.io/vocabulary/PropertyTemplate> .
-_:b1_c14n0 <http://www.w3.org/2000/01/rdf-schema#label> "Uber template1, property2"@eng .`
+_:b1_c14n0 <http://www.w3.org/2000/01/rdf-schema#label> "Uber template1, property2"@eng .
+<http://access.rdatoolkit.org/2.4.2.html> <http://www.w3.org/2000/01/rdf-schema#label> "Note on Manifestation"@eng .`
     const dataset = await datasetFromN3(rdf)
     const subjectTemplate = new TemplatesBuilder(dataset, "").build()
     expect(subjectTemplate.propertyTemplates[0]).toStrictEqual({
@@ -70,6 +71,7 @@ _:b1_c14n0 <http://www.w3.org/2000/01/rdf-schema#label> "Uber template1, propert
       immutable: true,
       remark: "A repeatable literal.",
       remarkUrl: "http://access.rdatoolkit.org/2.4.2.html",
+      remarkUrlLabel: "Note on Manifestation",
       defaults: [],
       valueSubjectTemplateKeys: [],
       authorities: [],
@@ -109,6 +111,7 @@ _:b2_c14n1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://sinopia.io/
       immutable: false,
       remark: null,
       remarkUrl: null,
+      remarkUrlLabel: null,
       defaults: [
         { literal: "default1", lang: "eng" },
         { literal: "default2", lang: null },
@@ -156,6 +159,7 @@ _:b3_c14n3 <http://www.w3.org/2000/01/rdf-schema#label> "Uber template1, propert
       immutable: false,
       remark: null,
       remarkUrl: null,
+      remarkUrlLabel: null,
       defaults: [
         { uri: "http://sinopia.io/uri1", label: "Test uri1" },
         { uri: "http://sinopia.io/uri2", label: null },
@@ -198,6 +202,7 @@ _:b4_c14n1 <http://www.w3.org/2000/01/rdf-schema#label> "Uber template1, propert
       immutable: false,
       remark: null,
       remarkUrl: null,
+      remarkUrlLabel: null,
       defaults: [],
       valueSubjectTemplateKeys: [
         "resourceTemplate:testing:uber2",
@@ -248,6 +253,7 @@ _:b5_c14n2 <http://www.w3.org/2000/01/rdf-schema#label> "URI1"@eng .`
       immutable: false,
       remark: null,
       remarkUrl: null,
+      remarkUrlLabel: null,
       defaults: [{ uri: "http://sinopia.io/uri1", label: "URI1" }],
       valueSubjectTemplateKeys: [],
       authorities: [

--- a/__tests__/__action_fixtures__/expandProperty-ADD_VALUE.json
+++ b/__tests__/__action_fixtures__/expandProperty-ADD_VALUE.json
@@ -107,6 +107,7 @@
               "ordered": false,
               "immutable": false,
               "remark": "A repeatable literal",
+              "remarkUrlLabel": null,
               "remarkUrl": null,
               "defaults": [],
               "valueSubjectTemplateKeys": [],

--- a/__tests__/__action_fixtures__/loadResource-ADD_SUBJECT.json
+++ b/__tests__/__action_fixtures__/loadResource-ADD_SUBJECT.json
@@ -55,6 +55,7 @@
 					"immutable": false,
 					"remark": "Multiple nested, repeatable resource templates.",
 					"remarkUrl": null,
+					"remarkUrlLabel": null,
 					"defaults": [],
 					"valueSubjectTemplateKeys": [
 						"resourceTemplate:testing:uber2",
@@ -75,6 +76,7 @@
 					"immutable": false,
 					"remark": "A repeatable literal.",
 					"remarkUrl": null,
+					"remarkUrlLabel": null,
 					"defaults": [],
 					"valueSubjectTemplateKeys": [],
 					"authorities": [],
@@ -92,6 +94,7 @@
 					"immutable": false,
 					"remark": "Multiple nested, non-repeatable resource templates.",
 					"remarkUrl": null,
+					"remarkUrlLabel": null,
 					"defaults": [],
 					"valueSubjectTemplateKeys": [
 						"resourceTemplate:testing:uber2",
@@ -112,6 +115,7 @@
 					"immutable": false,
 					"remark": "A non-repeatable literal.",
 					"remarkUrl": null,
+					"remarkUrlLabel": null,
 					"defaults": [],
 					"valueSubjectTemplateKeys": [],
 					"authorities": [],
@@ -129,6 +133,7 @@
 					"immutable": false,
 					"remark": "A non-repeatable URI.",
 					"remarkUrl": null,
+					"remarkUrlLabel": null,
 					"defaults": [],
 					"valueSubjectTemplateKeys": [],
 					"authorities": [],
@@ -146,6 +151,7 @@
 					"immutable": false,
 					"remark": "A repeatable URI.",
 					"remarkUrl": null,
+					"remarkUrlLabel": null,
 					"defaults": [],
 					"valueSubjectTemplateKeys": [],
 					"authorities": [],
@@ -163,6 +169,7 @@
 					"immutable": false,
 					"remark": "A repeatable literal with defaults.",
 					"remarkUrl": null,
+					"remarkUrlLabel": null,
 					"defaults": [
 						{
 							"literal": "Default literal1",
@@ -189,6 +196,7 @@
 					"immutable": false,
 					"remark": "A repeatable URI with defaults.",
 					"remarkUrl": null,
+					"remarkUrlLabel": null,
 					"defaults": [
 						{
 							"uri": "http://sinopia.io/defaultURI1",
@@ -215,6 +223,7 @@
 					"immutable": false,
 					"remark": null,
 					"remarkUrl": "http://access.rdatoolkit.org/2.13.html",
+					"remarkUrlLabel": null,
 					"defaults": [],
 					"valueSubjectTemplateKeys": [],
 					"authorities": [],
@@ -232,6 +241,7 @@
 					"immutable": false,
 					"remark": "A non-repeatable LOC lookup.",
 					"remarkUrl": null,
+					"remarkUrlLabel": null,
 					"defaults": [],
 					"valueSubjectTemplateKeys": [],
 					"authorities": [
@@ -255,6 +265,7 @@
 					"immutable": false,
 					"remark": "A repeatable LOC lookup.",
 					"remarkUrl": null,
+					"remarkUrlLabel": null,
 					"defaults": [],
 					"valueSubjectTemplateKeys": [],
 					"authorities": [
@@ -278,6 +289,7 @@
 					"immutable": false,
 					"remark": "A LOC lookup with multiple authorities.",
 					"remarkUrl": null,
+					"remarkUrlLabel": null,
 					"defaults": [],
 					"valueSubjectTemplateKeys": [],
 					"authorities": [
@@ -306,6 +318,7 @@
 					"immutable": false,
 					"remark": "A non-repeatable QA lookup.",
 					"remarkUrl": null,
+					"remarkUrlLabel": null,
 					"defaults": [],
 					"valueSubjectTemplateKeys": [],
 					"authorities": [
@@ -338,6 +351,7 @@
 					"immutable": false,
 					"remark": "A repeatable QA lookup.",
 					"remarkUrl": null,
+					"remarkUrlLabel": null,
 					"defaults": [],
 					"valueSubjectTemplateKeys": [],
 					"authorities": [
@@ -363,6 +377,7 @@
 					"immutable": false,
 					"remark": "A QA lookup with multiple authorities.",
 					"remarkUrl": null,
+					"remarkUrlLabel": null,
 					"defaults": [],
 					"valueSubjectTemplateKeys": [],
 					"authorities": [
@@ -395,6 +410,7 @@
 					"immutable": false,
 					"remark": "A non-repeatable Sinopia lookup.",
 					"remarkUrl": null,
+					"remarkUrlLabel": null,
 					"defaults": [],
 					"valueSubjectTemplateKeys": [],
 					"authorities": [
@@ -419,6 +435,7 @@
 					"immutable": false,
 					"remark": "A repeatable Sinopia lookup.",
 					"remarkUrl": null,
+					"remarkUrlLabel": null,
 					"defaults": [],
 					"valueSubjectTemplateKeys": [],
 					"authorities": [
@@ -443,6 +460,7 @@
 					"immutable": false,
 					"remark": "Mandatory nested resource templates.",
 					"remarkUrl": null,
+					"remarkUrlLabel": null,
 					"defaults": [],
 					"valueSubjectTemplateKeys": [
 						"resourceTemplate:testing:uber4"
@@ -462,6 +480,7 @@
 					"immutable": false,
 					"remark": "Ordered nested resource templates.",
 					"remarkUrl": null,
+					"remarkUrlLabel": null,
 					"defaults": [],
 					"valueSubjectTemplateKeys": [
 						"resourceTemplate:testing:uber4"
@@ -481,6 +500,7 @@
 					"immutable": false,
 					"remark": null,
 					"remarkUrl": null,
+					"remarkUrlLabel": null,
 					"defaults": [],
 					"valueSubjectTemplateKeys": [],
 					"authorities": [
@@ -505,6 +525,7 @@
 					"immutable": false,
 					"remark": null,
 					"remarkUrl": null,
+					"remarkUrlLabel": null,
 					"defaults": [],
 					"valueSubjectTemplateKeys": [],
 					"authorities": [
@@ -529,6 +550,7 @@
 					"immutable": false,
 					"remark": null,
 					"remarkUrl": null,
+					"remarkUrlLabel": null,
 					"defaults": [],
 					"valueSubjectTemplateKeys": [],
 					"authorities": [
@@ -553,6 +575,7 @@
 					"immutable": false,
 					"remark": null,
 					"remarkUrl": null,
+					"remarkUrlLabel": null,
 					"defaults": [],
 					"valueSubjectTemplateKeys": [],
 					"authorities": [
@@ -577,6 +600,7 @@
 					"immutable": false,
 					"remark": null,
 					"remarkUrl": null,
+					"remarkUrlLabel": null,
 					"defaults": [],
 					"valueSubjectTemplateKeys": [],
 					"authorities": [
@@ -601,6 +625,7 @@
 					"immutable": false,
 					"remark": "A required, repeatable literal with defaults.",
 					"remarkUrl": null,
+					"remarkUrlLabel": null,
 					"defaults": [
 						{
 							"literal": "Default required literal1",
@@ -627,6 +652,7 @@
 					"immutable": false,
 					"remark": "Nested, repeatable, suppressible resource template.",
 					"remarkUrl": null,
+					"remarkUrlLabel": null,
 					"defaults": [],
 					"valueSubjectTemplateKeys": [
 						"resourceTemplate:testing:uber5"
@@ -646,6 +672,7 @@
 					"immutable": false,
 					"remark": "rdfs label",
 					"remarkUrl": null,
+					"remarkUrlLabel": null,
 					"defaults": [],
 					"valueSubjectTemplateKeys": [],
 					"authorities": [],
@@ -663,6 +690,7 @@
 					"immutable": true,
 					"remark": "A non-repeatable, immutable literal.",
 					"remarkUrl": null,
+					"remarkUrlLabel": null,
 					"defaults": [],
 					"valueSubjectTemplateKeys": [],
 					"authorities": [],
@@ -713,6 +741,7 @@
 										"immutable": false,
 										"remark": "A repeatable literal",
 										"remarkUrl": null,
+										"remarkUrlLabel": null,
 										"defaults": [],
 										"valueSubjectTemplateKeys": [],
 										"authorities": [],
@@ -809,6 +838,7 @@
 										"immutable": false,
 										"remark": "A literal",
 										"remarkUrl": null,
+										"remarkUrlLabel": null,
 										"defaults": [],
 										"valueSubjectTemplateKeys": [],
 										"authorities": [],
@@ -826,6 +856,7 @@
 										"immutable": false,
 										"remark": null,
 										"remarkUrl": "http://access.rdatoolkit.org/1.0.html",
+										"remarkUrlLabel": null,
 										"defaults": [],
 										"valueSubjectTemplateKeys": [],
 										"authorities": [],
@@ -1132,6 +1163,7 @@
 										"immutable": false,
 										"remark": "A repeatable, required literal",
 										"remarkUrl": null,
+										"remarkUrlLabel": null,
 										"defaults": [],
 										"valueSubjectTemplateKeys": [],
 										"authorities": [],

--- a/__tests__/__action_fixtures__/loadResourceNestedResource-ADD_SUBJECT.json
+++ b/__tests__/__action_fixtures__/loadResourceNestedResource-ADD_SUBJECT.json
@@ -55,6 +55,7 @@
           "immutable": false,
           "remark": "Multiple nested, repeatable resource templates.",
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [
             "resourceTemplate:testing:uber2",
@@ -75,6 +76,7 @@
           "immutable": false,
           "remark": "A repeatable literal.",
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [],
           "authorities": [],
@@ -92,6 +94,7 @@
           "immutable": false,
           "remark": "Multiple nested, non-repeatable resource templates.",
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [
             "resourceTemplate:testing:uber2",
@@ -112,6 +115,7 @@
           "immutable": false,
           "remark": "A non-repeatable literal.",
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [],
           "authorities": [],
@@ -129,6 +133,7 @@
           "immutable": false,
           "remark": "A non-repeatable URI.",
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [],
           "authorities": [],
@@ -146,6 +151,7 @@
           "immutable": false,
           "remark": "A repeatable URI.",
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [],
           "authorities": [],
@@ -163,6 +169,7 @@
           "immutable": false,
           "remark": "A repeatable literal with defaults.",
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [
             {
               "literal": "Default literal1",
@@ -189,6 +196,7 @@
           "immutable": false,
           "remark": "A repeatable URI with defaults.",
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [
             {
               "uri": "http://sinopia.io/defaultURI1",
@@ -215,6 +223,7 @@
           "immutable": false,
           "remark": null,
           "remarkUrl": "http://access.rdatoolkit.org/2.13.html",
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [],
           "authorities": [],
@@ -232,6 +241,7 @@
           "immutable": false,
           "remark": "A non-repeatable LOC lookup.",
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [],
           "authorities": [
@@ -255,6 +265,7 @@
           "immutable": false,
           "remark": "A repeatable LOC lookup.",
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [],
           "authorities": [
@@ -278,6 +289,7 @@
           "immutable": false,
           "remark": "A LOC lookup with multiple authorities.",
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [],
           "authorities": [
@@ -306,6 +318,7 @@
           "immutable": false,
           "remark": "A non-repeatable QA lookup.",
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [],
           "authorities": [
@@ -338,6 +351,7 @@
           "immutable": false,
           "remark": "A repeatable QA lookup.",
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [],
           "authorities": [
@@ -363,6 +377,7 @@
           "immutable": false,
           "remark": "A QA lookup with multiple authorities.",
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [],
           "authorities": [
@@ -395,6 +410,7 @@
           "immutable": false,
           "remark": "A non-repeatable Sinopia lookup.",
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [],
           "authorities": [
@@ -419,6 +435,7 @@
           "immutable": false,
           "remark": "A repeatable Sinopia lookup.",
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [],
           "authorities": [
@@ -443,6 +460,7 @@
           "immutable": false,
           "remark": "Mandatory nested resource templates.",
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [
             "resourceTemplate:testing:uber4"
@@ -462,6 +480,7 @@
           "immutable": false,
           "remark": "Ordered nested resource templates.",
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [
             "resourceTemplate:testing:uber4"
@@ -481,6 +500,7 @@
           "immutable": false,
           "remark": null,
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [],
           "authorities": [
@@ -505,6 +525,7 @@
           "immutable": false,
           "remark": null,
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [],
           "authorities": [
@@ -529,6 +550,7 @@
           "immutable": false,
           "remark": null,
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [],
           "authorities": [
@@ -553,6 +575,7 @@
           "immutable": false,
           "remark": null,
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [],
           "authorities": [
@@ -577,6 +600,7 @@
           "immutable": false,
           "remark": null,
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [],
           "authorities": [
@@ -601,6 +625,7 @@
           "immutable": false,
           "remark": "A required, repeatable literal with defaults.",
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [
             {
               "literal": "Default required literal1",
@@ -627,6 +652,7 @@
           "immutable": false,
           "remark": "Nested, repeatable, suppressible resource template.",
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [
             "resourceTemplate:testing:uber5"
@@ -646,6 +672,7 @@
           "immutable": false,
           "remark": "rdfs label",
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [],
           "authorities": [],
@@ -663,6 +690,7 @@
           "immutable": true,
           "remark": "A non-repeatable, immutable literal.",
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [],
           "authorities": [],
@@ -713,6 +741,7 @@
                     "immutable": false,
                     "remark": "A repeatable literal",
                     "remarkUrl": null,
+                    "remarkUrlLabel": null,
                     "defaults": [],
                     "valueSubjectTemplateKeys": [],
                     "authorities": [],
@@ -770,6 +799,7 @@
                     "immutable": false,
                     "remark": "A literal",
                     "remarkUrl": null,
+                    "remarkUrlLabel": null,
                     "defaults": [],
                     "valueSubjectTemplateKeys": [],
                     "authorities": [],
@@ -787,6 +817,7 @@
                     "immutable": false,
                     "remark": null,
                     "remarkUrl": "http://access.rdatoolkit.org/1.0.html",
+                    "remarkUrlLabel": null,
                     "defaults": [],
                     "valueSubjectTemplateKeys": [],
                     "authorities": [],
@@ -954,6 +985,7 @@
                     "immutable": false,
                     "remark": "A repeatable, required literal",
                     "remarkUrl": null,
+                    "remarkUrlLabel": null,
                     "defaults": [],
                     "valueSubjectTemplateKeys": [],
                     "authorities": [],

--- a/__tests__/__action_fixtures__/newResource-ADD_SUBJECT.json
+++ b/__tests__/__action_fixtures__/newResource-ADD_SUBJECT.json
@@ -55,6 +55,7 @@
           "immutable": false,
           "remark": "Multiple nested, repeatable resource templates.",
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [
             "resourceTemplate:testing:uber2",
@@ -75,6 +76,7 @@
           "immutable": false,
           "remark": "A repeatable literal.",
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [],
           "authorities": [],
@@ -92,6 +94,7 @@
           "immutable": false,
           "remark": "Multiple nested, non-repeatable resource templates.",
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [
             "resourceTemplate:testing:uber2",
@@ -112,6 +115,7 @@
           "immutable": false,
           "remark": "A non-repeatable literal.",
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [],
           "authorities": [],
@@ -129,6 +133,7 @@
           "immutable": false,
           "remark": "A non-repeatable URI.",
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [],
           "authorities": [],
@@ -146,6 +151,7 @@
           "immutable": false,
           "remark": "A repeatable URI.",
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [],
           "authorities": [],
@@ -163,6 +169,7 @@
           "immutable": false,
           "remark": "A repeatable literal with defaults.",
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [
             {
               "literal": "Default literal1",
@@ -189,6 +196,7 @@
           "immutable": false,
           "remark": "A repeatable URI with defaults.",
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [
             {
               "uri": "http://sinopia.io/defaultURI1",
@@ -215,6 +223,7 @@
           "immutable": false,
           "remark": null,
           "remarkUrl": "http://access.rdatoolkit.org/2.13.html",
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [],
           "authorities": [],
@@ -232,6 +241,7 @@
           "immutable": false,
           "remark": "A non-repeatable LOC lookup.",
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [],
           "authorities": [
@@ -255,6 +265,7 @@
           "immutable": false,
           "remark": "A repeatable LOC lookup.",
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [],
           "authorities": [
@@ -278,6 +289,7 @@
           "immutable": false,
           "remark": "A LOC lookup with multiple authorities.",
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [],
           "authorities": [
@@ -306,6 +318,7 @@
           "immutable": false,
           "remark": "A non-repeatable QA lookup.",
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [],
           "authorities": [
@@ -338,6 +351,7 @@
           "immutable": false,
           "remark": "A repeatable QA lookup.",
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [],
           "authorities": [
@@ -363,6 +377,7 @@
           "immutable": false,
           "remark": "A QA lookup with multiple authorities.",
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [],
           "authorities": [
@@ -395,6 +410,7 @@
           "immutable": false,
           "remark": "A non-repeatable Sinopia lookup.",
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [],
           "authorities": [
@@ -419,6 +435,7 @@
           "immutable": false,
           "remark": "A repeatable Sinopia lookup.",
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [],
           "authorities": [
@@ -443,6 +460,7 @@
           "immutable": false,
           "remark": "Mandatory nested resource templates.",
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [
             "resourceTemplate:testing:uber4"
@@ -462,6 +480,7 @@
           "immutable": false,
           "remark": "Ordered nested resource templates.",
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [
             "resourceTemplate:testing:uber4"
@@ -481,6 +500,7 @@
           "immutable": false,
           "remark": null,
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [],
           "authorities": [
@@ -505,6 +525,7 @@
           "immutable": false,
           "remark": null,
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [],
           "authorities": [
@@ -529,6 +550,7 @@
           "immutable": false,
           "remark": null,
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [],
           "authorities": [
@@ -553,6 +575,7 @@
           "immutable": false,
           "remark": null,
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [],
           "authorities": [
@@ -577,6 +600,7 @@
           "immutable": false,
           "remark": null,
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [],
           "authorities": [
@@ -601,6 +625,7 @@
           "immutable": false,
           "remark": "A required, repeatable literal with defaults.",
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [
             {
               "literal": "Default required literal1",
@@ -627,6 +652,7 @@
           "immutable": false,
           "remark": "Nested, repeatable, suppressible resource template.",
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [
             "resourceTemplate:testing:uber5"
@@ -646,6 +672,7 @@
           "immutable": false,
           "remark": "rdfs label",
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [],
           "authorities": [],
@@ -663,6 +690,7 @@
           "immutable": true,
           "remark": "A non-repeatable, immutable literal.",
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [],
           "authorities": [],
@@ -713,6 +741,7 @@
                     "immutable": false,
                     "remark": "A repeatable literal",
                     "remarkUrl": null,
+                    "remarkUrlLabel": null,
                     "defaults": [],
                     "valueSubjectTemplateKeys": [],
                     "authorities": [],
@@ -770,6 +799,7 @@
                     "immutable": false,
                     "remark": "A literal",
                     "remarkUrl": null,
+                    "remarkUrlLabel": null,
                     "defaults": [],
                     "valueSubjectTemplateKeys": [],
                     "authorities": [],
@@ -787,6 +817,7 @@
                     "immutable": false,
                     "remark": null,
                     "remarkUrl": "http://access.rdatoolkit.org/1.0.html",
+                    "remarkUrlLabel": null,
                     "defaults": [],
                     "valueSubjectTemplateKeys": [],
                     "authorities": [],
@@ -859,6 +890,7 @@
                     "immutable": false,
                     "remark": "A repeatable literal",
                     "remarkUrl": null,
+                    "remarkUrlLabel": null,
                     "defaults": [],
                     "valueSubjectTemplateKeys": [],
                     "authorities": [],
@@ -916,6 +948,7 @@
                     "immutable": false,
                     "remark": "A literal",
                     "remarkUrl": null,
+                    "remarkUrlLabel": null,
                     "defaults": [],
                     "valueSubjectTemplateKeys": [],
                     "authorities": [],
@@ -933,6 +966,7 @@
                     "immutable": false,
                     "remark": null,
                     "remarkUrl": "http://access.rdatoolkit.org/1.0.html",
+                    "remarkUrlLabel": null,
                     "defaults": [],
                     "valueSubjectTemplateKeys": [],
                     "authorities": [],
@@ -1108,6 +1142,7 @@
                     "immutable": false,
                     "remark": "A repeatable, required literal",
                     "remarkUrl": null,
+                    "remarkUrlLabel": null,
                     "defaults": [],
                     "valueSubjectTemplateKeys": [],
                     "authorities": [],
@@ -1170,6 +1205,7 @@
                     "immutable": false,
                     "remark": "A repeatable, required literal",
                     "remarkUrl": null,
+                    "remarkUrlLabel": null,
                     "defaults": [],
                     "valueSubjectTemplateKeys": [],
                     "authorities": [],
@@ -1281,6 +1317,7 @@
                     "immutable": false,
                     "remark": "A repeatable URI",
                     "remarkUrl": null,
+                    "remarkUrlLabel": null,
                     "defaults": [],
                     "valueSubjectTemplateKeys": [],
                     "authorities": [],

--- a/__tests__/__action_fixtures__/newResourceFromDataset-ADD_SUBJECT.json
+++ b/__tests__/__action_fixtures__/newResourceFromDataset-ADD_SUBJECT.json
@@ -55,6 +55,7 @@
           "immutable": false,
           "remark": "Multiple nested, repeatable resource templates.",
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [
             "resourceTemplate:testing:uber2",
@@ -75,6 +76,7 @@
           "immutable": false,
           "remark": "A repeatable literal.",
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [],
           "authorities": [],
@@ -92,6 +94,7 @@
           "immutable": false,
           "remark": "Multiple nested, non-repeatable resource templates.",
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [
             "resourceTemplate:testing:uber2",
@@ -112,6 +115,7 @@
           "immutable": false,
           "remark": "A non-repeatable literal.",
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [],
           "authorities": [],
@@ -129,6 +133,7 @@
           "immutable": false,
           "remark": "A non-repeatable URI.",
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [],
           "authorities": [],
@@ -146,6 +151,7 @@
           "immutable": false,
           "remark": "A repeatable URI.",
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [],
           "authorities": [],
@@ -163,6 +169,7 @@
           "immutable": false,
           "remark": "A repeatable literal with defaults.",
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [
             {
               "literal": "Default literal1",
@@ -189,6 +196,7 @@
           "immutable": false,
           "remark": "A repeatable URI with defaults.",
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [
             {
               "uri": "http://sinopia.io/defaultURI1",
@@ -215,6 +223,7 @@
           "immutable": false,
           "remark": null,
           "remarkUrl": "http://access.rdatoolkit.org/2.13.html",
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [],
           "authorities": [],
@@ -232,6 +241,7 @@
           "immutable": false,
           "remark": "A non-repeatable LOC lookup.",
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [],
           "authorities": [
@@ -255,6 +265,7 @@
           "immutable": false,
           "remark": "A repeatable LOC lookup.",
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [],
           "authorities": [
@@ -278,6 +289,7 @@
           "immutable": false,
           "remark": "A LOC lookup with multiple authorities.",
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [],
           "authorities": [
@@ -306,6 +318,7 @@
           "immutable": false,
           "remark": "A non-repeatable QA lookup.",
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [],
           "authorities": [
@@ -338,6 +351,7 @@
           "immutable": false,
           "remark": "A repeatable QA lookup.",
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [],
           "authorities": [
@@ -363,6 +377,7 @@
           "immutable": false,
           "remark": "A QA lookup with multiple authorities.",
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [],
           "authorities": [
@@ -395,6 +410,7 @@
           "immutable": false,
           "remark": "A non-repeatable Sinopia lookup.",
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [],
           "authorities": [
@@ -419,6 +435,7 @@
           "immutable": false,
           "remark": "A repeatable Sinopia lookup.",
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [],
           "authorities": [
@@ -443,6 +460,7 @@
           "immutable": false,
           "remark": "Mandatory nested resource templates.",
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [
             "resourceTemplate:testing:uber4"
@@ -462,6 +480,7 @@
           "immutable": false,
           "remark": "Ordered nested resource templates.",
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [
             "resourceTemplate:testing:uber4"
@@ -481,6 +500,7 @@
           "immutable": false,
           "remark": null,
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [],
           "authorities": [
@@ -505,6 +525,7 @@
           "immutable": false,
           "remark": null,
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [],
           "authorities": [
@@ -529,6 +550,7 @@
           "immutable": false,
           "remark": null,
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [],
           "authorities": [
@@ -553,6 +575,7 @@
           "immutable": false,
           "remark": null,
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [],
           "authorities": [
@@ -577,6 +600,7 @@
           "immutable": false,
           "remark": null,
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [],
           "authorities": [
@@ -601,6 +625,7 @@
           "immutable": false,
           "remark": "A required, repeatable literal with defaults.",
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [
             {
               "literal": "Default required literal1",
@@ -627,6 +652,7 @@
           "immutable": false,
           "remark": "Nested, repeatable, suppressible resource template.",
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [
             "resourceTemplate:testing:uber5"
@@ -646,6 +672,7 @@
           "immutable": false,
           "remark": "rdfs label",
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [],
           "authorities": [],
@@ -663,6 +690,7 @@
           "immutable": true,
           "remark": "A non-repeatable, immutable literal.",
           "remarkUrl": null,
+          "remarkUrlLabel": null,
           "defaults": [],
           "valueSubjectTemplateKeys": [],
           "authorities": [],
@@ -713,6 +741,7 @@
                     "immutable": false,
                     "remark": "A repeatable literal",
                     "remarkUrl": null,
+                    "remarkUrlLabel": null,
                     "defaults": [],
                     "valueSubjectTemplateKeys": [],
                     "authorities": [],
@@ -809,6 +838,7 @@
                     "immutable": false,
                     "remark": "A literal",
                     "remarkUrl": null,
+                    "remarkUrlLabel": null,
                     "defaults": [],
                     "valueSubjectTemplateKeys": [],
                     "authorities": [],
@@ -826,6 +856,7 @@
                     "immutable": false,
                     "remark": null,
                     "remarkUrl": "http://access.rdatoolkit.org/1.0.html",
+                    "remarkUrlLabel": null,
                     "defaults": [],
                     "valueSubjectTemplateKeys": [],
                     "authorities": [],
@@ -1033,6 +1064,7 @@
                     "immutable": false,
                     "remark": "A repeatable, required literal",
                     "remarkUrl": null,
+                    "remarkUrlLabel": null,
                     "defaults": [],
                     "valueSubjectTemplateKeys": [],
                     "authorities": [],
@@ -1130,6 +1162,7 @@
                     "immutable": false,
                     "remark": "A repeatable URI",
                     "remarkUrl": null,
+                    "remarkUrlLabel": null,
                     "defaults": [],
                     "valueSubjectTemplateKeys": [],
                     "authorities": [],

--- a/src/TemplatesBuilder.js
+++ b/src/TemplatesBuilder.js
@@ -2,6 +2,8 @@ import _ from "lodash"
 import { findAuthorityConfig } from "utilities/authorityConfig"
 import rdf from "rdf-ext"
 
+const rdfsLabel = "http://www.w3.org/2000/01/rdf-schema#label"
+
 export default class TemplatesBuilder {
   constructor(dataset, uri, group = null, editGroups = []) {
     this.dataset = dataset
@@ -41,10 +43,7 @@ export default class TemplatesBuilder {
         this.resourceTerm,
         "http://sinopia.io/vocabulary/hasClass"
       ),
-      label: this.valueFor(
-        this.resourceTerm,
-        "http://www.w3.org/2000/01/rdf-schema#label"
-      ),
+      label: this.valueFor(this.resourceTerm, rdfsLabel),
       author: this.valueFor(
         this.resourceTerm,
         "http://sinopia.io/vocabulary/hasAuthor"
@@ -155,14 +154,19 @@ export default class TemplatesBuilder {
       propertyTerm,
       "http://sinopia.io/vocabulary/hasPropertyAttribute"
     )
+    const remarkUrl = this.valueFor(
+      propertyTerm,
+      "http://sinopia.io/vocabulary/hasRemarkUrl"
+    )
+    const remarkUrlLabel = remarkUrl
+      ? this.valueFor(remarkUrl, rdfsLabel)
+      : null
+
     return {
       // This key will be unique for resource templates, property templates.
       key: `${this.subjectTemplate.key} > ${propertyUri}`,
       subjectTemplateKey: this.subjectTemplate.key,
-      label: this.valueFor(
-        propertyTerm,
-        "http://www.w3.org/2000/01/rdf-schema#label"
-      ),
+      label: this.valueFor(propertyTerm, rdfsLabel),
       uri: propertyUri,
       required: propertyAttrValues.includes(
         "http://sinopia.io/vocabulary/propertyAttribute/required"
@@ -180,10 +184,8 @@ export default class TemplatesBuilder {
         propertyTerm,
         "http://sinopia.io/vocabulary/hasRemark"
       ),
-      remarkUrl: this.valueFor(
-        propertyTerm,
-        "http://sinopia.io/vocabulary/hasRemarkUrl"
-      ),
+      remarkUrl,
+      remarkUrlLabel,
       defaults: [],
       valueSubjectTemplateKeys: [],
       authorities: [],

--- a/src/components/editor/property/PropertyLabelInfoLink.jsx
+++ b/src/components/editor/property/PropertyLabelInfoLink.jsx
@@ -12,7 +12,7 @@ const PropertyLabelInfoLink = (props) => {
     <a
       href={url}
       className="prop-remark"
-      title={props.propertyTemplate.remarkUrl}
+      title={props.propertyTemplate.remarkUrlLabel || url}
       target="_blank"
       rel="noopener noreferrer"
     >


### PR DESCRIPTION


## Why was this change made?

Fixes #3240

## How was this change tested?



## Which documentation and/or configurations were updated?



