### PR TITLE
[HOLD] add literalDataType list for validation of literals against DataType

### DIFF
--- a/static/authorityConfig.json
+++ b/static/authorityConfig.json
@@ -2291,5 +2291,10 @@
     "label": "resourceAttribute",
     "uri": "file:/resourceAttribute.json",
     "component": "list"
+  },
+  {
+    "label": "literal validation data type",
+    "uri": "file:/literalDataType.json",
+    "component": "list"
   }
 ]

--- a/static/literalDataType.json
+++ b/static/literalDataType.json
@@ -1,0 +1,18 @@
+[
+  {
+    "uri": "http://www.w3.org/2001/XMLSchema/integer",
+    "label": "Arbitrary-size integer (xsd:integer)"
+  },
+  {
+    "uri": "http://www.w3.org/2001/XMLSchema/dateTime",
+    "label": "Date and time with or without timezone (xsd:dateTime)"
+  },
+  {
+    "uri": "http://www.w3.org/2001/XMLSchema/dateTimeStamp",
+    "label": "Date and time with required timezone (xsd:dateTimeStamp)"
+  },
+  {
+    "uri": "http://id.loc.gov/datatypes/edtf",
+    "label": "Extended Date/Time Format (EDTF)"
+  }
+]


### PR DESCRIPTION
### HOLD until JLitt is done with refactor from #3266
(or whenever @justinlittman wants to merge it)

## Why was this change made?

Part of #2889
(detailed steps to complete here: https://github.com/LD4P/sinopia_editor/issues/2889#issuecomment-954261209)

First step in allowing validation of literals against data types.

NOTE:  @justinlittman is actively changing where the "base templates" (the json that tells the editor what components to display for creating/editing resource templates) live per #3266, so this PR should not be merged until he is ready.

### Eventually:

![image](https://user-images.githubusercontent.com/96775/139500560-f1990e32-57ed-4aa4-9a4b-200cf7f3d1ed.png)

## How was this change tested?

locally, by hoking up changes to sinopia_api for this.

## Which documentation and/or configurations were updated?



