### PR TITLE
Merge groups into resource only when not a new resource

### DIFF
--- a/src/actionCreators/resourceHelpers.js
+++ b/src/actionCreators/resourceHelpers.js
@@ -112,8 +112,15 @@ export const addResourceFromDataset =
         errorKey
       )
     ).then((resource) => {
-      dispatch(addSubjectAction(_.merge(resource, otherResourceAttrs)))
-      return [resource, usedDataset]
+      // Do not copy group or editGroups (passed in via otherResourceAttrs) if resource is new (i.e., copied)
+      const newResource = _.merge(resource, otherResourceAttrs)
+      if (asNewResource) {
+        newResource.group = null
+        newResource.editGroups = []
+      }
+
+      dispatch(addSubjectAction(newResource))
+      return [newResource, usedDataset]
     })
   }
 


### PR DESCRIPTION
Fixes #3199

## Why was this change made?

This commit makes a small tweak to the spot in the codebase where groups are merged into resources, short-circuiting that behavior when the resource is new. The intent is to prevent copied resources from inheriting groups and edit groups from the resources from which they were copied. These should not be set, and the user should select the group and edit groups after copying the resource.

## How was this change tested?

CI

## Which documentation and/or configurations were updated?

None.

