### PR TITLE
Add 'upch' transfer target to Config.js

### DIFF
--- a/src/Config.js
+++ b/src/Config.js
@@ -163,6 +163,7 @@ class Config {
         usf: "Catalog",
         iowa_state: "Catalog",
         beit_ariela: "Catalog",
+        upch: "Catalog",
       },
       // Can add additional transfer targets, e.g., discovery
     }


### PR DESCRIPTION
## Why was this change made?
Adding Univeridad Peruana Cayetano Heredia catalog group as per https://github.com/LD4P/sinopia_editor/issues/4075


## How was this change tested?
n/a


## Which documentation and/or configurations were updated?
n/a


