### PR TITLE
Adding DBPedia Direct lookup

### DIFF
--- a/static/authorityConfig.json
+++ b/static/authorityConfig.json
@@ -201,6 +201,14 @@
     "component": "lookup"
   },
   {
+    "label": "DBPEDIA_(QA) - direct (Warning: may be slow)",
+    "uri": "urn:ld4p:qa:dbpedia_direct",
+    "authority": "dbpedia_direct",
+    "subauthority": "",
+    "language": "en",
+    "component": "lookup"
+  },
+  {
     "label": "Discogs",
     "uri": "urn:discogs",
     "authority": "discogs",


### PR DESCRIPTION
Adding direct lookup for DBPedia as a first step toward removing cached version.

