### PR TITLE
add configurations for validation of literals

### DIFF
--- a/src/components/vocabulary/Vocab.js
+++ b/src/components/vocabulary/Vocab.js
@@ -48,6 +48,10 @@ const vocabulary = {
       "The template used in creating, editing, or updating a resource",
     url: "http://sinopia.io/vocabulary/hasResourceTemplate",
   },
+  hasValidationDataType: {
+    description: "Data Type to validate the literal, e.g. integer or dateTime",
+    url: "http://sinopia.io/vocabulary/hasValidationDataType",
+  },
   hasValidationRegex: {
     description: "Regular Expression to validate a literal",
     url: "http://sinopia.io/vocabulary/hasValidationRegex",

--- a/src/components/vocabulary/Vocab.js
+++ b/src/components/vocabulary/Vocab.js
@@ -48,6 +48,10 @@ const vocabulary = {
       "The template used in creating, editing, or updating a resource",
     url: "http://sinopia.io/vocabulary/hasResourceTemplate",
   },
+  hasValidationRegex: {
+    description: "Regular Expression to validate a literal",
+    url: "http://sinopia.io/vocabulary/hasValidationRegex",
+  },
   PropertyTemplate: {
     description: "",
     url: "http://sinopia.io/vocabulary/PropertyTemplate",

--- a/static/authorityConfig.json
+++ b/static/authorityConfig.json
@@ -2291,5 +2291,10 @@
     "label": "resourceAttribute",
     "uri": "file:/resourceAttribute.json",
     "component": "list"
+  },
+  {
+    "label": "literal validation data type",
+    "uri": "file:/literalDataType.json",
+    "component": "list"
   }
 ]

--- a/static/literalDataType.json
+++ b/static/literalDataType.json
@@ -1,0 +1,18 @@
+[
+  {
+    "uri": "http://www.w3.org/2001/XMLSchema/integer",
+    "label": "Integer (xsd:integer)"
+  },
+  {
+    "uri": "http://www.w3.org/2001/XMLSchema/dateTime",
+    "label": "Date and time with or without timezone (xsd:dateTime)"
+  },
+  {
+    "uri": "http://www.w3.org/2001/XMLSchema/dateTimeStamp",
+    "label": "Date and time with required timezone (xsd:dateTimeStamp)"
+  },
+  {
+    "uri": "http://id.loc.gov/datatypes/edtf",
+    "label": "Extended Date/Time Format (EDTF)"
+  }
+]

--- a/static/templates/rt_literal_property_attrs_doc.json
+++ b/static/templates/rt_literal_property_attrs_doc.json
@@ -29,6 +29,32 @@
     ]
   },
   {
+    "@id": "_:b3",
+    "@type": [
+      "http://sinopia.io/vocabulary/PropertyTemplate"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Validation Regular Expression"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasRemark": [
+      {
+        "@value": "Regular Expression to validate the literal."
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyUri": [
+      {
+        "@id": "http://sinopia.io/vocabulary/hasValidationRegex"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyType": [
+      {
+        "@id": "http://sinopia.io/vocabulary/propertyType/literal"
+      }
+    ]
+  },
+  {
     "@id": "sinopia:template:property:literal",
     "http://sinopia.io/vocabulary/hasResourceTemplate": [
       {
@@ -61,6 +87,9 @@
         "@list": [
           {
             "@id": "_:b2"
+          },
+          {
+            "@id": "_:b3"
           }
         ]
       }

--- a/static/templates/rt_literal_property_attrs_doc.json
+++ b/static/templates/rt_literal_property_attrs_doc.json
@@ -30,9 +30,7 @@
   },
   {
     "@id": "_:b3",
-    "@type": [
-      "http://sinopia.io/vocabulary/PropertyTemplate"
-    ],
+    "@type": ["http://sinopia.io/vocabulary/PropertyTemplate"],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
         "@value": "Validation Regular Expression"
@@ -51,6 +49,44 @@
     "http://sinopia.io/vocabulary/hasPropertyType": [
       {
         "@id": "http://sinopia.io/vocabulary/propertyType/literal"
+      }
+    ]
+  },
+  {
+    "@id": "_:b4",
+    "@type": ["http://sinopia.io/vocabulary/PropertyTemplate"],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Validation Data Type"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasRemark": [
+      {
+        "@value": "Data Type to validate the literal, e.g. integer or dateTime."
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyUri": [
+      {
+        "@id": "http://sinopia.io/vocabulary/hasValidationDataType"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyType": [
+      {
+        "@id": "http://sinopia.io/vocabulary/propertyType/uri"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasLookupAttributes": [
+      {
+        "@id": "_:b5"
+      }
+    ]
+  },
+  {
+    "@id": "_:b5",
+    "@type": ["http://sinopia.io/vocabulary/LookupPropertyTemplate"],
+    "http://sinopia.io/vocabulary/hasAuthority": [
+      {
+        "@id": "file:/literalDataType.json"
       }
     ]
   },
@@ -90,6 +126,9 @@
           },
           {
             "@id": "_:b3"
+          },
+          {
+            "@id": "_:b4"
           }
         ]
       }


### PR DESCRIPTION
closes #2907

## Why was this change made?
Allow template author to specify a regex for a literal field.


## How was this change tested?



## Which documentation and/or configurations were updated?



