### PR TITLE
add user engagement metrics to editor ui

### DIFF
--- a/__tests__/feature/metrics/viewResourceMetrics.test.js
+++ b/__tests__/feature/metrics/viewResourceMetrics.test.js
@@ -47,7 +47,7 @@ describe("viewing resource metrics", () => {
       await screen.findByText("Resource editing")
       screen.getByText("10", { selector: ".card-text" })
 
-      expect(sinopiaMetrics.getResourceCreatedCount).toHaveBeenCalledWith({
+      expect(sinopiaMetrics.getResourceEditedCount).toHaveBeenCalledWith({
         startDate: "2021-01-01",
         endDate: "2022-01-01",
         group: "stanford",

--- a/__tests__/feature/metrics/viewUserMetrics.test.js
+++ b/__tests__/feature/metrics/viewUserMetrics.test.js
@@ -9,6 +9,12 @@ describe("viewing user metrics", () => {
   describe("when no error", () => {
     beforeEach(() => {
       jest.spyOn(sinopiaMetrics, "getUserCount").mockResolvedValue({ count: 1 })
+      jest
+        .spyOn(sinopiaMetrics, "getResourceUserCount")
+        .mockResolvedValue({ count: 5 })
+      jest
+        .spyOn(sinopiaMetrics, "getTemplateUserCount")
+        .mockResolvedValue({ count: 10 })
     })
 
     it("displays the metrics", async () => {
@@ -21,6 +27,10 @@ describe("viewing user metrics", () => {
 
       await screen.findByText("User count")
       screen.getByText("1", { selector: ".card-text" })
+      await screen.findByText("User Resource Saved Count")
+      screen.getByText("5", { selector: ".card-text" })
+      await screen.findByText("User Template Saved Count")
+      screen.getByText("10", { selector: ".card-text" })
     })
   })
 

--- a/src/components/metrics/ResourceMetrics.jsx
+++ b/src/components/metrics/ResourceMetrics.jsx
@@ -16,15 +16,11 @@ const ResourceMetrics = ({ triggerHandleOffsetMenu }) => (
       <div className="col-md-3">
         <ResourceCountMetric />
       </div>
-    </div>
-    <div className="row mb-4">
-      <div className="col-md-3">
-        <ResourceCreatedCountMetric />
-      </div>
-    </div>
-    <div className="row">
       <div className="col-md-3">
         <ResourceEditedCountMetric />
+      </div>
+      <div className="col-md-3">
+        <ResourceCreatedCountMetric />
       </div>
     </div>
   </MetricsWrapper>

--- a/src/components/metrics/TemplateMetrics.jsx
+++ b/src/components/metrics/TemplateMetrics.jsx
@@ -17,20 +17,16 @@ const TemplateMetrics = ({ triggerHandleOffsetMenu }) => (
       <div className="col-md-3">
         <TemplateCountMetric />
       </div>
+      <div className="col-md-3">
+        <TemplateUsageCountMetric />
+      </div>
     </div>
     <div className="row mb-4">
       <div className="col-md-3">
         <TemplateCreatedCountMetric />
       </div>
-    </div>
-    <div className="row mb-4">
       <div className="col-md-3">
         <TemplateEditedCountMetric />
-      </div>
-    </div>
-    <div className="row">
-      <div className="col-md-3">
-        <TemplateUsageCountMetric />
       </div>
     </div>
   </MetricsWrapper>

--- a/src/components/metrics/TemplateMetrics.jsx
+++ b/src/components/metrics/TemplateMetrics.jsx
@@ -17,7 +17,7 @@ const TemplateMetrics = ({ triggerHandleOffsetMenu }) => (
       <div className="col-md-3">
         <TemplateCountMetric />
       </div>
-      <div className="col-md-3">
+      <div className="col-md-6">
         <TemplateUsageCountMetric />
       </div>
     </div>

--- a/src/components/metrics/UserCountMetric.jsx
+++ b/src/components/metrics/UserCountMetric.jsx
@@ -1,0 +1,19 @@
+// Copyright 2019 Stanford University see LICENSE for license
+
+import React from "react"
+import CountCard from "./CountCard"
+import useMetric from "hooks/useMetric"
+
+const UserCountMetric = () => {
+  const userCountMetric = useMetric("getUserCount")
+
+  return (
+    <CountCard
+      count={userCountMetric?.count}
+      title="User count"
+      help="The total number of users."
+    />
+  )
+}
+
+export default UserCountMetric

--- a/src/components/metrics/UserMetrics.jsx
+++ b/src/components/metrics/UserMetrics.jsx
@@ -16,13 +16,9 @@ const UserMetrics = ({ triggerHandleOffsetMenu }) => (
       <div className="col-md-3">
         <UserCountMetric />
       </div>
-    </div>
-    <div className="row mb-4">
       <div className="col-md-3">
         <UserResourceCountMetric />
       </div>
-    </div>
-    <div className="row mb-4">
       <div className="col-md-3">
         <UserTemplateCountMetric />
       </div>

--- a/src/components/metrics/UserMetrics.jsx
+++ b/src/components/metrics/UserMetrics.jsx
@@ -3,31 +3,32 @@
 import React from "react"
 import PropTypes from "prop-types"
 import MetricsWrapper from "./MetricsWrapper"
-import CountCard from "./CountCard"
-import useMetric from "hooks/useMetric"
+import UserCountMetric from "./UserCountMetric"
+import UserResourceCountMetric from "./UserResourceCountMetric"
+import UserTemplateCountMetric from "./UserTemplateCountMetric"
 
-const UserMetrics = ({ triggerHandleOffsetMenu }) => {
-  const userCountMetric = useMetric("getUserCount")
-
-  return (
-    <MetricsWrapper
-      triggerHandleOffsetMenu={triggerHandleOffsetMenu}
-      title="User metrics"
-    >
-      <div className="row">
-        <div className="col-md-3">
-          {userCountMetric?.count && (
-            <CountCard
-              count={userCountMetric?.count}
-              title="User count"
-              help="The total number of users."
-            />
-          )}
-        </div>
+const UserMetrics = ({ triggerHandleOffsetMenu }) => (
+  <MetricsWrapper
+    triggerHandleOffsetMenu={triggerHandleOffsetMenu}
+    title="User metrics"
+  >
+    <div className="row mb-4">
+      <div className="col-md-3">
+        <UserCountMetric />
       </div>
-    </MetricsWrapper>
-  )
-}
+    </div>
+    <div className="row mb-4">
+      <div className="col-md-3">
+        <UserResourceCountMetric />
+      </div>
+    </div>
+    <div className="row mb-4">
+      <div className="col-md-3">
+        <UserTemplateCountMetric />
+      </div>
+    </div>
+  </MetricsWrapper>
+)
 
 UserMetrics.propTypes = {
   triggerHandleOffsetMenu: PropTypes.func,

--- a/src/components/metrics/UserResourceCountMetric.jsx
+++ b/src/components/metrics/UserResourceCountMetric.jsx
@@ -1,0 +1,35 @@
+// Copyright 2019 Stanford University see LICENSE for license
+
+import React, { useState } from "react"
+import CountCard from "./CountCard"
+import useMetric from "hooks/useMetric"
+import DateRangeFilter, {
+  defaultStartDate,
+  defaultEndDate,
+} from "./DateRangeFilter"
+
+const UserResourceCountMetric = () => {
+  const [params, setParams] = useState({
+    startDate: defaultStartDate,
+    endDate: defaultEndDate,
+  })
+
+  const userResourceCountMetric = useMetric("getResourceUserCount", params)
+
+  const footer = (
+    <React.Fragment>
+      <DateRangeFilter params={params} setParams={setParams} />
+    </React.Fragment>
+  )
+
+  return (
+    <CountCard
+      count={userResourceCountMetric?.count}
+      title="User Resource Saved Count"
+      help="The total number of unique users that saved at least one resource (excluding templates) in a specified time period."
+      footer={footer}
+    />
+  )
+}
+
+export default UserResourceCountMetric

--- a/src/components/metrics/UserTemplateCountMetric.jsx
+++ b/src/components/metrics/UserTemplateCountMetric.jsx
@@ -1,0 +1,35 @@
+// Copyright 2019 Stanford University see LICENSE for license
+
+import React, { useState } from "react"
+import CountCard from "./CountCard"
+import useMetric from "hooks/useMetric"
+import DateRangeFilter, {
+  defaultStartDate,
+  defaultEndDate,
+} from "./DateRangeFilter"
+
+const UserTemplateCountMetric = () => {
+  const [params, setParams] = useState({
+    startDate: defaultStartDate,
+    endDate: defaultEndDate,
+  })
+
+  const userTemplateCountMetric = useMetric("getTemplateUserCount", params)
+
+  const footer = (
+    <React.Fragment>
+      <DateRangeFilter params={params} setParams={setParams} />
+    </React.Fragment>
+  )
+
+  return (
+    <CountCard
+      count={userTemplateCountMetric?.count}
+      title="User Template Saved Count"
+      help="The total number of unique users that saved at least one resource template (excluding resources) in a specified time period."
+      footer={footer}
+    />
+  )
+}
+
+export default UserTemplateCountMetric

--- a/src/sinopiaMetrics.js
+++ b/src/sinopiaMetrics.js
@@ -43,6 +43,18 @@ export const getTemplateUsageCount = (params) =>
     compactPick(params, ["templateId"])
   )
 
+export const getResourceUserCount = (params) =>
+  getJson(
+    `${Config.sinopiaApiBase}/metrics/resourceUserCount/resource`,
+    compactPick(params, dateGroupFields)
+  )
+
+export const getTemplateUserCount = (params) =>
+  getJson(
+    `${Config.sinopiaApiBase}/metrics/resourceUserCount/template`,
+    compactPick(params, dateGroupFields)
+  )
+
 const compactPick = (obj, keys) =>
   _.pickBy(
     obj,


### PR DESCRIPTION
## Why was this change made?

Fixes #3398 - add user engagement metrics to user metrics UI page

I also tried putting the cards into sets of either two or three columns (in a second commit), instead of all stacked one on top of the other, since I think it looks better.  See screenshots.

Note: i created a component for the existing user count metric to match the style of the other metrics pages (where each card was its own component)


![Screen Shot 2021-12-02 at 12 57 40 PM](https://user-images.githubusercontent.com/47137/144502041-789050fd-70ee-4a93-a81f-7c448f4d6f5e.png)
![Screen Shot 2021-12-02 at 12 57 46 PM](https://user-images.githubusercontent.com/47137/144502050-e78d3c85-712b-4969-904a-2d02ffe35d96.png)
![Screen Shot 2021-12-02 at 12 57 51 PM](https://user-images.githubusercontent.com/47137/144502056-bb553d74-10ee-4711-ba9d-17870af63421.png)

## How was this change tested?

Localhost


## Which documentation and/or configurations were updated?



