### PR TITLE
Keep the link button on the same line as the URL field

### DIFF
--- a/src/components/editor/inputs/InputURIValue.jsx
+++ b/src/components/editor/inputs/InputURIValue.jsx
@@ -126,7 +126,7 @@ const InputURIValue = ({
         <label htmlFor={uriId} className="col-sm-1 col-form-label">
           URI
         </label>
-        <div className="col-sm-11">
+        <div className="col-sm-10">
           <TextareaAutosize
             required={propertyTemplate.required}
             className={uriControlClasses.join(" ")}
@@ -146,8 +146,8 @@ const InputURIValue = ({
             {uriErrors.join(", ")}
           </div>
         </div>
-        {showLink && (
-          <div className="col-md-auto d-flex align-items-end pb-2 ps-0">
+        <div className="col-md-auto d-flex align-items-end pb-2 ps-0">
+          {showLink && (
             <a
               href={currentURIContent}
               target="_blank"
@@ -160,8 +160,8 @@ const InputURIValue = ({
                 icon={faExternalLinkAlt}
               />
             </a>
-          </div>
-        )}
+          )}
+        </div>
       </div>
 
       <div className="row my-2">


### PR DESCRIPTION


## Why was this change made?
Fixes #3334


## How was this change tested?

<img width="1154" alt="Screen Shot 2021-11-16 at 3 37 45 PM" src="https://user-images.githubusercontent.com/92044/142069809-f1d68f5b-3c88-4fcf-ac8a-d70e91ce7268.png">


## Which documentation and/or configurations were updated?



