### PR TITLE
alpha sort list of languages in type ahead box

### DIFF
--- a/src/reducers/languages.js
+++ b/src/reducers/languages.js
@@ -23,7 +23,7 @@ export const languagesReceived = (state, action) => {
   return {
     ...state,
     languageLookup: options,
-    languages: createMap(options),
+    languages: createMap(options.sort((a, b) => a.label > b.label)),
   }
 }
 


### PR DESCRIPTION
## Why was this change made?

Fixes #824 - alpha sort languages in type ahead box

## How was this change tested?

Localhost browser

## Which documentation and/or configurations were updated?



