### PR TITLE
Update github-cli orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ orbs:
   node: circleci/node@5.0.2
   docker: circleci/docker@2.0.3
   aws-cli: circleci/aws-cli@3.1.0
-  gh: circleci/github-cli@2.1.0
+  gh: circleci/github-cli@2.2.0
 parameters:
   node-version:
     type: string


### PR DESCRIPTION
## Why was this change made?

Bring in latest github-cli orb with (hopefully) updated github pubkey.

## How was this change tested?

This will run when the next dependency updates run on April 3, 2023.

## Which documentation and/or configurations were updated?

None

