### PR TITLE
No longer suppress labels for optional classes.

### DIFF
--- a/static/templates/rt_resource_template_doc.json
+++ b/static/templates/rt_resource_template_doc.json
@@ -195,20 +195,6 @@
       {
         "@id": "http://sinopia.io/vocabulary/propertyType/uri"
       }
-    ],
-    "http://sinopia.io/vocabulary/hasUriAttributes": [
-      {
-        "@id": "_:b19"
-      }
-    ]
-  },
-  {
-    "@id": "_:b19",
-    "@type": ["http://sinopia.io/vocabulary/UriPropertyTemplate"],
-    "http://sinopia.io/vocabulary/hasUriAttribute": [
-      {
-        "@id": "http://sinopia.io/vocabulary/uriAttribute/labelSuppressed"
-      }
     ]
   },
   {


### PR DESCRIPTION
closes #3551

## Why was this change made?
Per @NancyL.


## How was this change tested?
Local


## Which documentation and/or configurations were updated?



