### PR TITLE
Changed label in search dropdown.

### DIFF
--- a/src/components/search/HeaderSearch.jsx
+++ b/src/components/search/HeaderSearch.jsx
@@ -106,7 +106,7 @@ const HeaderSearch = () => {
             Sinopia BIBFRAME instance resources
           </option>
           <option value={`${sinopiaSearchUri}/Item`}>
-            Sinopia BIBFRAME Items
+            Sinopia BIBFRAME item resources
           </option>
 
           {options}


### PR DESCRIPTION
closes #3392

## Why was this change made?
Consistency.


## How was this change tested?
![image](https://user-images.githubusercontent.com/588335/144288852-b121f915-8d00-42e3-b5e9-d9fa31030bc2.png)



## Which documentation and/or configurations were updated?



