### PR TITLE
Update DescPanel.jsx

### DIFF
--- a/src/components/home/DescPanel.jsx
+++ b/src/components/home/DescPanel.jsx
@@ -30,7 +30,7 @@ const DescPanel = () => {
       </ul>
       <p>
         Sinopia is developed by the{" "}
-        <a href="http://www.ld4p.org">
+        <a href="https://wiki.lyrasis.org/display/LD4P2">
           Linked Data for Production: Pathway to Implementation (LD4P2)
         </a>{" "}
         project, a collaboration among Cornell University, Harvard University,


### PR DESCRIPTION
Updated hyperlinked text "LD4P2" from ld4p.org (broken) to https://wiki.lyrasis.org/display/LD4P2

## Why was this change made?
The link currently in place leads to a broken page. Broken link was reported by a user.


## How was this change tested?



## Which documentation and/or configurations were updated?



