### PR TITLE
Update Config.js - updated PUC group to reflect AWS case

### DIFF
--- a/src/Config.js
+++ b/src/Config.js
@@ -157,7 +157,7 @@ class Config {
         memorial: "Catalog",
         jmu: "Catalog",
         brandeis: "Catalog",
-        puc: "Catalog",
+        PUC: "Catalog",
       },
       // Can add additional transfer targets, e.g., discovery
     }


### PR DESCRIPTION
## Why was this change made?
User group members reporting they cannot export to catalog; fixes group configuration files cases need to match AWS case.


## How was this change tested?
n/a


## Which documentation and/or configurations were updated?
n/a


