### PR TITLE
No longer suppress labels for chooseable properties.

### DIFF
--- a/static/templates/rt_property_template_doc.json
+++ b/static/templates/rt_property_template_doc.json
@@ -267,20 +267,6 @@
       {
         "@id": "http://sinopia.io/vocabulary/propertyType/uri"
       }
-    ],
-    "http://sinopia.io/vocabulary/hasUriAttributes": [
-      {
-        "@id": "_:b27"
-      }
-    ]
-  },
-  {
-    "@id": "_:b27",
-    "@type": ["http://sinopia.io/vocabulary/UriPropertyTemplate"],
-    "http://sinopia.io/vocabulary/hasUriAttribute": [
-      {
-        "@id": "http://sinopia.io/vocabulary/uriAttribute/labelSuppressed"
-      }
     ]
   },
   {


### PR DESCRIPTION
closes #3552

## Why was this change made?
Per @NancyL 


## How was this change tested?
Local


## Which documentation and/or configurations were updated?



