### PR TITLE
Removed the deprecated type part from the search URLs

### DIFF
--- a/src/Config.js
+++ b/src/Config.js
@@ -69,11 +69,11 @@ class Config {
    * This is the public endpont for the sinopia search.
    */
   static get searchPath() {
-    return "/api/search/sinopia_resources/sinopia/_search"
+    return "/api/search/sinopia_resources/_search"
   }
 
   static get templateSearchPath() {
-    return "/api/search/sinopia_templates/sinopia/_search"
+    return "/api/search/sinopia_templates/_search"
   }
 
   static get sinopiaDomainName() {


### PR DESCRIPTION


## Why was this change made?

Mapping types are deprecated in ElasticSearch since 7.0.0, see this: https://www.elastic.co/guide/en/elasticsearch/reference/7.17/removal-of-types.html

Sinopia editor currently uses ElasticSearch 7.4 in which you can have only one type per index and trying to add another results in error. Thus support for index name in path of HTTP queries exists only for backwards compatibility and has no effect on the search results.

Because support for mapping types has now been deprecated for so long it is becoming harder to create indexes that would comply with the Sinopia API that still uses the index name in the search query path. For example on the still-supported versions of ElasticSeach Java REST client libraries it is not possible to set the type at all; you need to go to the raw HTTP level to do it and information about how such a query looks like no longer exists in ElasticSearch documents in the web.

As a sidenote: On index creation the type name can be changed by changing a parameter, but on search is is hard-coded. This leads me to believe changing the type name via the parameter would result in a bug, because search would still utilize the default name.

## How was this change tested?

I tested the editor to work with these changes, but I also looked into the exact HTTP queries done by the editor on Chrome Dev Tools, and replicated them with curl with both the old and new path to verify the raw HTTP level response was identical. 

## Which documentation and/or configurations were updated?

None. I was not able to find the search path documented anywhere, and while the type can be given as config parameter on index creation on search it is hardcoded to Config.js; ie. it is not possible to change the mapping type without changing code itself. 
