### PR TITLE
Update NewsItem.jsx

### DIFF
--- a/src/components/home/NewsItem.jsx
+++ b/src/components/home/NewsItem.jsx
@@ -10,7 +10,7 @@ const NewsItem = () => (
     <p>
       <i>
         For complete release notes see the{" "}
-        <a href="https://github.com/LD4P/sinopia/wiki/Latest-Release,-What's-Next">
+        <a href="https://github.com/LD4P/sinopia/wiki/Latest-Release">
           Sinopia help site
         </a>
         .


### PR DESCRIPTION
Found another link issue - updated link to latest release notes URL

## Why was this change made?
The existing link does not lead the user to the latest release page; when logged out takes user to the sinopia github repo, when logged in it takes the user to create a new what's next/latest release page.


## How was this change tested?
I tested the existing link logged in vs. logged out.


## Which documentation and/or configurations were updated?
n/a


