### PR TITLE
Adds localAdminMetadataFor as a bfAdminMetadataRefs property.

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,8 @@ The following are only in the resource subject (that is, the base subject).
   bfAdminMetadataRefs: [uri of referenced admin metadata resource, ...],
   bfWorkRefs: [uri of referenced Bibframe Work resource, ...],
   bfInstanceRefs: [uri of referenced Bibframe Instance resource, ...],
-  bfItemRefs: [uri of referenced Bibframe Item resources, ...]
+  bfItemRefs: [uri of referenced Bibframe Item resources, ...],
+  sinopiaLocalAdminMetadataForRefs: [uri of referenced resources, ...]
 }
 ```
 

--- a/__tests__/__state_fixtures__/full_resource.json
+++ b/__tests__/__state_fixtures__/full_resource.json
@@ -38,6 +38,7 @@
   "rootPropertyKey": null,
   "labels": ["Uber template1"],
   "bfAdminMetadataRefs": [],
+  "localAdminMetadataForRefs": [],
   "bfItemRefs": [],
   "bfInstanceRefs": [],
   "bfWorkRefs": [],

--- a/__tests__/actionCreators/relationships.test.js
+++ b/__tests__/actionCreators/relationships.test.js
@@ -25,6 +25,8 @@ describe("loadRelationships()", () => {
       ],
       bfInstanceRefs: [],
       bfWorkRefs: [],
+      sinopiaLocalAdminMetadataForRefs: [],
+      sinopiaHasLocalAdminMetadataInferredRefs: [],
       bfAdminMetadataAllRefs: [
         "http://localhost:3000/resource/72f2f457-31f5-432c-8acf-b4037f7754g",
         "http://localhost:3000/resource/94f2f457-31f5-432c-8acf-b4037f7754i",

--- a/__tests__/reducers/resources.test.js
+++ b/__tests__/reducers/resources.test.js
@@ -330,6 +330,7 @@ describe("addSubject()", () => {
           bfInstanceRefs: [],
           bfItemRefs: [],
           bfWorkRefs: [],
+          localAdminMetadataForRefs: [],
           changed: true,
           classes: ["http://id.loc.gov/ontologies/bibframe/Barcode"],
           group: null,
@@ -372,6 +373,7 @@ describe("addSubject()", () => {
         bfInstanceRefs: [],
         bfItemRefs: [],
         bfWorkRefs: [],
+        localAdminMetadataForRefs: [],
         changed: true,
         classes: ["http://id.loc.gov/ontologies/bibframe/AbbreviatedTitle"],
         descUriOrLiteralValueKeys: [],
@@ -430,6 +432,7 @@ describe("addSubject()", () => {
         bfInstanceRefs: [],
         bfItemRefs: [],
         bfWorkRefs: [],
+        localAdminMetadataForRefs: [],
         group: null,
         editGroups: [],
         labels: ["Abbreviated Title"],
@@ -788,6 +791,9 @@ describe("addValue()", () => {
       expect(newState.subjects["wihOjn-0Z"].bfAdminMetadataRefs).toHaveLength(0)
       expect(newState.subjects["wihOjn-0Z"].bfInstanceRefs).toHaveLength(0)
       expect(newState.subjects["wihOjn-0Z"].bfItemRefs).toHaveLength(0)
+      expect(
+        newState.subjects["wihOjn-0Z"].localAdminMetadataForRefs
+      ).toHaveLength(0)
       expect(newState.subjects["wihOjn-0Z"].bfWorkRefs).toEqual([
         "http://localhost:3000/resource/74770f92-f8cf-48ee-970a-aefc97843738",
         "http://localhost:3000/resource/85770f92-f8cf-48ee-970a-aefc97843749",
@@ -813,6 +819,9 @@ describe("addValue()", () => {
       const newState = reducer(oldState.entities, newAddUriAction)
 
       expect(newState.subjects["wihOjn-0Z"].bfAdminMetadataRefs).toHaveLength(0)
+      expect(
+        newState.subjects["wihOjn-0Z"].localAdminMetadataForRefs
+      ).toHaveLength(0)
       expect(newState.subjects["wihOjn-0Z"].bfInstanceRefs).toEqual([
         "http://localhost:3000/resource/85770f92-f8cf-48ee-970a-aefc97843749",
       ])
@@ -843,6 +852,9 @@ describe("addValue()", () => {
       expect(newState.subjects["wihOjn-0Z"].bfItemRefs).toEqual([
         "http://localhost:3000/resource/85770f92-f8cf-48ee-970a-aefc97843749",
       ])
+      expect(
+        newState.subjects["wihOjn-0Z"].localAdminMetadataForRefs
+      ).toHaveLength(0)
       expect(newState.subjects["wihOjn-0Z"].bfWorkRefs).toHaveLength(1)
     })
   })
@@ -870,6 +882,36 @@ describe("addValue()", () => {
       expect(newState.subjects["wihOjn-0Z"].bfInstanceRefs).toHaveLength(0)
       expect(newState.subjects["wihOjn-0Z"].bfItemRefs).toHaveLength(0)
       expect(newState.subjects["wihOjn-0Z"].bfWorkRefs).toHaveLength(1)
+      expect(
+        newState.subjects["wihOjn-0Z"].localAdminMetadataForRefs
+      ).toHaveLength(0)
+    })
+  })
+
+  describe("new uri value that is a sinopia Local Admin Metadata ref", () => {
+    it("updates state", () => {
+      const oldState = createState({ hasResourceWithLookup: true })
+
+      const newAddUriAction = {
+        ...addUriAction,
+        payload: {
+          ...addUriAction.payload,
+          value: {
+            ...addUriAction.payload.value,
+            propertyUri: "https://sinopia.io/vocabulary/localAdminMetadataFor",
+          },
+        },
+      }
+
+      const newState = reducer(oldState.entities, newAddUriAction)
+
+      expect(newState.subjects["wihOjn-0Z"].localAdminMetadataForRefs).toEqual([
+        "http://localhost:3000/resource/85770f92-f8cf-48ee-970a-aefc97843749",
+      ])
+      expect(newState.subjects["wihOjn-0Z"].bfInstanceRefs).toHaveLength(0)
+      expect(newState.subjects["wihOjn-0Z"].bfItemRefs).toHaveLength(0)
+      expect(newState.subjects["wihOjn-0Z"].bfWorkRefs).toHaveLength(1)
+      expect(newState.subjects["wihOjn-0Z"].bfAdminMetadataRefs).toHaveLength(0)
     })
   })
 })
@@ -1024,6 +1066,27 @@ describe("removeValue()", () => {
       expect(
         newState.subjects.t9zVwg2zO.descUriOrLiteralValueKeys
       ).not.toContain("CxGx7WMh2")
+    })
+  })
+  describe("with a uri that is a sinopia Local Admin Metadata ref", () => {
+    it("removes a value for a property", () => {
+      const oldState = createState({ hasResourceWithLookup: true })
+      oldState.entities.values["s8-qt3-uu"].propertyUri =
+        "https://sinopia.io/vocabulary/localAdminMetadataFor"
+      oldState.entities.subjects["wihOjn-0Z"].localAdminMetadataForRefs = [
+        "http://localhost:3000/resource/74770f92-f8cf-48ee-970a-aefc97843738",
+      ]
+
+      const action = {
+        type: "REMOVE_VALUE",
+        payload: "s8-qt3-uu",
+      }
+
+      const newState = reducer(oldState.entities, action)
+      expect(newState.values["s8-qt3-uu"]).toBe(undefined)
+      expect(newState.subjects["wihOjn-0Z"].localAdminMetadataForRefs).toEqual(
+        []
+      )
     })
   })
   describe("with an error", () => {

--- a/__tests__/sinopiaApi.test.js
+++ b/__tests__/sinopiaApi.test.js
@@ -44,6 +44,7 @@ const resource = {
   bfInstanceRefs: [],
   bfItemRefs: [],
   bfWorkRefs: [],
+  sinopiaLocalAdminMetadataForRefs: [],
   group: "yale",
   editGroups: ["cornell"],
   types: ["https://w3id.org/arm/core/ontology/0.1/Enclosure"],

--- a/__tests__/testUtilities/fixtureLoaderHelper.js
+++ b/__tests__/testUtilities/fixtureLoaderHelper.js
@@ -95,6 +95,7 @@ export const getFixtureResource = (uri) => {
     bfItemRefs: [],
     bfInstanceRefs: [],
     bfWorkRefs: [],
+    sinopiaLocalAdminMetadataForRefs: [],
   }
 }
 

--- a/__tests__/testUtilities/stateResourceBuilderUtils.js
+++ b/__tests__/testUtilities/stateResourceBuilderUtils.js
@@ -93,6 +93,7 @@ export default class StateResourceBuilder {
     bfItemRefs = [],
     bfInstanceRefs = [],
     bfWorkRefs = [],
+    localAdminMetadataForRefs = [],
     changed = false,
     label = null,
     ...props
@@ -107,6 +108,7 @@ export default class StateResourceBuilder {
       bfItemRefs,
       bfInstanceRefs,
       bfWorkRefs,
+      localAdminMetadataForRefs,
       changed,
       label: label || _.first(props?.labels),
     }

--- a/src/reducers/resourceHelpers.js
+++ b/src/reducers/resourceHelpers.js
@@ -118,6 +118,10 @@ export const updateBibframeRefs = (state, value) => {
       // References admin metadata
       addToKeyArray(newSubject, "bfAdminMetadataRefs", value.uri)
       break
+    case "https://sinopia.io/vocabulary/localAdminMetadataFor":
+      // References Sinopia localadmin metadata
+      addToKeyArray(newSubject, "localAdminMetadataForRefs", value.uri)
+      break
     case "http://id.loc.gov/ontologies/bibframe/itemOf":
       // References instance
       addToKeyArray(newSubject, "bfInstanceRefs", value.uri)
@@ -155,6 +159,10 @@ export const removeBibframeRefs = (state, value) => {
     case "http://id.loc.gov/ontologies/bibframe/adminMetadata":
       // References admin metadata
       removeFromKeyArray(newSubject, "bfAdminMetadataRefs", value.uri)
+      break
+    case "https://sinopia.io/vocabulary/localAdminMetadataFor":
+      // References Sinopia localadmin metadata
+      removeFromKeyArray(newSubject, "localAdminMetadataForRefs", value.uri)
       break
     case "http://id.loc.gov/ontologies/bibframe/itemOf":
       // References instance

--- a/src/reducers/resources.js
+++ b/src/reducers/resources.js
@@ -173,6 +173,8 @@ const addSubjectToNewState = (state, subject, valueSubjectOfKey) => {
     if (_.isUndefined(newSubject.editGroups)) newSubject.editGroups = []
     if (_.isUndefined(newSubject.bfAdminMetadataRefs))
       newSubject.bfAdminMetadataRefs = []
+    if (_.isUndefined(newSubject.localAdminMetadataForRefs))
+      newSubject.localAdminMetadataForRefs = []
     if (_.isUndefined(newSubject.bfItemRefs)) newSubject.bfItemRefs = []
     if (_.isUndefined(newSubject.bfInstanceRefs)) newSubject.bfInstanceRefs = []
     if (_.isUndefined(newSubject.bfWorkRefs)) newSubject.bfWorkRefs = []

--- a/src/sinopiaApi.js
+++ b/src/sinopiaApi.js
@@ -257,6 +257,7 @@ const saveBodyForResource = (resource, user, group, editGroups) => {
       templateId: resource.subjectTemplate.id,
       types: [resource.subjectTemplate.class],
       bfAdminMetadataRefs: resource.bfAdminMetadataRefs,
+      sinopiaLocalAdminMetadataForRefs: resource.localAdminMetadataForRefs,
       bfItemRefs: resource.bfItemRefs,
       bfInstanceRefs: resource.bfInstanceRefs,
       bfWorkRefs: resource.bfWorkRefs,


### PR DESCRIPTION
## Why was this change made?
Sinolio


## How was this change tested?



## Which documentation and/or configurations were updated?



