### PR TITLE
Add scroll to top button to editor.

### DIFF
--- a/src/components/editor/ResourceComponent.jsx
+++ b/src/components/editor/ResourceComponent.jsx
@@ -18,6 +18,7 @@ import SaveAndPublishButton from "./actions/SaveAndPublishButton"
 import CopyToNewButton from "./actions/CopyToNewButton"
 import PreviewButton from "./actions/PreviewButton"
 import ResourceTitle from "./ResourceTitle"
+import TopButton from "./actions/TopButton"
 
 /**
  * This is the root component of the editor on the resource edit page
@@ -70,12 +71,15 @@ const ResourceComponent = () => {
       <div id="sticky-beacon" />
       <section className={stickyClasses.join(" ")} id="sticky-resource-header">
         <div className="row">
-          <div className="col-md-10">
+          <div className="col-md-9">
             <h3>
               <ResourceTitle resource={resource} />
               <CopyToNewButton />
               <PreviewButton />
             </h3>
+          </div>
+          <div className="col-md-1">
+            <TopButton />
           </div>
           <div className="col-md-2">
             <div className="d-flex justify-content-end">

--- a/src/components/editor/actions/TopButton.jsx
+++ b/src/components/editor/actions/TopButton.jsx
@@ -1,0 +1,26 @@
+// Copyright 2019 Stanford University see LICENSE for license
+
+import React from "react"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import { faArrowAltCircleUp } from "@fortawesome/free-solid-svg-icons"
+
+const TopButton = () => {
+  const handleClick = (event) => {
+    window.scrollTo(0, 0)
+    event.preventDefault()
+  }
+
+  return (
+    <button
+      type="button"
+      className="btn btn-link"
+      aria-label="Go to top"
+      title="Go to top"
+      onClick={handleClick}
+    >
+      <FontAwesomeIcon icon={faArrowAltCircleUp} className="icon-lg" /> Top
+    </button>
+  )
+}
+
+export default TopButton


### PR DESCRIPTION
closes #3763

Note that this was added to the sticky header instead of the bottom of the page.

## Why was this change made?
Editor joy.


## How was this change tested?
![image](https://github.com/LD4P/sinopia_editor/assets/588335/984d226e-aaa9-4037-b033-70b7a65e7231)



## Which documentation and/or configurations were updated?



