### PR TITLE
Loads base templates instead of retrieving from API.

### DIFF
--- a/__tests__/feature/editing/copyTemplateResource.test.js
+++ b/__tests__/feature/editing/copyTemplateResource.test.js
@@ -1,31 +1,25 @@
 import { renderApp, createHistory, createStore } from "testUtils"
-import { act, fireEvent, screen } from "@testing-library/react"
+import { fireEvent, screen } from "@testing-library/react"
 import * as sinopiaSearch from "sinopiaSearch"
 import { featureSetup } from "featureUtils"
 
 featureSetup()
 jest.mock("sinopiaSearch")
 
-// Mock out document.elementFromPoint used by useNavigableComponent.
-global.document.elementFromPoint = jest.fn()
-// Mock out scrollIntoView used by useNavigableComponent. See https://github.com/jsdom/jsdom/issues/1695
-Element.prototype.scrollIntoView = jest.fn()
-
 describe("Copying a template resource", () => {
   const history = createHistory(["/templates"])
   const store = createStore()
-  const promise = Promise.resolve()
 
   sinopiaSearch.getTemplateSearchResults.mockResolvedValue({
     results: [
       {
-        id: "sinopia:template:resource",
+        id: "resourceTemplate:bf2:Note",
         author: null,
         date: null,
         remark: null,
-        resourceLabel: "Resource Template (dummy)",
+        resourceLabel: "Note",
         resourceURI: "http://sinopia.io/vocabulary/ResourceTemplate",
-        uri: "http://localhost:3000/resource/sinopia:template:resource",
+        uri: "http://localhost:3000/resource/resourceTemplate:bf2:Note",
       },
     ],
     totalHits: 1,
@@ -42,30 +36,25 @@ describe("Copying a template resource", () => {
     const input = screen.getByPlaceholderText(
       "Enter id, label, URI, remark, group, or author"
     )
-    await fireEvent.change(input, { target: { value: "dummy" } })
-    await screen.findByText("sinopia:template:resource")
+    await fireEvent.change(input, { target: { value: "note" } })
+    await screen.findByText("resourceTemplate:bf2:Note")
 
     // Open the template
-    fireEvent.click(await screen.findByTestId("Copy Resource Template (dummy)"))
-    await act(() => promise)
+    fireEvent.click(await screen.findByTestId("Copy Note"))
 
     // Headers and labels appear
-    await screen.findByText("Resource Template (dummy)", { selector: "h3" })
-    const labels = await screen.findAllByText("Resource Template (dummy)")
-    expect(labels.length).toBe(2)
+    await screen.findByText("Note", { selector: "h3" })
+    const labels = await screen.findAllByText("Note")
+    expect(labels.length).toBe(3)
 
     // But there is no resource URI for the unsaved copy
-    expect(
-      screen.queryByText(
-        /URI for this resource: <http:\/\/localhost:3000\/resource\/sinopia:template:resource>/
-      )
-    ).not.toBeInTheDocument()
+    expect(screen.queryByText(/URI for this resource/)).not.toBeInTheDocument()
 
     const saveBtn = await screen.findAllByRole("button", { name: "Save" })
     expect(saveBtn[0]).not.toBeDisabled()
 
     // It has the 'template' class for header color
     const templateClasses = screen.getAllByTestId("template")
-    expect(templateClasses.length).toEqual(2)
+    expect(templateClasses.length).toEqual(9)
   })
 })

--- a/__tests__/feature/newResourceTemplate.test.js
+++ b/__tests__/feature/newResourceTemplate.test.js
@@ -1,5 +1,5 @@
 import { renderApp } from "testUtils"
-import { fireEvent, screen, waitFor } from "@testing-library/react"
+import { fireEvent, screen } from "@testing-library/react"
 import { featureSetup } from "featureUtils"
 
 featureSetup()
@@ -13,8 +13,6 @@ describe("creating new resource template ", () => {
 
     // Click the new resource template button
     fireEvent.click(screen.getByText("New template"))
-    await waitFor(() =>
-      expect(screen.getByText("Resource Template (dummy)", { selector: "h3" }))
-    )
+    await screen.findByText("Resource template", { selector: "h3" })
   }, 15000)
 })

--- a/__tests__/testUtilities/fixtureLoaderHelper.js
+++ b/__tests__/testUtilities/fixtureLoaderHelper.js
@@ -32,7 +32,6 @@ const templateFilenames = {
   "resourceTemplate:testing:uber3": "uber_template3.json",
   "resourceTemplate:testing:uber4": "uber_template4.json",
   "resourceTemplate:testing:uber5": "uber_template5.json",
-  "sinopia:template:resource": "ResourceTemplate.json",
   "resourceTemplate:bf2:Instance": "Instance.json",
 }
 

--- a/__tests__/testUtilities/stateUtils.js
+++ b/__tests__/testUtilities/stateUtils.js
@@ -106,7 +106,7 @@ const buildTemplateWithLiteral = (state, options) => {
       uri: "http://localhost:3000/resource/sinopia:template:resource",
       id: "sinopia:template:resource",
       class: "http://sinopia.io/vocabulary/ResourceTemplate",
-      label: "Resource Template (dummy)",
+      label: "Resource Template",
       author: null,
       remark: null,
       date: null,
@@ -156,7 +156,7 @@ const buildTemplateWithLiteral = (state, options) => {
         uri: "http://localhost:3000/resource/sinopia:template:resource",
         id: "sinopia:template:resource",
         class: "http://sinopia.io/vocabulary/ResourceTemplate",
-        label: "Resource Template (dummy)",
+        label: "Resource Template",
         author: null,
         remark: null,
         date: null,
@@ -164,7 +164,7 @@ const buildTemplateWithLiteral = (state, options) => {
           "sinopia:template:resource > http://www.w3.org/2000/01/rdf-schema#label",
         ],
       },
-      labels: ["Resource Template (dummy)"],
+      labels: ["Resource Template"],
     },
   }
   state.entities.properties = {
@@ -176,7 +176,7 @@ const buildTemplateWithLiteral = (state, options) => {
       propertyTemplateKey:
         "sinopia:template:resource > http://www.w3.org/2000/01/rdf-schema#label",
       valueKeys: ["SgS9CqKjmb"],
-      labels: ["Resource Template (dummy)", "Note"],
+      labels: ["Resource Template", "Note"],
       showNav: false,
     },
   }
@@ -184,7 +184,7 @@ const buildTemplateWithLiteral = (state, options) => {
     SgS9CqKjmb: {
       key: "SgS9CqKjmb",
       resourceKey: "8VrbxGPeF",
-      literal: "Resource Template (dummy)",
+      literal: "Resource Template",
       lang: "",
       uri: null,
       label: null,

--- a/static/templates/rt_literal_property_attrs_doc.json
+++ b/static/templates/rt_literal_property_attrs_doc.json
@@ -1,17 +1,25 @@
 [
   {
     "@id": "_:b2",
-    "@type": [
-      "http://sinopia.io/vocabulary/PropertyTemplate"
-    ],
+    "@type": ["http://sinopia.io/vocabulary/PropertyTemplate"],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "Note"
+        "@value": "Defaults"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasRemark": [
+      {
+        "@value": "Default literals."
       }
     ],
     "http://sinopia.io/vocabulary/hasPropertyUri": [
       {
-        "@id": "http://www.w3.org/2000/01/rdf-schema#label"
+        "@id": "http://sinopia.io/vocabulary/hasDefault"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyAttribute": [
+      {
+        "@id": "http://sinopia.io/vocabulary/propertyAttribute/repeatable"
       }
     ],
     "http://sinopia.io/vocabulary/hasPropertyType": [
@@ -21,28 +29,31 @@
     ]
   },
   {
-    "@id": "http://localhost:3000/resource/sinopia:template:resource",
+    "@id": "sinopia:template:property:literal",
     "http://sinopia.io/vocabulary/hasResourceTemplate": [
       {
         "@value": "sinopia:template:resource"
       }
     ],
-    "@type": [
-      "http://sinopia.io/vocabulary/ResourceTemplate"
-    ],
+    "@type": ["http://sinopia.io/vocabulary/ResourceTemplate"],
     "http://sinopia.io/vocabulary/hasResourceId": [
       {
-        "@value": "sinopia:template:resource"
+        "@value": "sinopia:template:property:literal"
       }
     ],
     "http://sinopia.io/vocabulary/hasClass": [
       {
-        "@id": "http://sinopia.io/vocabulary/ResourceTemplate"
+        "@id": "http://sinopia.io/vocabulary/LiteralPropertyTemplate"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
-        "@value": "Resource Template (dummy)"
+        "@value": "Literal attributes"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasRemark": [
+      {
+        "@value": "Attributes for a literal property."
       }
     ],
     "http://sinopia.io/vocabulary/hasPropertyTemplate": [

--- a/static/templates/rt_lookup_property_attrs_doc.json
+++ b/static/templates/rt_lookup_property_attrs_doc.json
@@ -1,0 +1,132 @@
+[
+  {
+    "@id": "_:b3",
+    "@type": ["http://sinopia.io/vocabulary/PropertyTemplate"],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Authorities"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasRemark": [
+      {
+        "@value": "Authorities for lookup."
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyUri": [
+      {
+        "@id": "http://sinopia.io/vocabulary/hasAuthority"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyAttribute": [
+      {
+        "@id": "http://sinopia.io/vocabulary/propertyAttribute/required"
+      },
+      {
+        "@id": "http://sinopia.io/vocabulary/propertyAttribute/repeatable"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyType": [
+      {
+        "@id": "http://sinopia.io/vocabulary/propertyType/uri"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasLookupAttributes": [
+      {
+        "@id": "_:b4"
+      }
+    ]
+  },
+  {
+    "@id": "_:b4",
+    "@type": ["http://sinopia.io/vocabulary/LookupPropertyTemplate"],
+    "http://sinopia.io/vocabulary/hasAuthority": [
+      {
+        "@id": "file:/authorityConfig.json"
+      }
+    ]
+  },
+  {
+    "@id": "_:b5",
+    "@type": ["http://sinopia.io/vocabulary/PropertyTemplate"],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Defaults"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasRemark": [
+      {
+        "@value": "Default URIs."
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyUri": [
+      {
+        "@id": "http://sinopia.io/vocabulary/hasDefault"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyAttribute": [
+      {
+        "@id": "http://sinopia.io/vocabulary/propertyAttribute/repeatable"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyType": [
+      {
+        "@id": "http://sinopia.io/vocabulary/propertyType/resource"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasResourceAttributes": [
+      {
+        "@id": "_:b6"
+      }
+    ]
+  },
+  {
+    "@id": "_:b6",
+    "@type": ["http://sinopia.io/vocabulary/ResourcePropertyTemplate"],
+    "http://sinopia.io/vocabulary/hasResourceTemplateId": [
+      {
+        "@id": "sinopia:template:uri"
+      }
+    ]
+  },
+  {
+    "@id": "sinopia:template:property:lookup",
+    "http://sinopia.io/vocabulary/hasResourceTemplate": [
+      {
+        "@value": "sinopia:template:resource"
+      }
+    ],
+    "@type": ["http://sinopia.io/vocabulary/ResourceTemplate"],
+    "http://sinopia.io/vocabulary/hasResourceId": [
+      {
+        "@value": "sinopia:template:property:lookup"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasClass": [
+      {
+        "@id": "http://sinopia.io/vocabulary/LookupPropertyTemplate"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Lookup attributes"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasRemark": [
+      {
+        "@value": "Attributes for a lookup property."
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyTemplate": [
+      {
+        "@list": [
+          {
+            "@id": "_:b3"
+          },
+          {
+            "@id": "_:b5"
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/static/templates/rt_property_template_doc.json
+++ b/static/templates/rt_property_template_doc.json
@@ -1,0 +1,411 @@
+[
+  {
+    "@id": "_:b11",
+    "@type": ["http://sinopia.io/vocabulary/PropertyTemplate"],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Property attributes"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasRemark": [
+      {
+        "@value": "Whether is property is repeatable, required and/or ordered."
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyUri": [
+      {
+        "@id": "http://sinopia.io/vocabulary/hasPropertyAttribute"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyAttribute": [
+      {
+        "@id": "http://sinopia.io/vocabulary/propertyAttribute/repeatable"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyType": [
+      {
+        "@id": "http://sinopia.io/vocabulary/propertyType/uri"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasLookupAttributes": [
+      {
+        "@id": "_:b12"
+      }
+    ]
+  },
+  {
+    "@id": "_:b12",
+    "@type": ["http://sinopia.io/vocabulary/LookupPropertyTemplate"],
+    "http://sinopia.io/vocabulary/hasAuthority": [
+      {
+        "@id": "file:/propertyAttribute.json"
+      }
+    ]
+  },
+  {
+    "@id": "_:b14",
+    "@type": ["http://sinopia.io/vocabulary/PropertyTemplate"],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Property type"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasRemark": [
+      {
+        "@value": "Type of property."
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyUri": [
+      {
+        "@id": "http://sinopia.io/vocabulary/hasPropertyType"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyAttribute": [
+      {
+        "@id": "http://sinopia.io/vocabulary/propertyAttribute/required"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyType": [
+      {
+        "@id": "http://sinopia.io/vocabulary/propertyType/uri"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasLookupAttributes": [
+      {
+        "@id": "_:b15"
+      }
+    ]
+  },
+  {
+    "@id": "_:b15",
+    "@type": ["http://sinopia.io/vocabulary/LookupPropertyTemplate"],
+    "http://sinopia.io/vocabulary/hasAuthority": [
+      {
+        "@id": "file:/propertyType.json"
+      }
+    ]
+  },
+  {
+    "@id": "_:b17",
+    "@type": ["http://sinopia.io/vocabulary/PropertyTemplate"],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Literal attributes (if a literal)"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasRemark": [
+      {
+        "@value": "Attributes for a literal."
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyUri": [
+      {
+        "@id": "http://sinopia.io/vocabulary/hasLiteralAttributes"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyType": [
+      {
+        "@id": "http://sinopia.io/vocabulary/propertyType/resource"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasResourceAttributes": [
+      {
+        "@id": "_:b18"
+      }
+    ]
+  },
+  {
+    "@id": "_:b18",
+    "@type": ["http://sinopia.io/vocabulary/ResourcePropertyTemplate"],
+    "http://sinopia.io/vocabulary/hasResourceTemplateId": [
+      {
+        "@id": "sinopia:template:property:literal"
+      }
+    ]
+  },
+  {
+    "@id": "_:b20",
+    "@type": ["http://sinopia.io/vocabulary/PropertyTemplate"],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "URI attributes (if a URI)"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasRemark": [
+      {
+        "@value": "Attributes for a URI."
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyUri": [
+      {
+        "@id": "http://sinopia.io/vocabulary/hasUriAttributes"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyType": [
+      {
+        "@id": "http://sinopia.io/vocabulary/propertyType/resource"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasResourceAttributes": [
+      {
+        "@id": "_:b21"
+      }
+    ]
+  },
+  {
+    "@id": "_:b21",
+    "@type": ["http://sinopia.io/vocabulary/ResourcePropertyTemplate"],
+    "http://sinopia.io/vocabulary/hasResourceTemplateId": [
+      {
+        "@id": "sinopia:template:property:uri"
+      }
+    ]
+  },
+  {
+    "@id": "_:b23",
+    "@type": ["http://sinopia.io/vocabulary/PropertyTemplate"],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Lookup attributes (if a lookup)"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasRemark": [
+      {
+        "@value": "Attributes for a lookup."
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyUri": [
+      {
+        "@id": "http://sinopia.io/vocabulary/hasLookupAttributes"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyType": [
+      {
+        "@id": "http://sinopia.io/vocabulary/propertyType/resource"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasResourceAttributes": [
+      {
+        "@id": "_:b24"
+      }
+    ]
+  },
+  {
+    "@id": "_:b24",
+    "@type": ["http://sinopia.io/vocabulary/ResourcePropertyTemplate"],
+    "http://sinopia.io/vocabulary/hasResourceTemplateId": [
+      {
+        "@id": "sinopia:template:property:lookup"
+      }
+    ]
+  },
+  {
+    "@id": "_:b25",
+    "@type": ["http://sinopia.io/vocabulary/PropertyTemplate"],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Nested resource attributes (if a resource)"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasRemark": [
+      {
+        "@value": "Attributes for a nested resource."
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyUri": [
+      {
+        "@id": "http://sinopia.io/vocabulary/hasResourceAttributes"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyType": [
+      {
+        "@id": "http://sinopia.io/vocabulary/propertyType/resource"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasResourceAttributes": [
+      {
+        "@id": "_:b26"
+      }
+    ]
+  },
+  {
+    "@id": "_:b26",
+    "@type": ["http://sinopia.io/vocabulary/ResourcePropertyTemplate"],
+    "http://sinopia.io/vocabulary/hasResourceTemplateId": [
+      {
+        "@id": "sinopia:template:property:resource"
+      }
+    ]
+  },
+  {
+    "@id": "_:b3",
+    "@type": ["http://sinopia.io/vocabulary/PropertyTemplate"],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Property"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasRemark": [
+      {
+        "@value": "The property's URI."
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyUri": [
+      {
+        "@id": "http://sinopia.io/vocabulary/hasPropertyUri"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyAttribute": [
+      {
+        "@id": "http://sinopia.io/vocabulary/propertyAttribute/required"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyType": [
+      {
+        "@id": "http://sinopia.io/vocabulary/propertyType/uri"
+      }
+    ]
+  },
+  {
+    "@id": "_:b5",
+    "@type": ["http://sinopia.io/vocabulary/PropertyTemplate"],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Label"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasRemark": [
+      {
+        "@value": "The property's label."
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyUri": [
+      {
+        "@id": "http://www.w3.org/2000/01/rdf-schema#label"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyAttribute": [
+      {
+        "@id": "http://sinopia.io/vocabulary/propertyAttribute/required"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyType": [
+      {
+        "@id": "http://sinopia.io/vocabulary/propertyType/literal"
+      }
+    ]
+  },
+  {
+    "@id": "_:b7",
+    "@type": ["http://sinopia.io/vocabulary/PropertyTemplate"],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Remark"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasRemark": [
+      {
+        "@value": "The property's remark (literal)."
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyUri": [
+      {
+        "@id": "http://sinopia.io/vocabulary/hasRemark"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyType": [
+      {
+        "@id": "http://sinopia.io/vocabulary/propertyType/literal"
+      }
+    ]
+  },
+  {
+    "@id": "_:b9",
+    "@type": ["http://sinopia.io/vocabulary/PropertyTemplate"],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Remark URL"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasRemark": [
+      {
+        "@value": "The property's remark (URL)."
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyUri": [
+      {
+        "@id": "http://sinopia.io/vocabulary/hasRemarkUrl"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyType": [
+      {
+        "@id": "http://sinopia.io/vocabulary/propertyType/uri"
+      }
+    ]
+  },
+  {
+    "@id": "sinopia:template:property",
+    "http://sinopia.io/vocabulary/hasResourceTemplate": [
+      {
+        "@value": "sinopia:template:resource"
+      }
+    ],
+    "@type": ["http://sinopia.io/vocabulary/ResourceTemplate"],
+    "http://sinopia.io/vocabulary/hasResourceId": [
+      {
+        "@value": "sinopia:template:property"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasClass": [
+      {
+        "@id": "http://sinopia.io/vocabulary/PropertyTemplate"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Property template"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasRemark": [
+      {
+        "@value": "Template for creating property templates."
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyTemplate": [
+      {
+        "@list": [
+          {
+            "@id": "_:b3"
+          },
+          {
+            "@id": "_:b5"
+          },
+          {
+            "@id": "_:b7"
+          },
+          {
+            "@id": "_:b9"
+          },
+          {
+            "@id": "_:b11"
+          },
+          {
+            "@id": "_:b14"
+          },
+          {
+            "@id": "_:b17"
+          },
+          {
+            "@id": "_:b20"
+          },
+          {
+            "@id": "_:b23"
+          },
+          {
+            "@id": "_:b25"
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/static/templates/rt_resource_property_attrs_doc.json
+++ b/static/templates/rt_resource_property_attrs_doc.json
@@ -1,0 +1,86 @@
+[
+  {
+    "@id": "_:b2",
+    "@type": ["http://sinopia.io/vocabulary/PropertyTemplate"],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Resource Template IDs"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasRemark": [
+      {
+        "@value": "Resource Template IDs, e.g., ld4p:RT:bf2:Title:AbbrTitle."
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyUri": [
+      {
+        "@id": "http://sinopia.io/vocabulary/hasResourceTemplateId"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyAttribute": [
+      {
+        "@id": "http://sinopia.io/vocabulary/propertyAttribute/required"
+      },
+      {
+        "@id": "http://sinopia.io/vocabulary/propertyAttribute/repeatable"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyType": [
+      {
+        "@id": "http://sinopia.io/vocabulary/propertyType/uri"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasLookupAttributes": [
+      {
+        "@id": "_:b3"
+      }
+    ]
+  },
+  {
+    "@id": "_:b3",
+    "@type": ["http://sinopia.io/vocabulary/LookupPropertyTemplate"],
+    "http://sinopia.io/vocabulary/hasAuthority": [
+      {
+        "@id": "urn:ld4p:sinopia:resourceTemplate"
+      }
+    ]
+  },
+  {
+    "@id": "sinopia:template:property:resource",
+    "http://sinopia.io/vocabulary/hasResourceTemplate": [
+      {
+        "@value": "sinopia:template:resource"
+      }
+    ],
+    "@type": ["http://sinopia.io/vocabulary/ResourceTemplate"],
+    "http://sinopia.io/vocabulary/hasResourceId": [
+      {
+        "@value": "sinopia:template:property:resource"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasClass": [
+      {
+        "@id": "http://sinopia.io/vocabulary/ResourcePropertyTemplate"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Resource attributes"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasRemark": [
+      {
+        "@value": "Attributes for a nested resource."
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyTemplate": [
+      {
+        "@list": [
+          {
+            "@id": "_:b2"
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/static/templates/rt_resource_template_doc.json
+++ b/static/templates/rt_resource_template_doc.json
@@ -1,0 +1,312 @@
+[
+  {
+    "@id": "_:b11",
+    "@type": ["http://sinopia.io/vocabulary/PropertyTemplate"],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Remark"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasRemark": [
+      {
+        "@value": "The resource's remark."
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyUri": [
+      {
+        "@id": "http://sinopia.io/vocabulary/hasRemark"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyType": [
+      {
+        "@id": "http://sinopia.io/vocabulary/propertyType/literal"
+      }
+    ]
+  },
+  {
+    "@id": "_:b13",
+    "@type": ["http://sinopia.io/vocabulary/PropertyTemplate"],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Date"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasRemark": [
+      {
+        "@value": "The resource's date."
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyUri": [
+      {
+        "@id": "http://sinopia.io/vocabulary/hasDate"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyType": [
+      {
+        "@id": "http://sinopia.io/vocabulary/propertyType/literal"
+      }
+    ]
+  },
+  {
+    "@id": "_:b14",
+    "@type": ["http://sinopia.io/vocabulary/PropertyTemplate"],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Property templates"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasRemark": [
+      {
+        "@value": "The resource's property templates."
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyUri": [
+      {
+        "@id": "http://sinopia.io/vocabulary/hasPropertyTemplate"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyAttribute": [
+      {
+        "@id": "http://sinopia.io/vocabulary/propertyAttribute/repeatable"
+      },
+      {
+        "@id": "http://sinopia.io/vocabulary/propertyAttribute/ordered"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyType": [
+      {
+        "@id": "http://sinopia.io/vocabulary/propertyType/resource"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasResourceAttributes": [
+      {
+        "@id": "_:b15"
+      }
+    ]
+  },
+  {
+    "@id": "_:b15",
+    "@type": ["http://sinopia.io/vocabulary/ResourcePropertyTemplate"],
+    "http://sinopia.io/vocabulary/hasResourceTemplateId": [
+      {
+        "@id": "sinopia:template:property"
+      }
+    ]
+  },
+  {
+    "@id": "_:b3",
+    "@type": ["http://sinopia.io/vocabulary/PropertyTemplate"],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Template ID"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasRemark": [
+      {
+        "@value": "The resource's Template ID, e.g., ld4p:RT:bf2:Title:AbbrTitle."
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyUri": [
+      {
+        "@id": "http://sinopia.io/vocabulary/hasResourceId"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyAttribute": [
+      {
+        "@id": "http://sinopia.io/vocabulary/propertyAttribute/required"
+      },
+      {
+        "@id": "http://sinopia.io/vocabulary/propertyAttribute/immutable"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyType": [
+      {
+        "@id": "http://sinopia.io/vocabulary/propertyType/literal"
+      }
+    ]
+  },
+  {
+    "@id": "_:b5",
+    "@type": ["http://sinopia.io/vocabulary/PropertyTemplate"],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Class"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasRemark": [
+      {
+        "@value": "The resource's class, e.g., http://id.loc.gov/ontologies/bibframe/AbbreviatedTitle."
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyUri": [
+      {
+        "@id": "http://sinopia.io/vocabulary/hasClass"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyAttribute": [
+      {
+        "@id": "http://sinopia.io/vocabulary/propertyAttribute/required"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyType": [
+      {
+        "@id": "http://sinopia.io/vocabulary/propertyType/uri"
+      }
+    ]
+  },
+  {
+    "@id": "_:b7",
+    "@type": ["http://sinopia.io/vocabulary/PropertyTemplate"],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Template Label"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasRemark": [
+      {
+        "@value": "The template's label."
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyUri": [
+      {
+        "@id": "http://www.w3.org/2000/01/rdf-schema#label"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyAttribute": [
+      {
+        "@id": "http://sinopia.io/vocabulary/propertyAttribute/required"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyType": [
+      {
+        "@id": "http://sinopia.io/vocabulary/propertyType/literal"
+      }
+    ]
+  },
+  {
+    "@id": "_:b9",
+    "@type": ["http://sinopia.io/vocabulary/PropertyTemplate"],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Author"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasRemark": [
+      {
+        "@value": "The resource's author."
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyUri": [
+      {
+        "@id": "http://sinopia.io/vocabulary/hasAuthor"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyType": [
+      {
+        "@id": "http://sinopia.io/vocabulary/propertyType/literal"
+      }
+    ]
+  },
+  {
+    "@id": "_:b16",
+    "@type": ["http://sinopia.io/vocabulary/PropertyTemplate"],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Resource attributes"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasRemark": [
+      {
+        "@value": "Whether resource is suppressible (must have only one property which is a lookup or URI)."
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyUri": [
+      {
+        "@id": "http://sinopia.io/vocabulary/hasResourceAttribute"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyAttribute": [
+      {
+        "@id": "http://sinopia.io/vocabulary/propertyAttribute/repeatable"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyType": [
+      {
+        "@id": "http://sinopia.io/vocabulary/propertyType/uri"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasLookupAttributes": [
+      {
+        "@id": "_:b17"
+      }
+    ]
+  },
+  {
+    "@id": "_:b17",
+    "@type": ["http://sinopia.io/vocabulary/LookupPropertyTemplate"],
+    "http://sinopia.io/vocabulary/hasAuthority": [
+      {
+        "@id": "file:/resourceAttribute.json"
+      }
+    ]
+  },
+  {
+    "@id": "sinopia:template:resource",
+    "http://sinopia.io/vocabulary/hasResourceTemplate": [
+      {
+        "@value": "sinopia:template:resource"
+      }
+    ],
+    "@type": ["http://sinopia.io/vocabulary/ResourceTemplate"],
+    "http://sinopia.io/vocabulary/hasResourceId": [
+      {
+        "@value": "sinopia:template:resource"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasClass": [
+      {
+        "@id": "http://sinopia.io/vocabulary/ResourceTemplate"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Resource template"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasRemark": [
+      {
+        "@value": "Template for creating resource templates."
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyTemplate": [
+      {
+        "@list": [
+          {
+            "@id": "_:b3"
+          },
+          {
+            "@id": "_:b5"
+          },
+          {
+            "@id": "_:b7"
+          },
+          {
+            "@id": "_:b9"
+          },
+          {
+            "@id": "_:b11"
+          },
+          {
+            "@id": "_:b13"
+          },
+          {
+            "@id": "_:b16"
+          },
+          {
+            "@id": "_:b14"
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/static/templates/rt_uri_doc.json
+++ b/static/templates/rt_uri_doc.json
@@ -1,0 +1,96 @@
+[
+  {
+    "@id": "_:b3",
+    "@type": ["http://sinopia.io/vocabulary/PropertyTemplate"],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "URI"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasRemark": [
+      {
+        "@value": "URI"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyUri": [
+      {
+        "@id": "http://sinopia.io/vocabulary/hasUri"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyAttribute": [
+      {
+        "@id": "http://sinopia.io/vocabulary/propertyAttribute/required"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyType": [
+      {
+        "@id": "http://sinopia.io/vocabulary/propertyType/uri"
+      }
+    ]
+  },
+  {
+    "@id": "_:b4",
+    "@type": ["http://sinopia.io/vocabulary/PropertyTemplate"],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Label"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasRemark": [
+      {
+        "@value": "Label"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyUri": [
+      {
+        "@id": "http://www.w3.org/2000/01/rdf-schema#label"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyType": [
+      {
+        "@id": "http://sinopia.io/vocabulary/propertyType/literal"
+      }
+    ]
+  },
+  {
+    "@id": "sinopia:template:uri",
+    "http://sinopia.io/vocabulary/hasResourceTemplate": [
+      {
+        "@value": "sinopia:template:resource"
+      }
+    ],
+    "@type": ["http://sinopia.io/vocabulary/ResourceTemplate"],
+    "http://sinopia.io/vocabulary/hasResourceId": [
+      {
+        "@value": "sinopia:template:uri"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasClass": [
+      {
+        "@id": "http://sinopia.io/vocabulary/Uri"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "URI"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasRemark": [
+      {
+        "@value": "A URI."
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyTemplate": [
+      {
+        "@list": [
+          {
+            "@id": "_:b3"
+          },
+          {
+            "@id": "_:b4"
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/static/templates/rt_uri_property_attrs_doc.json
+++ b/static/templates/rt_uri_property_attrs_doc.json
@@ -1,0 +1,83 @@
+[
+  {
+    "@id": "_:b2",
+    "@type": ["http://sinopia.io/vocabulary/PropertyTemplate"],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Defaults"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasRemark": [
+      {
+        "@value": "Default URIs."
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyUri": [
+      {
+        "@id": "http://sinopia.io/vocabulary/hasDefault"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyAttribute": [
+      {
+        "@id": "http://sinopia.io/vocabulary/propertyAttribute/repeatable"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyType": [
+      {
+        "@id": "http://sinopia.io/vocabulary/propertyType/resource"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasResourceAttributes": [
+      {
+        "@id": "_:b3"
+      }
+    ]
+  },
+  {
+    "@id": "_:b3",
+    "@type": ["http://sinopia.io/vocabulary/ResourcePropertyTemplate"],
+    "http://sinopia.io/vocabulary/hasResourceTemplateId": [
+      {
+        "@id": "sinopia:template:uri"
+      }
+    ]
+  },
+  {
+    "@id": "sinopia:template:property:uri",
+    "http://sinopia.io/vocabulary/hasResourceTemplate": [
+      {
+        "@value": "sinopia:template:resource"
+      }
+    ],
+    "@type": ["http://sinopia.io/vocabulary/ResourceTemplate"],
+    "http://sinopia.io/vocabulary/hasResourceId": [
+      {
+        "@value": "sinopia:template:property:uri"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasClass": [
+      {
+        "@id": "http://sinopia.io/vocabulary/UriPropertyTemplate"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "URI attributes"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasRemark": [
+      {
+        "@value": "Attributes for a URI property."
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyTemplate": [
+      {
+        "@list": [
+          {
+            "@id": "_:b2"
+          }
+        ]
+      }
+    ]
+  }
+]


### PR DESCRIPTION
part of #3266

## Why was this change made?
Easier maintenance and deploy of base templates.


## How was this change tested?



## Which documentation and/or configurations were updated?



