### PR TITLE
allow the app to set no default for template usage metric

### DIFF
--- a/__tests__/feature/metrics/viewTemplateMetrics.test.js
+++ b/__tests__/feature/metrics/viewTemplateMetrics.test.js
@@ -72,7 +72,7 @@ describe("viewing template metrics", () => {
       screen.getByText("10", { selector: ".card-text" })
 
       await screen.findByText("Template usage")
-      screen.getByText("15", { selector: ".card-text" })
+      screen.getByText("0", { selector: ".card-text" }) // starts as 0 if no default specified
 
       // Change template usage filter
       fireEvent.change(screen.getByPlaceholderText(/Enter id, label/), {

--- a/src/components/metrics/TemplateFilter.jsx
+++ b/src/components/metrics/TemplateFilter.jsx
@@ -4,7 +4,7 @@ import React from "react"
 import PropTypes from "prop-types"
 import InputTemplate from "../InputTemplate"
 
-// if you want to have have the input field pre-filled with a value (template id, labe, author, etc.), put it here
+// if you want to have have the input field pre-filled with a value (template id, label, author, etc.), put it here
 export const defaultTemplateId = null
 
 const TemplateFilter = ({ params, setParams }) => {
@@ -22,7 +22,7 @@ const TemplateFilter = ({ params, setParams }) => {
           htmlFor="template-choice"
           className="col-sm-3 col-form-label py-1"
         >
-          Search for template:
+          Search for template
         </label>
         <div className="col-sm-8 my-0">
           <InputTemplate

--- a/src/components/metrics/TemplateFilter.jsx
+++ b/src/components/metrics/TemplateFilter.jsx
@@ -4,7 +4,8 @@ import React from "react"
 import PropTypes from "prop-types"
 import InputTemplate from "../InputTemplate"
 
-export const defaultTemplateId = "pcc:bf2:Monograph:Instance"
+// if you want to have have the input field pre-filled with a value (template id, labe, author, etc.), put it here
+export const defaultTemplateId = null
 
 const TemplateFilter = ({ params, setParams }) => {
   const setTemplateId = (templateId) => {
@@ -21,7 +22,7 @@ const TemplateFilter = ({ params, setParams }) => {
           htmlFor="template-choice"
           className="col-sm-3 col-form-label py-1"
         >
-          Template
+          Search for template:
         </label>
         <div className="col-sm-8 my-0">
           <InputTemplate

--- a/src/components/metrics/TemplateUsageCountMetric.jsx
+++ b/src/components/metrics/TemplateUsageCountMetric.jsx
@@ -20,7 +20,7 @@ const TemplateUsageCountMetric = () => {
     <React.Fragment>
       <div className="row py-3">
         <label htmlFor="template-choice" className="col-sm-3">
-          Selected template ID:
+          Selected template ID
         </label>
         <div className="col-sm-8">{params.templateId}</div>
       </div>

--- a/src/components/metrics/TemplateUsageCountMetric.jsx
+++ b/src/components/metrics/TemplateUsageCountMetric.jsx
@@ -10,10 +10,20 @@ const TemplateUsageCountMetric = () => {
     templateId: defaultTemplateId,
   })
 
-  const templateUsageCountMetric = useMetric("getTemplateUsageCount", params)
+  const templateUsageCountMetric = useMetric(
+    "getTemplateUsageCount",
+    params,
+    !!params.templateId // this prevents the metric API call from firing if there is no templateId
+  )
 
   const footer = (
     <React.Fragment>
+      <div className="row py-3">
+        <label htmlFor="template-choice" className="col-sm-3">
+          Selected template ID:
+        </label>
+        <div className="col-sm-8">{params.templateId}</div>
+      </div>
       <TemplateFilter params={params} setParams={setParams} />
     </React.Fragment>
   )

--- a/src/hooks/useMetric.js
+++ b/src/hooks/useMetric.js
@@ -4,7 +4,7 @@ import { metricsErrorKey } from "utilities/errorKeyFactory"
 import { addError } from "actions/errors"
 import * as sinopiaMetrics from "../sinopiaMetrics"
 
-const useMetric = (name, params = null) => {
+const useMetric = (name, params = null, runMetric = true) => {
   const dispatch = useDispatch()
   const [metric, setMetric] = useState(null)
   const isMountedRef = useRef(false)
@@ -17,6 +17,7 @@ const useMetric = (name, params = null) => {
   }, [])
 
   useEffect(() => {
+    if (!runMetric) return setMetric({ count: 0 })
     sinopiaMetrics[name](params || {})
       .then((results) => {
         if (isMountedRef.current) setMetric(results)
@@ -31,7 +32,7 @@ const useMetric = (name, params = null) => {
           )
         }
       })
-  }, [name, params, dispatch])
+  }, [name, params, dispatch, runMetric])
 
   return metric
 }


### PR DESCRIPTION
## Why was this change made?

The template usage metric should start out as blank (0) until you search for a specific template.

Also, show the template ID of the currently reported on template to make it clear which one was selected (useful if you clear out the search, as it makes it clear why the results haven't changed yet):

![Screen Shot 2021-12-03 at 11 25 14 AM](https://user-images.githubusercontent.com/47137/144661255-45f00fb1-46bd-4a54-b860-47fb314dc335.png)


## How was this change tested?

Localhost, and updated test

## Which documentation and/or configurations were updated?



