### PR TITLE
Add missing ld4p context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,6 +169,7 @@ workflows:
           filters:
             <<: *branch_only_filter
       - integration:
+          context: ld4p
           filters:
             <<: *branch_only_filter
       - docker/publish:


### PR DESCRIPTION
## Why was this change made?
This context was missing, which was causing CI failure. This was because I removed redundant env variable configuration in Circle.


## How was this change tested?



## Which documentation and/or configurations were updated?



