### PR TITLE
Handles authorities without headers.

### DIFF
--- a/__tests__/utilities/QuestioningAuthority.test.js
+++ b/__tests__/utilities/QuestioningAuthority.test.js
@@ -96,6 +96,35 @@ describe("createLookupPromise()", () => {
     })
   })
 
+  describe("when no response header", () => {
+    beforeEach(() => {
+      global.fetch = jest.fn().mockImplementation(() =>
+        Promise.resolve({
+          ok: true,
+          url: "https://lookup.ld4l.org/authorities/search/local/publisher_cities_select_list?q=new+york&maxRecords=8&lang=en&context=true&response_header=true&startRecord=1",
+          status: 200,
+          statusText: "OK",
+          json: () => {
+            return [
+              {
+                id: "http://id.loc.gov/authorities/names/n79007751",
+                label: "New York (N.Y.)",
+                uri: "http://id.loc.gov/authorities/names/n79007751",
+              },
+            ]
+          },
+        })
+      )
+    })
+
+    it("adapts the response", async () => {
+      const authorityConfig = findAuthorityConfig("urn:qa:publisherCities")
+      const response = await createLookupPromise("New York", authorityConfig)
+      expect(response.response_header.total_records).toBe(1)
+      expect(response.results).toHaveLength(1)
+    })
+  })
+
   describe("when error response", () => {
     beforeEach(() => {
       global.fetch = jest.fn().mockImplementation(() =>

--- a/src/components/editor/inputs/LookupTab.jsx
+++ b/src/components/editor/inputs/LookupTab.jsx
@@ -57,16 +57,21 @@ const LookupTab = (props) => {
     </div>
   ))
 
+  // Not all authorities support paging
+  const isPaging = props.result.results.length <= Config.maxRecordsForQALookups
+
   return (
     <React.Fragment>
       {tabResults}
-      <SearchResultsPaging
-        key="search-paging"
-        resultsPerPage={Config.maxRecordsForQALookups}
-        startOfRange={props.result.options.startOfRange}
-        totalResults={props.result.totalHits}
-        changePage={handleChangePage}
-      />
+      {isPaging && (
+        <SearchResultsPaging
+          key="search-paging"
+          resultsPerPage={Config.maxRecordsForQALookups}
+          startOfRange={props.result.options.startOfRange}
+          totalResults={props.result.totalHits}
+          changePage={handleChangePage}
+        />
+      )}
     </React.Fragment>
   )
 }

--- a/src/utilities/QuestioningAuthority.js
+++ b/src/utilities/QuestioningAuthority.js
@@ -53,6 +53,17 @@ export const createLookupPromise = (
       return resp
     })
     .then((resp) => resp.json())
+    .then((json) => {
+      // This adapts authorities that don't return headers.
+      if (json.response_header) return json
+
+      return {
+        response_header: {
+          total_records: json.length,
+        },
+        results: json,
+      }
+    })
     .catch((err) => {
       console.error(
         `Error in Questioning Authority lookup: ${err.message || err}`


### PR DESCRIPTION
closes #3377

## Why was this change made?
Allow publisher cities authority to function properly.


## How was this change tested?
Unit, local


## Which documentation and/or configurations were updated?



