### PR TITLE
Config Cornell and Penn for exporting to ILS

### DIFF
--- a/__tests__/feature/editing/transfer.test.js
+++ b/__tests__/feature/editing/transfer.test.js
@@ -3,6 +3,7 @@ import { fireEvent, screen } from "@testing-library/react"
 import { createState } from "stateUtils"
 import { featureSetup } from "featureUtils"
 import * as sinopiaApi from "sinopiaApi"
+import Config from "Config"
 
 featureSetup()
 
@@ -13,6 +14,11 @@ const nonBfUri =
   "http://localhost:3000/resource/c7db5404-7d7d-40ac-b38e-c821d2c3ae3f"
 
 jest.spyOn(sinopiaApi, "postTransfer").mockResolvedValue()
+jest.spyOn(Config, "transferConfig", "get").mockReturnValue({
+  ils: {
+    stanford: "Catalog",
+  },
+})
 
 describe("transfer saved bf:Instance when user belongs to a transfer group", () => {
   it("allows transfer", async () => {

--- a/src/Config.js
+++ b/src/Config.js
@@ -144,6 +144,7 @@ class Config {
         // group: label
         stanford: "Catalog",
         cornell: "Catalog",
+        penn: "Catalog",
       },
       // Can add additional transfer targets, e.g., discovery
     }

--- a/src/Config.js
+++ b/src/Config.js
@@ -143,6 +143,7 @@ class Config {
       ils: {
         // group: label
         stanford: "Catalog",
+        cornell: "Catalog",
       },
       // Can add additional transfer targets, e.g., discovery
     }


### PR DESCRIPTION
## Why was this change made?
Adds `cornell` and `penn` groups to the `transferConfig` function to allow exporting to FOLIO via Airflow.


## How was this change tested?
Unit tests


## Which documentation and/or configurations were updated?
`src/Config.js`


