### PR TITLE
refactor tests to use renderCompontent and createStore

### DIFF
--- a/__tests__/components/editor/preview/ResourcePreviewHeader.test.js
+++ b/__tests__/components/editor/preview/ResourcePreviewHeader.test.js
@@ -1,24 +1,19 @@
 // Copyright 2019 Stanford University see LICENSE for license
 
 import React from "react"
-import { render } from "@testing-library/react"
+import { createStore, renderComponent } from "testUtils"
 import { createState } from "stateUtils"
 import { selectNormSubject } from "selectors/resources"
-import configureMockStore from "redux-mock-store"
 import ResourcePreviewHeader from "components/editor/preview/ResourcePreviewHeader"
-import { Provider } from "react-redux"
-
-const mockStore = configureMockStore()
 
 describe("<ResourcePreviewHeader />", () => {
   it("displays label, url and edit groups", () => {
     const state = createState({ hasTwoLiteralResources: true })
-    const store = mockStore(state)
+    const store = createStore(state)
     const resource = selectNormSubject(state, "t9zVwg2zO")
-    const header = render(
-      <Provider store={store}>
-        <ResourcePreviewHeader resource={resource} />
-      </Provider>
+    const header = renderComponent(
+      <ResourcePreviewHeader resource={resource} />,
+      store
     )
     expect(header.getByText("Abbreviated Title")).toBeTruthy // label is shown
     expect(header.getByText("Stanford University")).toBeTruthy // owner is shown with full group name

--- a/__tests__/components/editor/property/PropertyLabelInfo.test.js
+++ b/__tests__/components/editor/property/PropertyLabelInfo.test.js
@@ -1,26 +1,21 @@
 // Copyright 2021 Stanford University see LICENSE for license
 
 import React from "react"
-import { render } from "@testing-library/react"
+import { createStore, renderComponent } from "testUtils"
 import { createState } from "stateUtils"
-import configureMockStore from "redux-mock-store"
 import PropertyLabelInfo from "components/editor/property/PropertyLabelInfo"
-import { Provider } from "react-redux"
-
-const mockStore = configureMockStore()
 
 describe("<PropertyLabelInfo />", () => {
   it("displays remark only when no remark URL is present", () => {
     const state = createState({ hasResourceWithNestedResource: true })
-    const store = mockStore(state)
+    const store = createStore(state)
     const propertyTemplate =
       state.entities.propertyTemplates[
         "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property1"
       ]
-    const label = render(
-      <Provider store={store}>
-        <PropertyLabelInfo propertyTemplate={propertyTemplate} />
-      </Provider>
+    const label = renderComponent(
+      <PropertyLabelInfo propertyTemplate={propertyTemplate} />,
+      store
     )
     expect(label.getByRole("link").getAttribute("data-bs-content")).toBe(
       "Nested, repeatable resource template."
@@ -30,16 +25,15 @@ describe("<PropertyLabelInfo />", () => {
 
   it("displays remark URL only when no remark is present", () => {
     const state = createState({ hasResourceWithTwoNestedResources: true })
-    const store = mockStore(state)
+    const store = createStore(state)
     const propertyTemplate =
       state.entities.propertyTemplates[
         "resourceTemplate:testing:uber1 > http://id.loc.gov/ontologies/bibframe/uber/template1/property1"
       ]
 
-    const label = render(
-      <Provider store={store}>
-        <PropertyLabelInfo propertyTemplate={propertyTemplate} />
-      </Provider>
+    const label = renderComponent(
+      <PropertyLabelInfo propertyTemplate={propertyTemplate} />,
+      store
     )
     expect(label.getByRole("link").getAttribute("title")).toBe(
       "https://www.stanford.edu"
@@ -49,32 +43,30 @@ describe("<PropertyLabelInfo />", () => {
 
   it("displays both remark and remark URL when both are present", () => {
     const state = createState({ hasResourceWithTwoNestedResources: true })
-    const store = mockStore(state)
+    const store = createStore(state)
     const propertyTemplate =
       state.entities.propertyTemplates[
         "resourceTemplate:testing:uber2 > http://id.loc.gov/ontologies/bibframe/uber/template2/property1"
       ]
 
-    const label = render(
-      <Provider store={store}>
-        <PropertyLabelInfo propertyTemplate={propertyTemplate} />
-      </Provider>
+    const label = renderComponent(
+      <PropertyLabelInfo propertyTemplate={propertyTemplate} />,
+      store
     )
     expect(label.getAllByRole("link").length).toBe(2) //  two links present, the remark and the remark URL
   })
 
   it("displays no links when neither the remark nor the remark URL are present", () => {
     const state = createState({ hasResourceWithLiteral: true })
-    const store = mockStore(state)
+    const store = createStore(state)
     const propertyTemplate =
       state.entities.propertyTemplates[
         "ld4p:RT:bf2:Title:AbbrTitle > http://id.loc.gov/ontologies/bibframe/mainTitle"
       ]
 
-    const label = render(
-      <Provider store={store}>
-        <PropertyLabelInfo propertyTemplate={propertyTemplate} />
-      </Provider>
+    const label = renderComponent(
+      <PropertyLabelInfo propertyTemplate={propertyTemplate} />,
+      store
     )
     expect(label.queryAllByRole("link")).toBeFalsy //  no links present
   })

--- a/__tests__/components/editor/property/PropertyLabelInfoTooltip.test.js
+++ b/__tests__/components/editor/property/PropertyLabelInfoTooltip.test.js
@@ -1,27 +1,22 @@
 // Copyright 2021 Stanford University see LICENSE for license
 
 import React from "react"
-import { render } from "@testing-library/react"
+import { createStore, renderComponent } from "testUtils"
 import { createState } from "stateUtils"
 import { selectSubjectAndPropertyTemplates } from "selectors/templates"
-import configureMockStore from "redux-mock-store"
 import PropertyLabelInfoTooltip from "components/editor/property/PropertyLabelInfoTooltip"
-import { Provider } from "react-redux"
-
-const mockStore = configureMockStore()
 
 describe("<PropertyLabelInfoTooltip />", () => {
   it("displays remark without link", () => {
     const state = createState({ hasResourceWithNestedResource: true })
-    const store = mockStore(state)
+    const store = createStore(state)
     const propertyTemplate = selectSubjectAndPropertyTemplates(
       state,
       "resourceTemplate:testing:uber1"
     )
-    const tooltip = render(
-      <Provider store={store}>
-        <PropertyLabelInfoTooltip propertyTemplate={propertyTemplate} />
-      </Provider>
+    const tooltip = renderComponent(
+      <PropertyLabelInfoTooltip propertyTemplate={propertyTemplate} />,
+      store
     )
     expect(tooltip.getByRole("link").getAttribute("data-bs-content")).toBe(
       "Template for testing purposes."
@@ -30,15 +25,14 @@ describe("<PropertyLabelInfoTooltip />", () => {
 
   it("displays remark with a URL that is auto linked", () => {
     const state = createState({ hasResourceWithNestedResource: true })
-    const store = mockStore(state)
+    const store = createStore(state)
     const propertyTemplate = selectSubjectAndPropertyTemplates(
       state,
       "resourceTemplate:testing:uber2"
     )
-    const tooltip = render(
-      <Provider store={store}>
-        <PropertyLabelInfoTooltip propertyTemplate={propertyTemplate} />
-      </Provider>
+    const tooltip = renderComponent(
+      <PropertyLabelInfoTooltip propertyTemplate={propertyTemplate} />,
+      store
     )
     expect(tooltip.getByRole("link").getAttribute("data-bs-content")).toBe(
       'Template for testing purposes with single repeatable literal with a link to Stanford at <a target="_blank" href="https://www.stanford.edu">https://www.stanford.edu</a>'


### PR DESCRIPTION
## Why was this change made?

Refactor some tests to use the testUtils (as done in #3349)

## How was this change tested?



## Which documentation and/or configurations were updated?



