### PR TITLE
Removed Cultural Heritage Organizations authority.

### DIFF
--- a/static/authorityConfig.json
+++ b/static/authorityConfig.json
@@ -2205,11 +2205,6 @@
     "component": "list"
   },
   {
-    "label": "Cultural Heritage Organizations (LOC)",
-    "uri": "https://id.loc.gov/vocabulary/organizations",
-    "component": "list"
-  },
-  {
     "label": "file type",
     "uri": "https://id.loc.gov/vocabulary/mfiletype",
     "component": "list"


### PR DESCRIPTION
## Why was this change made?
This authority is broken and has been replaced by a QA authority.


## How was this change tested?



## Which documentation and/or configurations were updated?
authorityConfig.json


