### PR TITLE
suppress language button for literal hasValidationRegex and hasValidtionDataType

### DIFF
--- a/static/templates/rt_literal_property_attrs_doc.json
+++ b/static/templates/rt_literal_property_attrs_doc.json
@@ -46,6 +46,11 @@
         "@id": "http://sinopia.io/vocabulary/hasValidationRegex"
       }
     ],
+    "http://sinopia.io/vocabulary/hasPropertyAttribute": [
+      {
+        "@id": "http://sinopia.io/vocabulary/propertyAttribute/languageSuppressed"
+      }
+    ],
     "http://sinopia.io/vocabulary/hasPropertyType": [
       {
         "@id": "http://sinopia.io/vocabulary/propertyType/literal"
@@ -68,6 +73,11 @@
     "http://sinopia.io/vocabulary/hasPropertyUri": [
       {
         "@id": "http://sinopia.io/vocabulary/hasValidationDataType"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyAttribute": [
+      {
+        "@id": "http://sinopia.io/vocabulary/propertyAttribute/languageSuppressed"
       }
     ],
     "http://sinopia.io/vocabulary/hasPropertyType": [


### PR DESCRIPTION
## Why was this change made?

Fixes #3332 

### Before

note laguage "button"

![image](https://user-images.githubusercontent.com/96775/142047511-fa49981a-a34a-41f0-abfd-4e0341b98c62.png)

### After

![image](https://user-images.githubusercontent.com/96775/142078831-fb79fa71-5b16-469e-ae1b-dcaa7eb9ac0a.png)


## How was this change tested?

locally, unit tests.

## Which documentation and/or configurations were updated?



