### PR TITLE
EditorActions resource tabs now below ResourcesNav

### DIFF
--- a/src/components/editor/Editor.jsx
+++ b/src/components/editor/Editor.jsx
@@ -81,13 +81,13 @@ const Editor = (props) => {
   return (
     <div id="editor">
       <Header triggerEditorMenu={props.triggerHandleOffsetMenu} />
-      <EditorActions />
       <EditorPreviewModal />
       {displayErrors && hasErrors && (
         <ErrorMessages resourceKey={resourceKey} />
       )}
       <GroupChoiceModal />
       <ResourcesNav />
+      <EditorActions />
       <ResourceComponent />
       <EditorActions />
     </div>


### PR DESCRIPTION
## Why was this change made?

Fixes #3223

Moves EditorActions down

## After

(example - "short title")

![image](https://user-images.githubusercontent.com/96775/139113048-2c7a9dad-867b-4dd0-9e82-f33a80c7d0ef.png)

(example - use window with to emulate "long title")

![image](https://user-images.githubusercontent.com/96775/139113127-5654b729-56ca-4e88-9f48-afd325f19f58.png)


## Before

![image](https://user-images.githubusercontent.com/96775/139112999-eeea9ae6-cfaa-4349-930c-ff20bc1b1a2c.png)


## How was this change tested?

locally.

## Which documentation and/or configurations were updated?



