### PR TITLE
remove extra class that was adding extra close button to help

### DIFF
--- a/src/components/menu/CanvasMenu.jsx
+++ b/src/components/menu/CanvasMenu.jsx
@@ -28,7 +28,7 @@ const CanvasMenu = (props) => {
       <button
         type="button"
         aria-label="Close Help Menu"
-        className="btn-close pull-right"
+        className="btn pull-right"
         href="#"
         onClick={props.closeHandleMenu}
       >


### PR DESCRIPTION
## Why was this change made?

Fixes #3302 - get rid of extra close button in help menu:

![Screen Shot 2021-11-05 at 2 53 07 PM](https://user-images.githubusercontent.com/47137/140582883-103b878a-cefe-4729-aa93-b20d37737db4.png)

## How was this change tested?

Localhost

## Which documentation and/or configurations were updated?



