### PR TITLE
Adds accessibility note and link to footer

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -36,8 +36,16 @@ const Footer = () => (
           >
             Creative Commons CC0 1.0 Universal Public Domain Dedication
           </a>
-          . Published <a href="/vocabulary">Vocabulary</a>. &nbsp; Sinopia v
-          {Package.version}
+          . Published <a href="/vocabulary">Vocabulary</a>. &nbsp; If you cannot
+          access content or use features on this website due to a disability,
+          please&nbsp;
+          <a
+            rel="noopener noreferrer"
+            href="mailto:library-accessibility-contact@lists.stanford.edu"
+          >
+            report your accessibility issue
+          </a>
+          . &nbsp;Sinopia v{Package.version}
         </small>
       </p>
     </div>


### PR DESCRIPTION
## Why was this change made?
Fixes #3748 

<img width="973" alt="Screenshot 2023-11-29 at 1 44 24 PM" src="https://github.com/LD4P/sinopia_editor/assets/71847/fed4722c-3398-4306-9d88-f99cfbfc5d32">

## How was this change tested?
Unit tests


## Which documentation and/or configurations were updated?
n/a


