### PR TITLE
Validate literals as literals, not URIs.

### DIFF
--- a/__tests__/reducers/resourceValidationHelpers.test.js
+++ b/__tests__/reducers/resourceValidationHelpers.test.js
@@ -32,6 +32,7 @@ describe("new literal value with validationDataType of integer", () => {
             uri: null,
             label: null,
             valueSubjectKey: null,
+            component: "InputLiteralValue",
           },
         },
       }
@@ -60,6 +61,7 @@ describe("new literal value with validationDataType of integer", () => {
             uri: null,
             label: null,
             valueSubjectKey: null,
+            component: "InputLiteralValue",
           },
         },
       }
@@ -161,6 +163,7 @@ describe("new literal value with validationDataType of dateTime", () => {
             uri: null,
             label: null,
             valueSubjectKey: null,
+            component: "InputLiteralValue",
           },
         },
       }
@@ -189,6 +192,7 @@ describe("new literal value with validationDataType of dateTime", () => {
             uri: null,
             label: null,
             valueSubjectKey: null,
+            component: "InputLiteralValue",
           },
         },
       }
@@ -217,6 +221,7 @@ describe("new literal value with validationDataType of dateTime", () => {
             uri: null,
             label: null,
             valueSubjectKey: null,
+            component: "InputLiteralValue",
           },
         },
       }
@@ -249,6 +254,7 @@ describe("new literal value with validationDataType of dateTimeStamp", () => {
             uri: null,
             label: null,
             valueSubjectKey: null,
+            component: "InputLiteralValue",
           },
         },
       }
@@ -277,6 +283,7 @@ describe("new literal value with validationDataType of dateTimeStamp", () => {
             uri: null,
             label: null,
             valueSubjectKey: null,
+            component: "InputLiteralValue",
           },
         },
       }
@@ -305,6 +312,7 @@ describe("new literal value with validationDataType of dateTimeStamp", () => {
             uri: null,
             label: null,
             valueSubjectKey: null,
+            component: "InputLiteralValue",
           },
         },
       }

--- a/__tests__/reducers/resources.test.js
+++ b/__tests__/reducers/resources.test.js
@@ -532,6 +532,7 @@ describe("addValue()", () => {
             uri: null,
             label: null,
             valueSubjectKey: null,
+            component: "InputLiteralValue",
           },
         },
       }
@@ -549,6 +550,7 @@ describe("addValue()", () => {
         label: null,
         valueSubjectKey: null,
         errors: ["Literal required"],
+        component: "InputLiteralValue",
       })
       expect(newState.properties["JQEtq-vmq8"].valueKeys).toContain("DxGx7WMh3")
       expect(newState.properties["JQEtq-vmq8"].show).toBe(true)

--- a/src/reducers/resourceHelpers.js
+++ b/src/reducers/resourceHelpers.js
@@ -188,7 +188,7 @@ export const updateValueErrors = (state, valueKey) => {
   const propertyTemplate = state.propertyTemplates[property.propertyTemplateKey]
   // If this is first value, then must have a value.
   const errors = []
-  if (propertyTemplate.type === "literal") {
+  if (value.component === "InputLiteralValue") {
     errors.push(literalRequiredError(value, property, propertyTemplate))
     if (value.literal !== null && value.literal !== "") {
       errors.push(literalRegexValidationError(value, propertyTemplate))
@@ -196,9 +196,7 @@ export const updateValueErrors = (state, valueKey) => {
       errors.push(literalDateTimeValidationError(value, propertyTemplate))
       errors.push(literalDateTimeStampValidationError(value, propertyTemplate))
     }
-  }
-
-  if (propertyTemplate.type === "uri") {
+  } else if (propertyTemplate.type === "uri") {
     errors.push(uriPropertiesAndValueErrors(value, property, propertyTemplate))
   }
 


### PR DESCRIPTION
closes #3259

## Why was this change made?
In a particular corner case, literals were being mis-validated.


## How was this change tested?



## Which documentation and/or configurations were updated?



