### PR TITLE
show network error on lookup instead of no results

### DIFF
--- a/src/components/editor/inputs/LookupTab.jsx
+++ b/src/components/editor/inputs/LookupTab.jsx
@@ -30,12 +30,12 @@ const LookupTab = (props) => {
     )
   }
 
-  if (!props.result.totalHits) {
-    return <strong>No results</strong>
+  if (props.result.error) {
+    return <span className="text-danger">{props.result.error}</span>
   }
 
-  if (props.result.error) {
-    return <span className="dropdown-error">{props.result.error}</span>
+  if (!props.result.totalHits) {
+    return <strong>No results</strong>
   }
 
   const tabResults = props.result.results.map((hit) => (


### PR DESCRIPTION
## Why was this change made?

Fixes #3341 - show an error on QA lookups if there are network issues instead of showing "No results"


## How was this change tested?

Localhost

## Which documentation and/or configurations were updated?



