### PR TITLE
GraphBuilder: add datatype declaration to literal value when present

### DIFF
--- a/__tests__/GraphBuilder.test.js
+++ b/__tests__/GraphBuilder.test.js
@@ -2,7 +2,10 @@ import GraphBuilder from "GraphBuilder"
 import ResourceBuilder from "resourceBuilderUtils"
 
 describe("GraphBuilder", () => {
-  const build = new ResourceBuilder({ injectPropertyIntoValue: true })
+  const build = new ResourceBuilder({
+    injectPropertyTemplateIntoValue: true,
+    injectPropertyIntoValue: true,
+  })
   describe("graph()", () => {
     it("builds a graph for literals", () => {
       const resource = build.subject({

--- a/__tests__/GraphBuilder.test.js
+++ b/__tests__/GraphBuilder.test.js
@@ -38,6 +38,44 @@ describe("GraphBuilder", () => {
       expect(new GraphBuilder(resource).graph.toCanonical()).toMatch(rdf)
     })
 
+    it("builds a graph for literal with validationDataType", () => {
+      const resource = build.subject({
+        subjectTemplate: build.subjectTemplate({
+          id: "resourceTemplate:testing:literalValidation",
+          clazz: "http://sinopia.io/testing/LiteralValidation",
+        }),
+        properties: [
+          build.literalProperty({
+            propertyTemplate: build.propertyTemplate({
+              subjectTemplateKey: "resourceTemplate:testing:literalValidation",
+              label: "literalValidation, integer validationDataType",
+              uris: {
+                "http://sinopia.io/testing/LiteralValidation/property3":
+                  "http://sinopia.io/testing/LiteralValidation/property3",
+              },
+              type: "literal",
+              validationDataType: "http://www.w3.org/2001/XMLSchema#integer",
+              languageSuppressed: true,
+              component: "InputLiteral",
+            }),
+            values: [
+              build.literalValue({
+                literal: "literal with dataType",
+                lang: null,
+                propertyUri:
+                  "http://sinopia.io/testing/LiteralValidation/property3",
+              }),
+            ],
+          }),
+        ],
+      })
+
+      const rdf = `<> <http://sinopia.io/testing/LiteralValidation/property3> "literal with dataType"^^<http://www.w3.org/2001/XMLSchema#integer> .
+<> <http://sinopia.io/vocabulary/hasResourceTemplate> "resourceTemplate:testing:literalValidation" .
+<> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://sinopia.io/testing/LiteralValidation> .`
+      expect(new GraphBuilder(resource).graph.toCanonical()).toMatch(rdf)
+    })
+
     it("builds a graph for uris", () => {
       const resource = build.subject({
         subjectTemplate: build.subjectTemplate({

--- a/__tests__/GraphBuilder.test.js
+++ b/__tests__/GraphBuilder.test.js
@@ -3,7 +3,7 @@ import ResourceBuilder from "resourceBuilderUtils"
 
 describe("GraphBuilder", () => {
   const build = new ResourceBuilder({
-    injectPropertyTemplateIntoValue: true,
+    injectPropertyKeyIntoValue: true,
     injectPropertyIntoValue: true,
   })
   describe("graph()", () => {

--- a/__tests__/__action_fixtures__/loadResource-ADD_SUBJECT-multiple-property-uris.js
+++ b/__tests__/__action_fixtures__/loadResource-ADD_SUBJECT-multiple-property-uris.js
@@ -1,7 +1,7 @@
 import ResourceBuilder from "resourceBuilderUtils"
 import subjectTemplate from "./subjectTemplate-multiple_property_uris"
 
-const build = new ResourceBuilder({ injectPropertyIntoValue: true })
+const build = new ResourceBuilder({ injectPropertyTemplateIntoValue: true })
 
 const expectedAction = {
   type: "ADD_SUBJECT",

--- a/__tests__/__action_fixtures__/loadResource-ADD_SUBJECT-multiple-property-uris.js
+++ b/__tests__/__action_fixtures__/loadResource-ADD_SUBJECT-multiple-property-uris.js
@@ -1,7 +1,7 @@
 import ResourceBuilder from "resourceBuilderUtils"
 import subjectTemplate from "./subjectTemplate-multiple_property_uris"
 
-const build = new ResourceBuilder({ injectPropertyTemplateIntoValue: true })
+const build = new ResourceBuilder({ injectPropertyKeyIntoValue: true })
 
 const expectedAction = {
   type: "ADD_SUBJECT",

--- a/__tests__/__action_fixtures__/loadResource-ADD_SUBJECT.js
+++ b/__tests__/__action_fixtures__/loadResource-ADD_SUBJECT.js
@@ -1,7 +1,7 @@
 import ResourceBuilder from "resourceBuilderUtils"
 import subjectTemplate from "./subjectTemplate-inputs"
 
-const build = new ResourceBuilder({ injectPropertyTemplateIntoValue: true })
+const build = new ResourceBuilder({ injectPropertyKeyIntoValue: true })
 
 const expectedAction = {
   type: "ADD_SUBJECT",

--- a/__tests__/__action_fixtures__/loadResource-ADD_SUBJECT.js
+++ b/__tests__/__action_fixtures__/loadResource-ADD_SUBJECT.js
@@ -1,7 +1,7 @@
 import ResourceBuilder from "resourceBuilderUtils"
 import subjectTemplate from "./subjectTemplate-inputs"
 
-const build = new ResourceBuilder({ injectPropertyIntoValue: true })
+const build = new ResourceBuilder({ injectPropertyTemplateIntoValue: true })
 
 const expectedAction = {
   type: "ADD_SUBJECT",

--- a/__tests__/__action_fixtures__/newResource-ADD_SUBJECT.js
+++ b/__tests__/__action_fixtures__/newResource-ADD_SUBJECT.js
@@ -1,7 +1,7 @@
 import ResourceBuilder from "resourceBuilderUtils"
 import subjectTemplate from "./subjectTemplate-inputs"
 
-const build = new ResourceBuilder({ injectPropertyTemplateIntoValue: true })
+const build = new ResourceBuilder({ injectPropertyKeyIntoValue: true })
 
 const expectedAction = {
   type: "ADD_SUBJECT",

--- a/__tests__/__action_fixtures__/newResource-ADD_SUBJECT.js
+++ b/__tests__/__action_fixtures__/newResource-ADD_SUBJECT.js
@@ -1,7 +1,7 @@
 import ResourceBuilder from "resourceBuilderUtils"
 import subjectTemplate from "./subjectTemplate-inputs"
 
-const build = new ResourceBuilder({ injectPropertyIntoValue: true })
+const build = new ResourceBuilder({ injectPropertyTemplateIntoValue: true })
 
 const expectedAction = {
   type: "ADD_SUBJECT",

--- a/__tests__/__action_fixtures__/newResourceCopy-ADD_SUBJECT.js
+++ b/__tests__/__action_fixtures__/newResourceCopy-ADD_SUBJECT.js
@@ -1,6 +1,6 @@
 import ResourceBuilder from "resourceBuilderUtils"
 
-const build = new ResourceBuilder({ injectPropertyTemplateIntoValue: true })
+const build = new ResourceBuilder({ injectPropertyKeyIntoValue: true })
 
 const expectedAction = {
   type: "ADD_SUBJECT",

--- a/__tests__/__action_fixtures__/newResourceCopy-ADD_SUBJECT.js
+++ b/__tests__/__action_fixtures__/newResourceCopy-ADD_SUBJECT.js
@@ -1,6 +1,6 @@
 import ResourceBuilder from "resourceBuilderUtils"
 
-const build = new ResourceBuilder({ injectPropertyIntoValue: true })
+const build = new ResourceBuilder({ injectPropertyTemplateIntoValue: true })
 
 const expectedAction = {
   type: "ADD_SUBJECT",

--- a/__tests__/__action_fixtures__/newResourceFromDataset-ADD_SUBJECT-bad-ordered.js
+++ b/__tests__/__action_fixtures__/newResourceFromDataset-ADD_SUBJECT-bad-ordered.js
@@ -1,7 +1,7 @@
 import ResourceBuilder from "resourceBuilderUtils"
 import orderedSubjectTemplate from "./subjectTemplate-ordered"
 
-const build = new ResourceBuilder({ injectPropertyIntoValue: true })
+const build = new ResourceBuilder({ injectPropertyTemplateIntoValue: true })
 
 const expectedAction = {
   type: "ADD_SUBJECT",

--- a/__tests__/__action_fixtures__/newResourceFromDataset-ADD_SUBJECT-bad-ordered.js
+++ b/__tests__/__action_fixtures__/newResourceFromDataset-ADD_SUBJECT-bad-ordered.js
@@ -1,7 +1,7 @@
 import ResourceBuilder from "resourceBuilderUtils"
 import orderedSubjectTemplate from "./subjectTemplate-ordered"
 
-const build = new ResourceBuilder({ injectPropertyTemplateIntoValue: true })
+const build = new ResourceBuilder({ injectPropertyKeyIntoValue: true })
 
 const expectedAction = {
   type: "ADD_SUBJECT",

--- a/__tests__/__action_fixtures__/newResourceFromDataset-ADD_SUBJECT-nested.js
+++ b/__tests__/__action_fixtures__/newResourceFromDataset-ADD_SUBJECT-nested.js
@@ -2,7 +2,7 @@ import ResourceBuilder from "resourceBuilderUtils"
 import suppressibleSubjectTemplate from "./subjectTemplate-suppressible"
 import uriSubjectTemplate from "./subjectTemplate-uri"
 
-const build = new ResourceBuilder({ injectPropertyIntoValue: true })
+const build = new ResourceBuilder({ injectPropertyTemplateIntoValue: true })
 
 const expectedAction = {
   type: "ADD_SUBJECT",

--- a/__tests__/__action_fixtures__/newResourceFromDataset-ADD_SUBJECT-nested.js
+++ b/__tests__/__action_fixtures__/newResourceFromDataset-ADD_SUBJECT-nested.js
@@ -2,7 +2,7 @@ import ResourceBuilder from "resourceBuilderUtils"
 import suppressibleSubjectTemplate from "./subjectTemplate-suppressible"
 import uriSubjectTemplate from "./subjectTemplate-uri"
 
-const build = new ResourceBuilder({ injectPropertyTemplateIntoValue: true })
+const build = new ResourceBuilder({ injectPropertyKeyIntoValue: true })
 
 const expectedAction = {
   type: "ADD_SUBJECT",

--- a/__tests__/__action_fixtures__/newResourceFromDataset-ADD_SUBJECT-ordered.js
+++ b/__tests__/__action_fixtures__/newResourceFromDataset-ADD_SUBJECT-ordered.js
@@ -2,7 +2,7 @@ import ResourceBuilder from "resourceBuilderUtils"
 import orderedSubjectTemplate from "./subjectTemplate-ordered"
 import literalSubjectTemplate from "./subjectTemplate-literal"
 
-const build = new ResourceBuilder({ injectPropertyTemplateIntoValue: true })
+const build = new ResourceBuilder({ injectPropertyKeyIntoValue: true })
 
 const expectedAction = {
   type: "ADD_SUBJECT",

--- a/__tests__/__action_fixtures__/newResourceFromDataset-ADD_SUBJECT-ordered.js
+++ b/__tests__/__action_fixtures__/newResourceFromDataset-ADD_SUBJECT-ordered.js
@@ -2,7 +2,7 @@ import ResourceBuilder from "resourceBuilderUtils"
 import orderedSubjectTemplate from "./subjectTemplate-ordered"
 import literalSubjectTemplate from "./subjectTemplate-literal"
 
-const build = new ResourceBuilder({ injectPropertyIntoValue: true })
+const build = new ResourceBuilder({ injectPropertyTemplateIntoValue: true })
 
 const expectedAction = {
   type: "ADD_SUBJECT",

--- a/__tests__/__action_fixtures__/newResourceFromDataset-ADD_SUBJECT.js
+++ b/__tests__/__action_fixtures__/newResourceFromDataset-ADD_SUBJECT.js
@@ -2,7 +2,7 @@ import ResourceBuilder from "resourceBuilderUtils"
 import inputsSubjectTemplate from "./subjectTemplate-inputs"
 import literalSubjectTemplate from "./subjectTemplate-literal"
 
-const build = new ResourceBuilder({ injectPropertyTemplateIntoValue: true })
+const build = new ResourceBuilder({ injectPropertyKeyIntoValue: true })
 
 const expectedAction = {
   type: "ADD_SUBJECT",

--- a/__tests__/__action_fixtures__/newResourceFromDataset-ADD_SUBJECT.js
+++ b/__tests__/__action_fixtures__/newResourceFromDataset-ADD_SUBJECT.js
@@ -2,7 +2,7 @@ import ResourceBuilder from "resourceBuilderUtils"
 import inputsSubjectTemplate from "./subjectTemplate-inputs"
 import literalSubjectTemplate from "./subjectTemplate-literal"
 
-const build = new ResourceBuilder({ injectPropertyIntoValue: true })
+const build = new ResourceBuilder({ injectPropertyTemplateIntoValue: true })
 
 const expectedAction = {
   type: "ADD_SUBJECT",

--- a/__tests__/testUtilities/resourceBuilderUtils.js
+++ b/__tests__/testUtilities/resourceBuilderUtils.js
@@ -5,8 +5,12 @@ import { findAuthorityConfig } from "utilities/authorityConfig"
  * Helper for building resources (and parts) and templates.
  */
 export default class ResourceBuilder {
-  constructor({ injectPropertyTemplateIntoValue = false } = {}) {
+  constructor({
+    injectPropertyTemplateIntoValue = false,
+    injectPropertyIntoValue = false,
+  } = {}) {
     this.injectPropertyTemplateIntoValue = injectPropertyTemplateIntoValue
+    this.injectPropertyIntoValue = injectPropertyIntoValue
   }
 
   key() {
@@ -155,14 +159,13 @@ export default class ResourceBuilder {
     if (propertyTemplateKey) property.propertyTemplateKey = propertyTemplateKey
     if (subjectKey) property.subjectKey = subjectKey
 
-    // Inject property into value
+    // Inject propertyTemplate into value
     if (!_.isEmpty(values) && this.injectPropertyTemplateIntoValue)
-      values.forEach((value) => {
-        value.propertyKey = property.key
-        if (value.literal && property?.propertyTemplate?.validationDataType) {
-          value.property = property
-        }
-      })
+      values.forEach((value) => (value.propertyKey = property.key))
+
+    // Inject property into value
+    if (!_.isEmpty(values) && this.injectPropertyIntoValue)
+      values.forEach((value) => (value.property = property))
 
     return property
   }

--- a/__tests__/testUtilities/resourceBuilderUtils.js
+++ b/__tests__/testUtilities/resourceBuilderUtils.js
@@ -157,7 +157,12 @@ export default class ResourceBuilder {
 
     // Inject property into value
     if (!_.isEmpty(values) && this.injectPropertyIntoValue)
-      values.forEach((value) => (value.propertyKey = property.key))
+      values.forEach((value) => {
+        value.propertyKey = property.key
+        if (value.literal && property?.propertyTemplate?.validationDataType) {
+          value.property = property
+        }
+      })
 
     return property
   }
@@ -185,7 +190,6 @@ export default class ResourceBuilder {
 
   literalValue({ literal, lang = "eng", ...props }) {
     assertProps({ literal })
-
     return this.value({
       literal,
       lang,

--- a/__tests__/testUtilities/resourceBuilderUtils.js
+++ b/__tests__/testUtilities/resourceBuilderUtils.js
@@ -6,10 +6,10 @@ import { findAuthorityConfig } from "utilities/authorityConfig"
  */
 export default class ResourceBuilder {
   constructor({
-    injectPropertyTemplateIntoValue = false,
+    injectPropertyKeyIntoValue = false,
     injectPropertyIntoValue = false,
   } = {}) {
-    this.injectPropertyTemplateIntoValue = injectPropertyTemplateIntoValue
+    this.injectPropertyKeyIntoValue = injectPropertyKeyIntoValue
     this.injectPropertyIntoValue = injectPropertyIntoValue
   }
 
@@ -160,7 +160,7 @@ export default class ResourceBuilder {
     if (subjectKey) property.subjectKey = subjectKey
 
     // Inject propertyTemplate into value
-    if (!_.isEmpty(values) && this.injectPropertyTemplateIntoValue)
+    if (!_.isEmpty(values) && this.injectPropertyKeyIntoValue)
       values.forEach((value) => (value.propertyKey = property.key))
 
     // Inject property into value

--- a/__tests__/testUtilities/resourceBuilderUtils.js
+++ b/__tests__/testUtilities/resourceBuilderUtils.js
@@ -5,8 +5,8 @@ import { findAuthorityConfig } from "utilities/authorityConfig"
  * Helper for building resources (and parts) and templates.
  */
 export default class ResourceBuilder {
-  constructor({ injectPropertyIntoValue = false } = {}) {
-    this.injectPropertyIntoValue = injectPropertyIntoValue
+  constructor({ injectPropertyTemplateIntoValue = false } = {}) {
+    this.injectPropertyTemplateIntoValue = injectPropertyTemplateIntoValue
   }
 
   key() {
@@ -156,7 +156,7 @@ export default class ResourceBuilder {
     if (subjectKey) property.subjectKey = subjectKey
 
     // Inject property into value
-    if (!_.isEmpty(values) && this.injectPropertyIntoValue)
+    if (!_.isEmpty(values) && this.injectPropertyTemplateIntoValue)
       values.forEach((value) => {
         value.propertyKey = property.key
         if (value.literal && property?.propertyTemplate?.validationDataType) {

--- a/src/GraphBuilder.js
+++ b/src/GraphBuilder.js
@@ -106,7 +106,16 @@ export default class GraphBuilder {
   }
 
   buildLiteralValue(value, subjectTerm, propertyTerm) {
-    const valueTerm = rdf.literal(value.literal, value.lang)
+    // TODO: ?. accessor for 2 tests that are hella annoying to fix
+    const validationDataType =
+      value.property?.propertyTemplate?.validationDataType
+    let valueTerm
+    if (validationDataType) {
+      const namedNode = rdf.namedNode(validationDataType)
+      valueTerm = rdf.literal(value.literal, namedNode)
+    } else {
+      valueTerm = rdf.literal(value.literal, value.lang)
+    }
     this.dataset.add(rdf.quad(subjectTerm, propertyTerm, valueTerm))
   }
 


### PR DESCRIPTION
## Why was this change made?

Closes #2891

When there is a validationDataType, the URI is now included in the RDF as the @type of the literal property's value.

### After

we indicate the datatype in the graph:

![image](https://user-images.githubusercontent.com/96775/142294864-dfc641c0-e1d8-44b6-a883-10996de4164e.png)

## How was this change tested?

unit test and locally on my laptop

## Which documentation and/or configurations were updated?



