### PR TITLE
Remove unused weak-napi dependency and disable Sass charset/BOM emission

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,8 +59,7 @@
         "redux": "^4.1.1",
         "redux-thunk": "^2.3.0",
         "stream-browserify": "^3.0.0",
-        "uuid": "^8.3.1",
-        "weak-napi": "^2.0.2"
+        "uuid": "^8.3.1"
       },
       "devDependencies": {
         "@babel/core": "^7.19.0",
@@ -12017,19 +12016,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/get-symbol-from-current-process-h": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/get-symbol-from-current-process-h/-/get-symbol-from-current-process-h-1.0.2.tgz",
-      "integrity": "sha512-syloC6fsCt62ELLrr1VKBM1ggOpMdetX9hTrdW77UQdcApPHLmf7CI7OKcN1c9kYuNxKcDe4iJ4FY9sX3aw2xw=="
-    },
-    "node_modules/get-uv-event-loop-napi-h": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/get-uv-event-loop-napi-h/-/get-uv-event-loop-napi-h-1.0.6.tgz",
-      "integrity": "sha512-t5c9VNR84nRoF+eLiz6wFrEp1SE2Acg0wS+Ysa2zF0eROes+LzOfuTaVHxGy8AbS8rq7FHEJzjnCZo1BupwdJg==",
-      "dependencies": {
-        "get-symbol-from-current-process-h": "^1.0.1"
-      }
-    },
     "node_modules/getos": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/getos/-/getos-3.2.1.tgz",
@@ -18750,16 +18736,6 @@
         "node": ">= 6.13.0"
       }
     },
-    "node_modules/node-gyp-build": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
-      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
-      "bin": {
-        "node-gyp-build": "bin.js",
-        "node-gyp-build-optional": "optional.js",
-        "node-gyp-build-test": "build-test.js"
-      }
-    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -21623,15 +21599,6 @@
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
     },
-    "node_modules/setimmediate-napi": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/setimmediate-napi/-/setimmediate-napi-1.0.6.tgz",
-      "integrity": "sha512-sdNXN15Av1jPXuSal4Mk4tEAKn0+8lfF9Z50/negaQMrAIO9c1qM0eiCh8fT6gctp0RiCObk+6/Xfn5RMGdZoA==",
-      "dependencies": {
-        "get-symbol-from-current-process-h": "^1.0.1",
-        "get-uv-event-loop-napi-h": "^1.0.5"
-      }
-    },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -23199,22 +23166,6 @@
       "dependencies": {
         "minimalistic-assert": "^1.0.0"
       }
-    },
-    "node_modules/weak-napi": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/weak-napi/-/weak-napi-2.0.2.tgz",
-      "integrity": "sha512-LcOSVFrghtVXf4QH+DLIy8iPiCktV7lVbqRDYP+bDPpLzC41RCHQPMyQOnPpWO41Ie4CmnDxS+mbL72r5xFMMQ==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "node-addon-api": "^3.0.0",
-        "node-gyp-build": "^4.2.1",
-        "setimmediate-napi": "^1.0.3"
-      }
-    },
-    "node_modules/weak-napi/node_modules/node-addon-api": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
-      "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A=="
     },
     "node_modules/webidl-conversions": {
       "version": "6.1.0",
@@ -32914,19 +32865,6 @@
         "get-intrinsic": "^1.2.6"
       }
     },
-    "get-symbol-from-current-process-h": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/get-symbol-from-current-process-h/-/get-symbol-from-current-process-h-1.0.2.tgz",
-      "integrity": "sha512-syloC6fsCt62ELLrr1VKBM1ggOpMdetX9hTrdW77UQdcApPHLmf7CI7OKcN1c9kYuNxKcDe4iJ4FY9sX3aw2xw=="
-    },
-    "get-uv-event-loop-napi-h": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/get-uv-event-loop-napi-h/-/get-uv-event-loop-napi-h-1.0.6.tgz",
-      "integrity": "sha512-t5c9VNR84nRoF+eLiz6wFrEp1SE2Acg0wS+Ysa2zF0eROes+LzOfuTaVHxGy8AbS8rq7FHEJzjnCZo1BupwdJg==",
-      "requires": {
-        "get-symbol-from-current-process-h": "^1.0.1"
-      }
-    },
     "getos": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/getos/-/getos-3.2.1.tgz",
@@ -38081,11 +38019,6 @@
       "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
       "dev": true
     },
-    "node-gyp-build": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
-      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ=="
-    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -40148,15 +40081,6 @@
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
     },
-    "setimmediate-napi": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/setimmediate-napi/-/setimmediate-napi-1.0.6.tgz",
-      "integrity": "sha512-sdNXN15Av1jPXuSal4Mk4tEAKn0+8lfF9Z50/negaQMrAIO9c1qM0eiCh8fT6gctp0RiCObk+6/Xfn5RMGdZoA==",
-      "requires": {
-        "get-symbol-from-current-process-h": "^1.0.1",
-        "get-uv-event-loop-napi-h": "^1.0.5"
-      }
-    },
     "setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -41332,23 +41256,6 @@
       "dev": true,
       "requires": {
         "minimalistic-assert": "^1.0.0"
-      }
-    },
-    "weak-napi": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/weak-napi/-/weak-napi-2.0.2.tgz",
-      "integrity": "sha512-LcOSVFrghtVXf4QH+DLIy8iPiCktV7lVbqRDYP+bDPpLzC41RCHQPMyQOnPpWO41Ie4CmnDxS+mbL72r5xFMMQ==",
-      "requires": {
-        "node-addon-api": "^3.0.0",
-        "node-gyp-build": "^4.2.1",
-        "setimmediate-napi": "^1.0.3"
-      },
-      "dependencies": {
-        "node-addon-api": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
-          "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A=="
-        }
       }
     },
     "webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -106,8 +106,7 @@
     "redux": "^4.1.1",
     "redux-thunk": "^2.3.0",
     "stream-browserify": "^3.0.0",
-    "uuid": "^8.3.1",
-    "weak-napi": "^2.0.2"
+    "uuid": "^8.3.1"
   },
   "devDependencies": {
     "@babel/core": "^7.19.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -48,6 +48,15 @@ module.exports = {
           {
             // compiles Sass to CSS
             loader: "sass-loader",
+            options: {
+              // Prevent Dart Sass from prepending a UTF-8 BOM/@charset when
+              // compiled output contains non-ASCII characters (e.g. "❯" in
+              // main.scss) — a leading BOM corrupts the next selector, which
+              // dropped Bootstrap's :root custom properties in some builds.
+              sassOptions: {
+                charset: false,
+              },
+            },
           },
         ],
       },


### PR DESCRIPTION
weak-napi is a native module dependency that isn't used anywhere in the codebase and fails to build with newer Python toolchains (removed distutils). Separately, Dart Sass was prepending a BOM before the compiled Bootstrap :root rule whenever the stylesheet contained non-ASCII characters, invalidating that selector and dropping all --bs-* CSS custom properties in some deployed builds (broken card backgrounds, link colors, etc.). Disabling sass-loader's charset option prevents Sass from emitting that marker.

Generated with Claude Code v2.1.226 (Sonnet 5, claude-sonnet-5)

## Why was this change made?
Display bug in deployed environments


## How was this change tested?
Unit tests


## Which documentation and/or configurations were updated?
`package.json`, `package-lock.json`, and `webpack.config.js`


