### PR TITLE
Adds label for EDTF literal.

### DIFF
--- a/src/components/editor/property/LiteralTypeLabel.jsx
+++ b/src/components/editor/property/LiteralTypeLabel.jsx
@@ -8,6 +8,8 @@ const LiteralTypeLabel = ({ propertyTemplate }) => {
       "http://www.w3.org/2001/XMLSchema#dateTime": "a date time",
       "http://www.w3.org/2001/XMLSchema#dateTimeStamp":
         "a date time with timezone",
+      "http://id.loc.gov/datatypes/edtf/":
+        "an Extended Date Time Format (EDTF) date",
     }
 
     let label = `Enter ${


### PR DESCRIPTION
closes #3384

## Why was this change made?
Consistency with other literal validation.


## How was this change tested?
![image](https://user-images.githubusercontent.com/588335/144287989-31244dc2-a45b-43cd-b19b-492ecf62cd9e.png)



## Which documentation and/or configurations were updated?



