### PR TITLE
clear resource from state after preview

### DIFF
--- a/src/components/editor/preview/PreviewModal.jsx
+++ b/src/components/editor/preview/PreviewModal.jsx
@@ -13,7 +13,7 @@ import {
   selectCurrentPreviewResourceKey,
   selectNormSubject,
 } from "selectors/resources"
-import { setCurrentPreviewResource } from "actions/resources"
+import { setCurrentPreviewResource, clearResource } from "actions/resources"
 import ResourceDisplay from "./ResourceDisplay"
 import usePermissions from "hooks/usePermissions"
 import MarcButton from "../actions/MarcButton"
@@ -36,8 +36,8 @@ const PreviewModal = (props) => {
   const close = (event) => {
     event.preventDefault()
     dispatch(setCurrentPreviewResource(null))
-    // TODO: Remove from state.
     dispatch(hideModal())
+    dispatch(clearResource(currentResourceKey))
   }
 
   const editAndClose = (event) => {


### PR DESCRIPTION
## Why was this change made?

Fixes #3231 - remove resource from state after preview

Just followed what was done in this other preview component: https://github.com/LD4P/sinopia_editor/blob/main/src/components/editor/preview/VersionPreviewModal.jsx#L33-L38

## How was this change tested?



## Which documentation and/or configurations were updated?



