### PR TITLE
literal with validationDataType does not display language button

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ A "resource template" is comprised of one or more "property templates."  But the
 
 **base templates** are in the `static/templates/` folder, and may themselves refer to files up a level in the `static/` folder.  The loading of the base templates is baked into the sinopia_editor code.
 
-Reiterating: the UI widgets displayed for a property template are driven by what is in the `static/` folder and its subfolders.  There is no additional deployment necessary.
+Reiterating: the UI widgets displayed for creating/editing a property template are driven by what is in the `static/` folder and its subfolders.  There is no additional deployment necessary.
 
 #### Updates to https://sinopia.io/vocabulary
 

--- a/__tests__/TemplatesBuilder.test.js
+++ b/__tests__/TemplatesBuilder.test.js
@@ -89,7 +89,7 @@ _:b1_c14n0 <http://www.w3.org/2000/01/rdf-schema#label> "Uber template1, propert
     )
   })
 
-  it("builds literal property template", async () => {
+  it("builds literal property template with validationDataType value", async () => {
     const rdf = `<> <http://sinopia.io/vocabulary/hasClass> <http://id.loc.gov/ontologies/bibframe/Uber1> .
 <> <http://sinopia.io/vocabulary/hasPropertyTemplate> _:b1_c14n1 .
 <> <http://sinopia.io/vocabulary/hasResourceId> <resourceTemplate:testing:uber1> .
@@ -126,6 +126,49 @@ _:b2_c14n1 <http://sinopia.io/vocabulary/hasValidationDataType> <http://www.w3.o
         type: "literal",
         validationRegex: "^\\d+$",
         validationDataType: "http://www.w3.org/2001/XMLSchema/integer",
+        languageSuppressed: true,
+        component: "InputLiteral",
+      })
+    )
+  })
+
+  it("builds literal property template without validationDataType value", async () => {
+    const rdf = `<> <http://sinopia.io/vocabulary/hasClass> <http://id.loc.gov/ontologies/bibframe/Uber1> .
+<> <http://sinopia.io/vocabulary/hasPropertyTemplate> _:b1_c14n1 .
+<> <http://sinopia.io/vocabulary/hasResourceId> <resourceTemplate:testing:uber1> .
+<> <http://sinopia.io/vocabulary/hasResourceTemplate> "sinopia:template:resource" .
+<> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://sinopia.io/vocabulary/ResourceTemplate> .
+<> <http://www.w3.org/2000/01/rdf-schema#label> "Uber template1"@eng .
+<http://sinopia.io/vocabulary/propertyType/literal> <http://www.w3.org/2000/01/rdf-schema#label> "literal" .
+_:b1_c14n1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b2_c14n0 .
+_:b1_c14n1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b2_c14n0 <http://sinopia.io/vocabulary/hasLiteralAttributes> _:b2_c14n1 .
+_:b2_c14n0 <http://sinopia.io/vocabulary/hasPropertyType> <http://sinopia.io/vocabulary/propertyType/literal> .
+_:b2_c14n0 <http://sinopia.io/vocabulary/hasPropertyUri> <http://id.loc.gov/ontologies/bibframe/uber/template1/property1> .
+_:b2_c14n0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://sinopia.io/vocabulary/PropertyTemplate> .
+_:b2_c14n0 <http://www.w3.org/2000/01/rdf-schema#label> "Uber template1, property2"@eng .
+_:b2_c14n1 <http://sinopia.io/vocabulary/hasDefault> "default1"@eng .
+_:b2_c14n1 <http://sinopia.io/vocabulary/hasDefault> "default2" .
+_:b2_c14n1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://sinopia.io/vocabulary/LiteralPropertyTemplate> .
+_:b2_c14n1 <http://sinopia.io/vocabulary/hasValidationRegex> "^\\\\d+$"@eng .`
+    const dataset = await datasetFromN3(rdf)
+    const subjectTemplate = new TemplatesBuilder(dataset, "").build()
+    expect(subjectTemplate.propertyTemplates[0]).toStrictEqual(
+      build.propertyTemplate({
+        subjectTemplateKey: "resourceTemplate:testing:uber1",
+        label: "Uber template1, property2",
+        uris: {
+          "http://id.loc.gov/ontologies/bibframe/uber/template1/property1":
+            "http://id.loc.gov/ontologies/bibframe/uber/template1/property1",
+        },
+        defaults: [
+          { literal: "default1", lang: "eng" },
+          { literal: "default2", lang: null },
+        ],
+        type: "literal",
+        validationRegex: "^\\d+$",
+        validationDataType: null,
+        languageSuppressed: false,
         component: "InputLiteral",
       })
     )

--- a/src/TemplatesBuilder.js
+++ b/src/TemplatesBuilder.js
@@ -129,8 +129,11 @@ export default class TemplatesBuilder {
     propertyTemplate.defaults = this.defaultsForLiteral(propertyTerm)
     propertyTemplate.validationRegex =
       this.validationRegexForLiteral(propertyTerm)
-    propertyTemplate.validationDataType =
-      this.validationDataTypeForLiteral(propertyTerm)
+    const validationDataType = this.validationDataTypeForLiteral(propertyTerm)
+    if (validationDataType) {
+      propertyTemplate.languageSuppressed = true
+      propertyTemplate.validationDataType = validationDataType
+    }
     propertyTemplate.component = "InputLiteral"
     return propertyTemplate
   }


### PR DESCRIPTION
## Why was this change made?

Fixes #3287

When a property template has a literal which has a validationDataType specified, then a resource using that property template should not display the language button for the literal with the validationDataType.

### After

Look!  no language button!

![image](https://user-images.githubusercontent.com/96775/142041185-99135c69-ca1b-49e3-8f40-a2b3a6b43d8d.png)

from this property template:

![image](https://user-images.githubusercontent.com/96775/142041412-c5657b92-dadd-4a0b-be0d-56960baefbce.png)


## How was this change tested?

with a new unit test, and locally (see pix above)


## Which documentation and/or configurations were updated?



