### PR TITLE
Update Footer.jsx

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -21,7 +21,7 @@ const Footer = () => (
           Sinopia is a project of{" "}
           <a
             rel="grant noopener noreferrer"
-            href="http://www.ld4p.org"
+            href="https://searchworks.stanford.edu/view/qt361vf0063"
             target="_blank"
           >
             Linked Data for Production 2 (LD4P2)


### PR DESCRIPTION
Updated LD4P2 link in footer from recently taken offline ld4p.org to Searchworks record to archived LD4P2 site.

## Why was this change made?
Link was updated to archived version of the page that is currently linked. Current link takes user to a "you've been blocked" page.

## How was this change tested?
n/a


## Which documentation and/or configurations were updated?
n/a


