### PR TITLE
set z-index for dropdown so it stays on top

### DIFF
--- a/src/hooks/useNavLink.js
+++ b/src/hooks/useNavLink.js
@@ -37,7 +37,10 @@ const useNavLink = (navObj) => {
     event.preventDefault()
 
     const elem = document.querySelector(`#${navTargetId}`)
-    if (!isInViewport(elem)) elem.scrollIntoView({ behavior: "smooth" })
+    if (!isInViewport(elem)) {
+      const y = elem.getBoundingClientRect().top + window.pageYOffset - 90 // do not scroll to top, leave space for header row
+      window.scrollTo({ top: y, behavior: "smooth" })
+    }
     dispatch(
       setCurrentComponent(
         navObj.rootSubjectKey,

--- a/src/styles/bootstrap-override.scss
+++ b/src/styles/bootstrap-override.scss
@@ -26,7 +26,7 @@ $primary-disabled: lighten(map-get($theme-colors, "secondary"), 20%);
 }
 
 .dropdown-menu {
-  z-index: 3000;
+  z-index: $zindex-sticky + 1;
 }
 
 body {

--- a/src/styles/bootstrap-override.scss
+++ b/src/styles/bootstrap-override.scss
@@ -25,6 +25,10 @@ $primary-disabled: lighten(map-get($theme-colors, "secondary"), 20%);
   text-decoration: underline;
 }
 
+.dropdown-menu {
+  z-index: 3000;
+}
+
 body {
   font-family: "Source Sans Pro", sans-serif;
   margin: 0 20px;


### PR DESCRIPTION
## Why was this change made?

Fixes #3310:

- adjust zindex for drop-downs to ensure they stay on top
- adjust scroll position for left nav links to account for header

**Drop down menu no longer obscured:**

![Screen Shot 2021-11-08 at 4 36 56 PM](https://user-images.githubusercontent.com/47137/140840367-a7cbea5d-06bf-4afc-99b8-e3ee5faa2ec5.png)

**After clicking "Template Label" in left nav, scroll position set correctly:**

![Screen Shot 2021-11-08 at 4 37 03 PM](https://user-images.githubusercontent.com/47137/140840406-af0f5b73-0094-4639-85d0-43cd9b010adc.png)

## How was this change tested?

Localhost


## Which documentation and/or configurations were updated?



