### PR TITLE
Updates Orbs used in project

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,9 @@
 version: 2.1
 orbs:
-  node: circleci/node@4.7.0
-  docker: circleci/docker@1.7.0
-  aws-cli: circleci/aws-cli@2.0
-  gh: circleci/github-cli@1.0.4
+  node: circleci/node@5.0.2
+  docker: circleci/docker@2.0.3
+  aws-cli: circleci/aws-cli@3.1.0
+  gh: circleci/github-cli@2.1.0
 parameters:
   node-version:
     type: string


### PR DESCRIPTION
## Why was this change made?
From [Circle-CI](https://support.circleci.com/hc/en-us/articles/4421154407195-Deprecating-Ubuntu-14-04-and-16-04-images-EOL-5-31-22), the Orbs we are using are being depreciated.


## How was this change tested?
Unit and integration tests


## Which documentation and/or configurations were updated?
`.circleci/config.yml`


