### PR TITLE
New Serials publication type, Note Types, and Relationship authorities

### DIFF
--- a/static/authorityConfig.json
+++ b/static/authorityConfig.json
@@ -2443,6 +2443,11 @@
     "component": "list"
   },
   {
+    "label": "note type",
+    "uri": "https://id.loc.gov/vocabulary/mnotetype",
+    "component": "list"
+  },
+  {
     "label": "playback channels",
     "uri": "https://id.loc.gov/vocabulary/mplayback",
     "component": "list"
@@ -2485,6 +2490,11 @@
   {
     "label": "relief",
     "uri": "https://id.loc.gov/vocabulary/mrelief",
+    "component": "list"
+  },
+  {
+    "label": "serial publication type",
+    "uri": "https://id.loc.gov/vocabulary/mserialpubtype",
     "component": "list"
   },
   {

--- a/static/authorityConfig.json
+++ b/static/authorityConfig.json
@@ -2488,6 +2488,11 @@
     "component": "list"
   },
   {
+    "label": "relationship",
+    "uri": "https://id.loc.gov/vocabulary/relationship",
+    "component": "list"
+  },
+  {
     "label": "relief",
     "uri": "https://id.loc.gov/vocabulary/mrelief",
     "component": "list"


### PR DESCRIPTION
## Why was this change made?
Fixes #3725
Fixes #3726
Fixes #3732


## How was this change tested?
Unit tests


## Which documentation and/or configurations were updated?
`authorityConfig.json`

